### PR TITLE
Fix perk XP attribution: sync values to server, invalidate caches

### DIFF
--- a/src/api/quest-runs/use-quest-reward-preview.test.tsx
+++ b/src/api/quest-runs/use-quest-reward-preview.test.tsx
@@ -21,8 +21,9 @@ jest.mock('../common/provisional-client', () => ({
 }));
 
 const mockApiClient = apiClient as jest.Mocked<typeof apiClient>;
-const mockProvisionalApiClient =
-  provisionalApiClient as jest.Mocked<typeof provisionalApiClient>;
+const mockProvisionalApiClient = provisionalApiClient as jest.Mocked<
+  typeof provisionalApiClient
+>;
 
 describe('useQuestRewardPreview', () => {
   let queryClient: QueryClient;
@@ -49,7 +50,7 @@ describe('useQuestRewardPreview', () => {
         baseXP: 90,
         adjustedXP: 135,
         multiplier: 1.5,
-        perksApplied: ['quest_mastery_endurance'],
+        perksApplied: ['endurance_focus'],
       },
     ],
     effects: {
@@ -116,7 +117,8 @@ describe('useQuestRewardPreview', () => {
 
     it('does not fetch when enabled is false', () => {
       const { result } = renderHook(
-        () => useQuestRewardPreview({ questTemplateId: 'quest-3', enabled: false }),
+        () =>
+          useQuestRewardPreview({ questTemplateId: 'quest-3', enabled: false }),
         {
           wrapper: createWrapper(),
         }

--- a/src/api/skill-tree/use-respec-skill-tree.test.tsx
+++ b/src/api/skill-tree/use-respec-skill-tree.test.tsx
@@ -68,7 +68,9 @@ describe('useRespecSkillTree', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApiClient.post).toHaveBeenCalledWith('/users/me/skill-tree/respec');
+    expect(mockApiClient.post).toHaveBeenCalledWith(
+      '/users/me/skill-tree/respec'
+    );
     expect(result.current.data).toEqual(mockRespecResponse);
     expect(result.current.isError).toBe(false);
   });
@@ -89,7 +91,7 @@ describe('useRespecSkillTree', () => {
     expect(result.current.data).toBeUndefined();
   });
 
-  it('invalidates skill-tree query on success', async () => {
+  it('invalidates skill-tree and quest-reward-preview queries on success', async () => {
     mockApiClient.post.mockResolvedValue({ data: mockRespecResponse });
 
     const { result } = renderHook(
@@ -110,7 +112,10 @@ describe('useRespecSkillTree', () => {
     });
 
     // Spy on invalidateQueries
-    const invalidateSpy = jest.spyOn(result.current.client, 'invalidateQueries');
+    const invalidateSpy = jest.spyOn(
+      result.current.client,
+      'invalidateQueries'
+    );
 
     result.current.mutation.mutate();
 
@@ -118,6 +123,9 @@ describe('useRespecSkillTree', () => {
 
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['skill-tree'],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['quest-reward-preview'],
     });
   });
 

--- a/src/api/skill-tree/use-respec-skill-tree.ts
+++ b/src/api/skill-tree/use-respec-skill-tree.ts
@@ -12,10 +12,8 @@ export const useRespecSkillTree = () => {
       return response.data;
     },
     onSuccess: () => {
-      // Invalidate skill-tree query to refetch latest data
-      queryClient.invalidateQueries({
-        queryKey: ['skill-tree'],
-      });
+      queryClient.invalidateQueries({ queryKey: ['skill-tree'] });
+      queryClient.invalidateQueries({ queryKey: ['quest-reward-preview'] });
     },
   });
 };

--- a/src/api/skill-tree/use-unlock-perk.test.tsx
+++ b/src/api/skill-tree/use-unlock-perk.test.tsx
@@ -80,9 +80,12 @@ describe('useUnlockPerk', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApiClient.post).toHaveBeenCalledWith('/users/me/skill-tree/unlock', {
-      nodeId: 'quick_break',
-    });
+    expect(mockApiClient.post).toHaveBeenCalledWith(
+      '/users/me/skill-tree/unlock',
+      {
+        nodeId: 'quick_break',
+      }
+    );
     expect(result.current.data).toEqual(mockUnlockPerkResponse);
     expect(result.current.isError).toBe(false);
   });
@@ -101,10 +104,13 @@ describe('useUnlockPerk', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApiClient.post).toHaveBeenCalledWith('/users/me/skill-tree/unlock', {
-      nodeId: 'quest_mastery',
-      choice: 'quest_mastery_quick',
-    });
+    expect(mockApiClient.post).toHaveBeenCalledWith(
+      '/users/me/skill-tree/unlock',
+      {
+        nodeId: 'quest_mastery',
+        choice: 'quest_mastery_quick',
+      }
+    );
     expect(result.current.data).toEqual(mockUnlockPerkResponse);
   });
 
@@ -126,7 +132,7 @@ describe('useUnlockPerk', () => {
     expect(result.current.data).toBeUndefined();
   });
 
-  it('invalidates skill-tree query on success', async () => {
+  it('invalidates skill-tree and quest-reward-preview queries on success', async () => {
     mockApiClient.post.mockResolvedValue({ data: mockUnlockPerkResponse });
 
     const { result } = renderHook(
@@ -147,7 +153,10 @@ describe('useUnlockPerk', () => {
     });
 
     // Spy on invalidateQueries
-    const invalidateSpy = jest.spyOn(result.current.client, 'invalidateQueries');
+    const invalidateSpy = jest.spyOn(
+      result.current.client,
+      'invalidateQueries'
+    );
 
     result.current.mutation.mutate({
       nodeId: 'quick_break',
@@ -157,6 +166,9 @@ describe('useUnlockPerk', () => {
 
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['skill-tree'],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['quest-reward-preview'],
     });
   });
 

--- a/src/api/skill-tree/use-unlock-perk.ts
+++ b/src/api/skill-tree/use-unlock-perk.ts
@@ -15,10 +15,8 @@ export const useUnlockPerk = () => {
       return response.data;
     },
     onSuccess: () => {
-      // Invalidate skill-tree query to refetch latest data
-      queryClient.invalidateQueries({
-        queryKey: ['skill-tree'],
-      });
+      queryClient.invalidateQueries({ queryKey: ['skill-tree'] });
+      queryClient.invalidateQueries({ queryKey: ['quest-reward-preview'] });
     },
   });
 };

--- a/src/components/skill-tree/perk-icon.tsx
+++ b/src/components/skill-tree/perk-icon.tsx
@@ -55,10 +55,6 @@ export const PERK_ICON_MAP: Record<string, any> = {
   thoughtful_adventurer: require('@/../assets/icons/perks/thoughtful-adventurer.svg'),
   weekday_grind: require('@/../assets/icons/perks/weekday_grind.svg'),
   weekend_warrior: require('@/../assets/icons/perks/weekend_warrior.svg'),
-
-  // Aliases (same icon, different unlock paths)
-  quest_mastery_quick: require('@/../assets/icons/perks/quick_start.svg'),
-  quest_mastery_endurance: require('@/../assets/icons/perks/endurance_focus.svg'),
 };
 
 export function PerkIcon({ perkId, isUnlocked, size = 32 }: PerkIconProps) {

--- a/src/lib/perks.test.ts
+++ b/src/lib/perks.test.ts
@@ -49,6 +49,36 @@ describe('perks utilities', () => {
       ]);
     });
 
+    test('proportional split discriminates server-aligned values from the prior inflated table', () => {
+      // Three perks whose *integer* split diverges between old and new value tables.
+      // baseXP=100, adjustedXP=160 (total bonus 60).
+      // New values: quick_break=0.10, endurance_focus=0.15, streak_master=0.35
+      //   ratios sum to 0.60. Splits: floor(0.10/0.60*60)=10, floor(0.15/0.60*60)=15, remainder=35.
+      // Old values would have been: 0.35, 0.50, 0.50 — sum 1.35.
+      //   Splits: floor(0.35/1.35*60)=15, floor(0.50/1.35*60)=22, remainder=23.
+      // [10, 15, 35] vs [15, 22, 23] — different. This test fails on the old table.
+      const result = calculatePerkBonuses(100, 160, [
+        'quick_break',
+        'endurance_focus',
+        'streak_master',
+      ]);
+      expect(result).toEqual([
+        { id: 'quick_break', name: 'Quick Break', bonusXP: 10, icon: 'zap' },
+        {
+          id: 'endurance_focus',
+          name: 'Endurance Focus',
+          bonusXP: 15,
+          icon: 'dumbbell',
+        },
+        {
+          id: 'streak_master',
+          name: 'Streak Master',
+          bonusXP: 35,
+          icon: 'flame',
+        },
+      ]);
+    });
+
     it('returns empty array when no bonus XP', () => {
       const result = calculatePerkBonuses(100, 100, ['quick_break']);
       expect(result).toEqual([]);

--- a/src/lib/perks.test.ts
+++ b/src/lib/perks.test.ts
@@ -30,31 +30,23 @@ describe('perks utilities', () => {
   });
 
   describe('calculatePerkBonuses', () => {
-    it('calculates bonuses proportionally based on perk values', () => {
-      // quick_break: 0.2 (20%), endurance_focus: 0.3 (30%)
-      // Total value: 0.5, so quick_break gets 40% of bonus, endurance_focus gets 60%
-      const result = calculatePerkBonuses(100, 150, [
+    test('calculatePerkBonuses splits XP proportionally using server-aligned values', () => {
+      // baseXP=100, +Quick Break (0.10) + Endurance Focus (0.15) = total 0.25 bonus = 125
+      const result = calculatePerkBonuses(100, 125, [
         'quick_break',
         'endurance_focus',
       ]);
-
-      expect(result).toHaveLength(2);
-
-      const quickBreak = result.find((p) => p.id === 'quick_break');
-      const endurance = result.find((p) => p.id === 'endurance_focus');
-
-      expect(quickBreak).toBeDefined();
-      expect(endurance).toBeDefined();
-
-      // 50 total bonus: 40% = 20, 60% = 30
-      expect(quickBreak!.bonusXP).toBe(20);
-      expect(endurance!.bonusXP).toBe(30);
-
-      // Verify names and icons
-      expect(quickBreak!.name).toBe('Quick Break');
-      expect(quickBreak!.icon).toBe('zap');
-      expect(endurance!.name).toBe('Endurance Focus');
-      expect(endurance!.icon).toBe('dumbbell');
+      // 0.10 / 0.25 * 25 = 10 → quick_break: 10
+      // remainder for endurance_focus: 15
+      expect(result).toEqual([
+        { id: 'quick_break', name: 'Quick Break', bonusXP: 10, icon: 'zap' },
+        {
+          id: 'endurance_focus',
+          name: 'Endurance Focus',
+          bonusXP: 15,
+          icon: 'dumbbell',
+        },
+      ]);
     });
 
     it('returns empty array when no bonus XP', () => {

--- a/src/lib/perks.ts
+++ b/src/lib/perks.ts
@@ -23,7 +23,7 @@ export const PERK_DATA: Record<string, PerkMetadata> = {
   first_timer: { name: 'First Timer', icon: 'star', value: 0.2 },
   weekend_warrior: { name: 'Weekend Warrior', icon: 'sword', value: 0.25 },
   weekday_grind: { name: 'Weekday Grind', icon: 'calendar', value: 0.15 },
-  quick_start: { name: 'Quick Start', icon: 'zap', value: 0.0 }, // Duration perk, no XP bonus
+  quick_start: { name: 'Quick Start', icon: 'zap', value: 0.0 }, // Server value is 0.1 (duration_reduction); client uses 0.0 so calculatePerkBonuses excludes it from the XP-bonus split.
   streak_master: { name: 'Streak Master', icon: 'flame', value: 0.35 },
   streak_god: { name: 'Streak God', icon: 'flame', value: 0.5 },
 

--- a/src/lib/perks.ts
+++ b/src/lib/perks.ts
@@ -11,52 +11,84 @@ interface PerkMetadata {
  * Maps perk IDs to their metadata
  */
 export const PERK_DATA: Record<string, PerkMetadata> = {
-  // Universal perks (values match server /unquest-server/src/data/perks.js)
-  quick_break: { name: 'Quick Break', icon: 'zap', value: 0.35 },
-  morning_ritual: { name: 'Morning Ritual', icon: 'sunrise', value: 0.3 },
-  endurance_focus: { name: 'Endurance Focus', icon: 'dumbbell', value: 0.5 },
-  thoughtful_adventurer: { name: 'Thoughtful Adventurer', icon: 'brain', value: 0.25 },
-  first_timer: { name: 'First Timer', icon: 'star', value: 0.5 },
-  weekend_warrior: { name: 'Weekend Warrior', icon: 'sword', value: 0.4 },
-  weekday_grind: { name: 'Weekday Grind', icon: 'calendar', value: 0.25 },
+  // Universal perks (values match server /unquest-server/src/data/perks.js — verified 2026-04-28)
+  quick_break: { name: 'Quick Break', icon: 'zap', value: 0.1 },
+  morning_ritual: { name: 'Morning Ritual', icon: 'sunrise', value: 0.1 },
+  endurance_focus: { name: 'Endurance Focus', icon: 'dumbbell', value: 0.15 },
+  thoughtful_adventurer: {
+    name: 'Thoughtful Adventurer',
+    icon: 'brain',
+    value: 0.15,
+  },
+  first_timer: { name: 'First Timer', icon: 'star', value: 0.2 },
+  weekend_warrior: { name: 'Weekend Warrior', icon: 'sword', value: 0.25 },
+  weekday_grind: { name: 'Weekday Grind', icon: 'calendar', value: 0.15 },
   quick_start: { name: 'Quick Start', icon: 'zap', value: 0.0 }, // Duration perk, no XP bonus
-  streak_master: { name: 'Streak Master', icon: 'flame', value: 0.5 },
-  streak_god: { name: 'Streak God', icon: 'flame', value: 1.0 },
-
-  // Aliases (same icon, different unlock paths)
-  quest_mastery_quick: { name: 'Quick Start', icon: 'zap', value: 0.0 },
-  quest_mastery_endurance: { name: 'Endurance Focus', icon: 'dumbbell', value: 0.5 },
+  streak_master: { name: 'Streak Master', icon: 'flame', value: 0.35 },
+  streak_god: { name: 'Streak God', icon: 'flame', value: 0.5 },
 
   // Alchemist perks
-  alchemist_alchemical_precision: { name: 'Alchemical Precision', icon: 'flask-conical', value: 0.75 },
-  alchemist_crafting_prowess: { name: 'Crafting Prowess', icon: 'hammer', value: 0.4 },
-  alchemist_transmuters_efficiency: { name: "Transmuter's Efficiency", icon: 'hourglass', value: 0.6 },
+  alchemist_alchemical_precision: {
+    name: 'Alchemical Precision',
+    icon: 'flask-conical',
+    value: 0.3,
+  },
+  alchemist_crafting_prowess: {
+    name: 'Crafting Prowess',
+    icon: 'hammer',
+    value: 0.1,
+  },
+  alchemist_transmuters_efficiency: {
+    name: "Transmuter's Efficiency",
+    icon: 'hourglass',
+    value: 0.2,
+  },
 
   // Knight perks
-  knight_warriors_might: { name: "Warrior's Might", icon: 'sword', value: 0.4 },
-  knight_champions_endurance: { name: "Champion's Endurance", icon: 'medal', value: 0.6 },
-  knight_tactical_discipline: { name: 'Tactical Discipline', icon: 'target', value: 0.6 },
+  knight_warriors_might: { name: "Warrior's Might", icon: 'sword', value: 0.1 },
+  knight_champions_endurance: {
+    name: "Champion's Endurance",
+    icon: 'medal',
+    value: 0.2,
+  },
+  knight_tactical_discipline: {
+    name: 'Tactical Discipline',
+    icon: 'target',
+    value: 0.3,
+  },
 
   // Bard perks
-  bard_charismatic_flair: { name: 'Charismatic Flair', icon: 'sparkles', value: 0.4 },
-  bard_master_performer: { name: 'Master Performer', icon: 'mic', value: 0.75 },
-  bard_inspiring_presence: { name: 'Inspiring Presence', icon: 'users', value: 0.5 },
+  bard_charismatic_flair: {
+    name: 'Charismatic Flair',
+    icon: 'sparkles',
+    value: 0.1,
+  },
+  bard_master_performer: { name: 'Master Performer', icon: 'mic', value: 0.2 },
+  bard_inspiring_presence: {
+    name: 'Inspiring Presence',
+    icon: 'users',
+    value: 0.3,
+  },
 
   // Wizard perks
-  wizard_scholars_mind: { name: "Scholar's Mind", icon: 'book', value: 0.4 },
-  wizard_arcane_focus: { name: 'Arcane Focus', icon: 'wand', value: 0.75 },
-  fire_path: { name: 'Fire Path', icon: 'flame', value: 0.5 },
-  water_path: { name: 'Water Path', icon: 'droplet', value: 0.5 },
+  wizard_scholars_mind: { name: "Scholar's Mind", icon: 'book', value: 0.1 },
+  wizard_arcane_focus: { name: 'Arcane Focus', icon: 'wand', value: 0.2 },
+  fire_path: { name: 'Fire Path', icon: 'flame', value: 0.3 },
+  water_path: { name: 'Water Path', icon: 'droplet', value: 0.3 },
 
   // Scout perks
-  scout_lone_wanderer: { name: 'Lone Wanderer', icon: 'compass', value: 0.4 },
-  scout_survivalist: { name: 'Survivalist', icon: 'tent', value: 0.6 },
-  scout_master_tracker: { name: 'Master Tracker', icon: 'binoculars', value: 0.75 },
+  scout_lone_wanderer: { name: 'Lone Wanderer', icon: 'compass', value: 0.1 },
+  scout_survivalist: { name: 'Survivalist', icon: 'tent', value: 0.2 },
+  scout_master_tracker: {
+    name: 'Master Tracker',
+    icon: 'binoculars',
+    value: 0.3,
+  },
 
   // Druid perks
-  druid_natures_touch: { name: "Nature's Touch", icon: 'leaf', value: 0.4 },
-  druid_vitality: { name: 'Vitality', icon: 'heart-pulse', value: 1.0 },
-  druid_harmony: { name: 'Harmony', icon: 'yin-yang', value: 0.6 },
+  druid_natures_touch: { name: "Nature's Touch", icon: 'leaf', value: 0.1 },
+  druid_vitality: { name: 'Vitality', icon: 'heart-pulse', value: 0.2 },
+  druid_harmony: { name: 'Harmony', icon: 'yin-yang', value: 0.3 },
 };
 
 /**

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -69,7 +69,7 @@ export type CharacterType =
   | 'bard'
   | 'druid'
   | 'knight'
-  | 'scholar'
+  | 'scout'
   | 'wizard';
 
 export interface Account {


### PR DESCRIPTION
## Summary

Three related fixes to the skill-tree / perks UI that were producing incorrect or stale information after a perk change.

- **Sync `PERK_DATA` to server values.** The client copy in `src/lib/perks.ts` had drifted 2-4× above the authoritative table in `unquest-server/src/data/perks.js`. `calculatePerkBonuses` uses these values to split the post-completion XP breakdown across applied perks, so the UI was showing inflated attribution numbers (e.g. +50 XP for a perk that actually contributed +35). All values now match the server; verified 2026-04-28.
- **Invalidate `quest-reward-preview` on perk mutations.** `useUnlockPerk` and `useRespecSkillTree` only invalidated `['skill-tree']`, leaving the pending-quest reward-preview cache stale for up to 5 minutes after a perk change. Both `onSuccess` handlers now invalidate both keys.
- **`CharacterType` bugfix.** The union still listed the early-development name `'scholar'` instead of `'scout'`, diverging from the server enum and the rest of the mobile codebase (`characters.ts`, leaderboard types, perk ids).

## Notes

- `quick_start` is intentionally kept at `value: 0.0` on the client even though the server stores `0.1`. It's a `duration_reduction` perk, not an XP bonus — a non-zero client value would falsely include it in the proportional XP split. The inline comment now documents this divergence at the call site.
- Two orphan aliases (`quest_mastery_quick`, `quest_mastery_endurance`) that don't exist server-side were removed from both `PERK_DATA` and `PERK_ICON_MAP`.
- The split-attribution test from 662519f happened to produce identical integer splits under both old and new tables. 6988431 adds a discriminating 3-perk case (quick_break + endurance_focus + streak_master @ adjustedXP=160) where the splits actually diverge: new values yield [10, 15, 35], old would have given [15, 22, 23].

## Test plan

- [ ] `pnpm check-all` passes
- [ ] Unlock a perk → pending-quest reward preview reflects the new multiplier without waiting for cache TTL
- [ ] Respec skill tree → reward preview clears stale perk influence
- [ ] Complete a quest with multiple perks active → XP breakdown numbers sum to the actual bonus and individual values are plausible
- [ ] No `'scholar'` references remain anywhere the union is consumed