### PR TITLE
Fix streaks notification not displaying. Add individual notifications toggle state.

### DIFF
--- a/src/app/(app)/custom-quest.test.tsx
+++ b/src/app/(app)/custom-quest.test.tsx
@@ -32,11 +32,11 @@ jest.mock('@expo/vector-icons', () => ({
 
 // Mock zustand store
 jest.mock('@/store/quest-store', () => ({
-  useQuestStore: {
+  useQuestStore: jest.fn(() => ({
     getState: jest.fn().mockReturnValue({
       prepareQuest: jest.fn(),
     }),
-  },
+  })),
 }));
 
 describe('CustomQuestScreen', () => {

--- a/src/app/(app)/settings.test.tsx
+++ b/src/app/(app)/settings.test.tsx
@@ -1,0 +1,100 @@
+import { render, waitFor } from '@testing-library/react-native';
+
+import Settings from './settings';
+
+// Mock the navigation dependencies
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    replace: jest.fn(),
+  }),
+  Link: 'Link',
+}));
+
+// Mock the animation hooks
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock');
+  Reanimated.default.call = () => {};
+  return {
+    ...Reanimated,
+    useSharedValue: jest.fn(() => ({ value: 0 })),
+    withTiming: jest.fn(() => 1),
+    useAnimatedStyle: jest.fn(() => ({})),
+  };
+});
+
+// Mock DateTimePicker
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+
+// Mock the auth hook
+jest.mock('@/lib', () => ({
+  useAuth: () => ({
+    signOut: jest.fn(),
+  }),
+}));
+
+// Mock all notification services to return simple promises
+jest.mock('@/lib/services/notifications', () => ({
+  areNotificationsEnabled: jest.fn().mockResolvedValue(true),
+  cancelDailyReminderNotification: jest.fn().mockResolvedValue(true),
+  cancelStreakWarningNotification: jest.fn().mockResolvedValue(true),
+  requestNotificationPermissions: jest.fn().mockResolvedValue(true),
+  scheduleDailyReminderNotification: jest.fn().mockResolvedValue(true),
+  scheduleStreakWarningNotification: jest.fn().mockResolvedValue(true),
+}));
+
+// Mock user service
+jest.mock('@/lib/services/user', () => ({
+  getUserDetails: jest.fn().mockResolvedValue({ email: 'test@example.com' }),
+  deleteUserAccount: jest.fn(),
+}));
+
+// Mock the stores used in Settings
+jest.mock('@/store/settings-store', () => ({
+  useSettingsStore: jest.fn(() => ({
+    dailyReminder: { enabled: false, time: null },
+    streakWarning: { enabled: false, time: null },
+    setDailyReminder: jest.fn(),
+    setStreakWarning: jest.fn(),
+  })),
+}));
+
+jest.mock('@/store/user-store', () => ({
+  useUserStore: jest.fn(() => ({
+    user: { email: 'test@example.com' },
+    setUser: jest.fn(),
+  })),
+}));
+
+// Mock expo-font
+jest.mock('expo-font', () => ({
+  isLoaded: jest.fn(() => true),
+  loadAsync: jest.fn(() => Promise.resolve()),
+}));
+
+// Mock @expo/vector-icons
+jest.mock('@expo/vector-icons', () => ({
+  Feather: 'Feather',
+}));
+
+// Mock lucide-react-native
+jest.mock('lucide-react-native', () => ({
+  Flame: 'Flame',
+}));
+
+// Mock the UI components
+jest.mock('@/components/ui', () => ({
+  FocusAwareStatusBar: 'FocusAwareStatusBar',
+  ScrollView: 'ScrollView',
+  Text: 'Text',
+  View: 'View',
+}));
+
+// Test that the component renders without errors
+describe('Settings Screen', () => {
+  it('renders without crashing', async () => {
+    const { getByText } = render(<Settings />);
+    await waitFor(() => {
+      expect(getByText('Settings')).toBeTruthy();
+    });
+  });
+});

--- a/src/lib/services/notifications.ts
+++ b/src/lib/services/notifications.ts
@@ -185,6 +185,7 @@ export const cancelDailyReminderNotification = async (): Promise<boolean> => {
 export const scheduleStreakWarningNotification = async (): Promise<boolean> => {
   // Check if notifications are enabled
   const enabled = await areNotificationsEnabled();
+  console.log('scheduleStreakWarningNotification enabled: ', enabled);
   if (!enabled) {
     return false;
   }
@@ -217,15 +218,20 @@ export const scheduleStreakWarningNotification = async (): Promise<boolean> => {
       streakWarning.time?.minute || 0 // Use settings or default to 0 minutes
     );
 
-    // If it's already past the set time, don't schedule for today
+    console.log('warningTime: ', warningTime);
+    console.log('today: ', today);
+
+    // If it's already past the set time, schedule for tomorrow instead
     if (today > warningTime) {
-      return false;
+      console.log('scheduling tomorrow');
+      return await scheduleTomorrowStreakWarning();
     }
 
     // Calculate seconds until the warning time
     const secondsUntilWarning = Math.floor(
       (warningTime.getTime() - today.getTime()) / 1000
     );
+    console.log('secondsUntilWarning: ', secondsUntilWarning);
 
     await ExpoNotifications.scheduleNotificationAsync({
       identifier: STREAK_WARNING_ID,
@@ -236,6 +242,7 @@ export const scheduleStreakWarningNotification = async (): Promise<boolean> => {
         sound: true,
       },
       trigger: {
+        type: SchedulableTriggerInputTypes.TIME_INTERVAL,
         seconds: secondsUntilWarning,
         channelId: Platform.OS === 'android' ? QUEST_CHANNEL_ID : undefined,
       },
@@ -251,7 +258,6 @@ export const scheduleStreakWarningNotification = async (): Promise<boolean> => {
   }
 };
 
-// Also update the scheduleTomorrowStreakWarning function
 export const scheduleTomorrowStreakWarning = async (): Promise<boolean> => {
   // Check if notifications are enabled
   const enabled = await areNotificationsEnabled();

--- a/src/lib/services/quest-timer.ts
+++ b/src/lib/services/quest-timer.ts
@@ -357,6 +357,7 @@ export default class QuestTimer {
               failedAttributes,
               failedContent
             );
+            this.oneSignalActivityId = null;
           } catch (error) {
             console.error(
               'Error ending OneSignal Live Activity (Failure):',
@@ -496,8 +497,11 @@ export default class QuestTimer {
       await BackgroundService.stop();
     }
 
+    // Explicitly nullify all class properties before clearing storage
+    this.oneSignalActivityId = null;
     this.questTemplate = null;
     this.questStartTime = null;
+    this.questRunId = null;
 
     // Clear quest data from storage
     await this.clearQuestData();


### PR DESCRIPTION
## What does this do?

Streak reminder notifications weren't working because we were triggering them improperly (using seconds instead of a time interval type).

This fixes that, and simultaneously resolves a bug which displayed the notification immediately when enabling it.
It also adds settings store state for individual notifications which can be toggled off individually.
Update tests too.
Also fixes a bug in which the live activity wouldn't work after a failed quest because the live activity ID was still stored but it was long dismissed.