### PR TITLE
Fix #309: correct option labels at end of Vaedros storyline

### DIFF
--- a/src/app/(app)/index.test.tsx
+++ b/src/app/(app)/index.test.tsx
@@ -231,9 +231,15 @@ describe('Home Component - Integration Tests', () => {
 
       const { unmount } = render(<Home />);
 
-      // User sees the quest title and a start button
+      // User sees the quest title and a start button. The label is
+      // 'Begin your journey' (not 'Start Quest') because the mock state
+      // has no completed story quests, which is the first-time-player CTA.
+      // The recap text also says 'Begin your journey' for fresh players,
+      // so we expect to see it appear at least once on the screen.
       expect(screen.getByText('The Lake Discovery')).toBeTruthy();
-      expect(screen.getByText('Start Quest')).toBeTruthy();
+      expect(screen.getAllByText('Begin your journey').length).toBeGreaterThan(
+        0
+      );
 
       unmount();
     });

--- a/src/app/(app)/index.tsx
+++ b/src/app/(app)/index.tsx
@@ -137,6 +137,7 @@ export default function Home() {
     currentMapName: _currentMapName,
     storyProgress: _storyProgress,
     isStorylineComplete,
+    hasStartedStoryline,
   } = useHomeData({
     serverQuests,
     availableQuests,
@@ -469,7 +470,7 @@ export default function Home() {
                 activeIndex={activeIndex}
                 serverQuests={serverQuests}
                 storyOptions={storyOptions}
-                isStorylineComplete={isStorylineComplete}
+                hasStartedStoryline={hasStartedStoryline}
                 hasPremiumAccess={hasPremiumAccess}
                 onQuestSelect={handleQuestOptionSelect}
                 onShowPaywall={() => setShowPaywallModal(true)}

--- a/src/features/home/components/story-option-buttons.test.tsx
+++ b/src/features/home/components/story-option-buttons.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react-native';
+import React from 'react';
+
+import { StoryOptionButtons } from './story-option-buttons';
+
+describe('StoryOptionButtons', () => {
+  // Issue #309: at the final story quest, two branching options were both
+  // rendered with the literal label "Begin your journey" (the first-quest
+  // override) instead of their actual `option.text`. Tapping still routed
+  // to the correct quest, so the bug was purely in the rendered label.
+  it('renders option.text on multi-option branches when storyline is at completion threshold', () => {
+    render(
+      <StoryOptionButtons
+        activeIndex={0}
+        serverQuests={[]}
+        storyOptions={[
+          {
+            id: 'opt-a',
+            text: 'Take the amulet to the temple',
+            nextQuestId: 'quest-30b',
+          },
+          {
+            id: 'opt-b',
+            text: 'Bury the amulet at the cliff',
+            nextQuestId: 'quest-30c',
+          },
+        ]}
+        hasStartedStoryline={true}
+        hasPremiumAccess={true}
+        onQuestSelect={jest.fn()}
+        onShowPaywall={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Take the amulet to the temple')).toBeTruthy();
+    expect(screen.getByText('Bury the amulet at the cliff')).toBeTruthy();
+    expect(screen.queryByText('Begin your journey')).toBeNull();
+  });
+
+  it('shows the "Begin your journey" CTA on the very first quest (no options, storyline not yet started)', () => {
+    render(
+      <StoryOptionButtons
+        activeIndex={0}
+        serverQuests={[{ customId: 'quest-1', isPremium: false }]}
+        storyOptions={[]}
+        hasStartedStoryline={false}
+        hasPremiumAccess={true}
+        onQuestSelect={jest.fn()}
+        onShowPaywall={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Begin your journey')).toBeTruthy();
+    expect(screen.queryByText('Start Quest')).toBeNull();
+  });
+
+  it('shows the generic "Start Quest" CTA on a single-quest screen once the storyline is underway', () => {
+    render(
+      <StoryOptionButtons
+        activeIndex={0}
+        serverQuests={[{ customId: 'quest-15', isPremium: false }]}
+        storyOptions={[]}
+        hasStartedStoryline={true}
+        hasPremiumAccess={true}
+        onQuestSelect={jest.fn()}
+        onShowPaywall={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Start Quest')).toBeTruthy();
+    expect(screen.queryByText('Begin your journey')).toBeNull();
+  });
+});

--- a/src/features/home/components/story-option-buttons.tsx
+++ b/src/features/home/components/story-option-buttons.tsx
@@ -18,7 +18,7 @@ interface StoryOptionButtonsProps {
   activeIndex: number;
   serverQuests: ServerQuest[];
   storyOptions: QuestOption[];
-  isStorylineComplete: boolean;
+  hasStartedStoryline: boolean;
   hasPremiumAccess: boolean;
   onQuestSelect: (questId: string | null) => void;
   onShowPaywall: () => void;
@@ -52,7 +52,7 @@ export function StoryOptionButtons({
   activeIndex,
   serverQuests,
   storyOptions,
-  isStorylineComplete,
+  hasStartedStoryline,
   hasPremiumAccess,
   onQuestSelect,
   onShowPaywall,
@@ -88,7 +88,7 @@ export function StoryOptionButtons({
             label={
               quest.isPremium && !hasPremiumAccess
                 ? 'Unlock full Vaedros storyline'
-                : isStorylineComplete
+                : !hasStartedStoryline
                   ? 'Begin your journey'
                   : 'Start Quest'
             }
@@ -151,9 +151,7 @@ export function StoryOptionButtons({
             label={
               questIsPremium && !hasPremiumAccess
                 ? 'Unlock full Vaedros storyline'
-                : isStorylineComplete
-                  ? 'Begin your journey'
-                  : option.text
+                : option.text
             }
             onPress={() => {
               if (questIsPremium && !hasPremiumAccess) {
@@ -256,9 +254,7 @@ export function StoryOptionButtons({
                 label={
                   questIsPremium && !hasPremiumAccess
                     ? 'Unlock full Vaedros storyline'
-                    : isStorylineComplete
-                      ? 'Begin your journey'
-                      : option.text
+                    : option.text
                 }
                 onPress={() => {
                   if (questIsPremium && !hasPremiumAccess) {

--- a/src/features/home/hooks/use-home-data.ts
+++ b/src/features/home/hooks/use-home-data.ts
@@ -80,6 +80,11 @@ export function useHomeData({
   // Check if storyline is complete
   const isStorylineComplete = storyProgress >= STORYLINE_COMPLETE_THRESHOLD;
 
+  // True once the user has completed at least one story quest. Used to
+  // gate the "Begin your journey" first-quest CTA so it only appears for
+  // brand-new players, not at every label decision.
+  const hasStartedStoryline = storyProgress > 0;
+
   // Get quest recap text
   const getQuestRecap = useMemo(() => {
     // Use server quest recap if available
@@ -184,5 +189,6 @@ export function useHomeData({
     currentMapName,
     storyProgress,
     isStorylineComplete,
+    hasStartedStoryline,
   };
 }

--- a/src/features/home/types/home-types.ts
+++ b/src/features/home/types/home-types.ts
@@ -65,6 +65,7 @@ export interface HomeData {
   currentMapName: string;
   storyProgress: number;
   isStorylineComplete: boolean;
+  hasStartedStoryline: boolean;
 }
 
 /**


### PR DESCRIPTION
Closes #309.

## Summary

- At quest 30, both branching options rendered the literal string `'Begin your journey'` instead of their actual `option.text` (taps still routed to the correct quest, so the bug was purely cosmetic but appeared at the storyline's emotional peak).
- Root cause: a boolean named `isStorylineComplete` (`storyProgress >= 0.999`) was used in three button-label conditionals as if it meant "storyline not yet started". The misnaming silently produced wrong behavior only at the very end of the storyline.
- Fix replaces the prop with a correctly-named `hasStartedStoryline` (`storyProgress > 0`) and limits the `'Begin your journey'` first-quest CTA to the only render branch where it actually belongs (single quest, no options). The option-list branches now always render `option.text` directly — they never had a reason to override it.
- `isStorylineComplete` is preserved on `useHomeData` for the legitimate consumer at `index.tsx:370` (story-card "completed" badge).

## Test plan

- [x] Added `story-option-buttons.test.tsx` with three tests:
  - reproduces #309 (multi-option labels render `option.text`, not `'Begin your journey'`)
  - first-quest CTA preserved (`'Begin your journey'` shows when `hasStartedStoryline` is false on a single-quest screen)
  - generic CTA after first quest (`'Start Quest'` shows when `hasStartedStoryline` is true)
- [x] Updated `index.test.tsx` single-quest assertion to reflect the corrected first-time-player CTA
- [x] All 40 home-feature tests pass
- [x] Full suite shows same failure count as `main` baseline (7 pre-existing failing suites in unrelated files: auth, guilds, profile, cooperative-pending; my changes add 3 new passing tests)
- [ ] Manual verification on device: complete quests through quest 30 and confirm both final options now show their actual labels (e.g. amulet decisions) rather than duplicated `'Begin your journey'`