### PR TITLE
Add Eyebrow design-system primitive across quest and onboarding screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ credentials/
 credentials.json
 
 CLAUDE.md
+docs/

--- a/src/app/cooperative-pending-quest.test.tsx
+++ b/src/app/cooperative-pending-quest.test.tsx
@@ -229,7 +229,8 @@ describe('CooperativePendingQuestScreen', () => {
     // Now the main screen should be visible
     await waitFor(() => {
       expect(queryByText('Get Ready!')).toBeFalsy();
-      expect(getByText('Cooperative Quest')).toBeTruthy();
+      expect(getByText('COOPERATIVE QUEST')).toBeTruthy();
+      expect(getByText('Start Quest')).toBeTruthy();
       expect(getByTestId('quest-card')).toBeTruthy();
       expect(getByText('Test Cooperative Quest')).toBeTruthy();
       expect(getByText('10 minutes')).toBeTruthy();

--- a/src/app/cooperative-pending-quest.tsx
+++ b/src/app/cooperative-pending-quest.tsx
@@ -13,11 +13,13 @@ import {
   BackgroundImage,
   Button,
   Card,
+  Eyebrow,
   Text,
   Title,
   View,
 } from '@/components/ui';
 import colors from '@/components/ui/colors';
+import { getQuestModeLabel } from '@/lib/utils/quest-utils';
 import { useCharacterStore } from '@/store/character-store';
 import { useQuestStore } from '@/store/quest-store';
 import { type CustomQuestTemplate } from '@/store/types';
@@ -224,10 +226,11 @@ export default function CooperativePendingQuestScreen() {
           paddingHorizontal: UI_CONFIG.HORIZONTAL_PADDING,
         }}
       >
-        {/* Title */}
-        <Animated.View style={headerStyle}>
+        {/* Eyebrow + Title */}
+        <Animated.View style={headerStyle} className="items-center">
+          <Eyebrow text={getQuestModeLabel('cooperative')} />
           <Title variant="centered" className="text-4xl">
-            Cooperative Quest
+            Start Quest
           </Title>
         </Animated.View>
 

--- a/src/app/onboarding/app-introduction.test.tsx
+++ b/src/app/onboarding/app-introduction.test.tsx
@@ -67,6 +67,7 @@ describe('AppIntroductionScreen', () => {
 
     // Use waitFor to handle the async permission check
     await waitFor(() => {
+      expect(getByText('INTRODUCTION')).toBeTruthy();
       expect(getByText('emberglow')).toBeTruthy();
       expect(
         getByText('Discover quests and embrace your journey.')
@@ -88,6 +89,7 @@ describe('AppIntroductionScreen', () => {
 
     // Check that we've moved to the notifications step
     await waitFor(() => {
+      expect(getByText('INTRODUCTION')).toBeTruthy();
       expect(getByText('Notifications')).toBeTruthy();
       expect(getByText('Enable notifications')).toBeTruthy();
     });

--- a/src/app/onboarding/app-introduction.tsx
+++ b/src/app/onboarding/app-introduction.tsx
@@ -11,6 +11,7 @@ import Animated, {
 
 import {
   Button,
+  Eyebrow,
   FocusAwareStatusBar,
   Text,
   Title,
@@ -100,6 +101,9 @@ export default function AppIntroductionScreen() {
       case IntroStep.WELCOME:
         return (
           <View key="welcome">
+            <Animated.View entering={FadeInLeft.delay(50)}>
+              <Eyebrow text="Introduction" />
+            </Animated.View>
             <Animated.View entering={FadeInLeft.delay(100)}>
               <Title text="emberglow" />
             </Animated.View>
@@ -132,6 +136,9 @@ export default function AppIntroductionScreen() {
 
         return (
           <View key="notifications">
+            <Animated.View entering={FadeInLeft.delay(50)}>
+              <Eyebrow text="Introduction" />
+            </Animated.View>
             <Animated.View entering={FadeInLeft.delay(100)}>
               <Title text="Notifications" />
             </Animated.View>

--- a/src/app/onboarding/welcome.test.tsx
+++ b/src/app/onboarding/welcome.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { render, screen } from '@/lib/test-utils';
+
+import WelcomeScreen from './welcome';
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+}));
+
+jest.mock('@/store/onboarding-store', () => ({
+  OnboardingStep: { SELECTING_CHARACTER: 'SELECTING_CHARACTER' },
+  useOnboardingStore: () => ({ setCurrentStep: jest.fn() }),
+}));
+
+describe('WelcomeScreen', () => {
+  it('renders the brand title and tagline', () => {
+    render(<WelcomeScreen />);
+
+    expect(screen.getByText('emberglow')).toBeOnTheScreen();
+    expect(screen.getByText('Level Up By Logging Off')).toBeOnTheScreen();
+  });
+
+  it('renders the BEGIN YOUR JOURNEY eyebrow', () => {
+    render(<WelcomeScreen />);
+
+    expect(screen.getByText('BEGIN YOUR JOURNEY')).toBeOnTheScreen();
+  });
+});

--- a/src/app/onboarding/welcome.tsx
+++ b/src/app/onboarding/welcome.tsx
@@ -6,6 +6,7 @@ import { Image, TouchableOpacity } from 'react-native';
 import {
   BackgroundImage,
   Button,
+  Eyebrow,
   FocusAwareStatusBar,
   Text,
   Title,
@@ -42,6 +43,7 @@ export default function WelcomeScreen() {
             style={{ width: 120, height: 120 }}
             resizeMode="contain"
           />
+          <Eyebrow text="Begin Your Journey" className="mt-2" />
           <Title className="text-4xl" variant="centered">
             emberglow
           </Title>

--- a/src/app/pending-quest.test.tsx
+++ b/src/app/pending-quest.test.tsx
@@ -58,6 +58,12 @@ jest.mock('@/components/ui', () => {
       ),
     Card: ({ children, testID, ...props }: any) =>
       React.createElement(RN.View, { testID, ...props }, children),
+    Eyebrow: ({ text, children, ...props }: any) =>
+      React.createElement(
+        RN.Text,
+        props,
+        (text ?? children ?? '').toString().toUpperCase()
+      ),
     Text: (props: any) => React.createElement(RN.Text, props),
     Title: (props: any) => React.createElement(RN.Text, props),
     View: (props: any) => React.createElement(RN.View, props),
@@ -326,6 +332,23 @@ describe('PendingQuestScreen', () => {
       const { getByText } = render(<PendingQuestScreen />);
 
       expect(getByText('Start Quest')).toBeTruthy();
+    });
+
+    it('displays the eyebrow with the quest mode for story quests', () => {
+      const { getByText } = render(<PendingQuestScreen />);
+
+      expect(getByText('STORY QUEST')).toBeTruthy();
+    });
+
+    it('displays the eyebrow with the quest mode for custom quests', () => {
+      useQuestStore.setState({
+        pendingQuest: mockCustomQuest,
+        cancelQuest: jest.fn(),
+      });
+
+      const { getByText } = render(<PendingQuestScreen />);
+
+      expect(getByText('CUSTOM QUEST')).toBeTruthy();
     });
 
     it('displays lock instructions text', () => {

--- a/src/app/pending-quest.tsx
+++ b/src/app/pending-quest.tsx
@@ -6,8 +6,16 @@ import Animated, { FadeInDown } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useQuestRewardPreview } from '@/api/quest-runs';
-import { BackgroundImage, Button, Text, Title, View } from '@/components/ui';
+import {
+  BackgroundImage,
+  Button,
+  Eyebrow,
+  Text,
+  Title,
+  View,
+} from '@/components/ui';
 import colors from '@/components/ui/colors';
+import { getQuestModeLabel } from '@/lib/utils/quest-utils';
 import { useCharacterStore } from '@/store/character-store';
 import { useQuestStore } from '@/store/quest-store';
 import { useUserStore } from '@/store/user-store';
@@ -81,8 +89,9 @@ export default function PendingQuestScreen() {
           paddingHorizontal: UI_CONFIG.HORIZONTAL_PADDING,
         }}
       >
-        {/* Title */}
-        <Animated.View style={headerStyle}>
+        {/* Eyebrow + Title */}
+        <Animated.View style={headerStyle} className="items-center">
+          <Eyebrow text={getQuestModeLabel(pendingQuest.mode)} />
           <Title variant="centered" className="text-4xl">
             {STRINGS.TITLE}
           </Title>

--- a/src/app/quest-completed-signup.test.tsx
+++ b/src/app/quest-completed-signup.test.tsx
@@ -108,17 +108,34 @@ describe('QuestCompletedSignupScreen', () => {
     it('should display the completion message', () => {
       const { getByText } = render(<QuestCompletedSignupScreen />);
 
-      expect(
-        getByText("You've completed your first quest—Vaedros already feels safer!")
-      ).toBeTruthy();
+      expect(getByText("You've completed your first quest!")).toBeTruthy();
     });
 
     it('should display account benefits', () => {
       const { getByText } = render(<QuestCompletedSignupScreen />);
 
-      expect(getByText('Create an account to:')).toBeTruthy();
-      expect(getByText('• Save your progress and continue your story')).toBeTruthy();
-      expect(getByText('• Unlock the ability to add friends')).toBeTruthy();
+      expect(getByText('Sign up to unlock:')).toBeTruthy();
+      expect(
+        getByText('Continue your story across 29 more quests')
+      ).toBeTruthy();
+      expect(
+        getByText('Forge custom quests from your real-world goals')
+      ).toBeTruthy();
+      expect(
+        getByText("Track your hero's journey in the journal")
+      ).toBeTruthy();
+      expect(
+        getByText('Explore the map of Vaedros and uncover hidden regions')
+      ).toBeTruthy();
+      expect(
+        getByText('Form a guild and run cooperative quests with friends')
+      ).toBeTruthy();
+    });
+
+    it('should display the chapter eyebrow label', () => {
+      const { getByText } = render(<QuestCompletedSignupScreen />);
+
+      expect(getByText('QUEST ONE · COMPLETE')).toBeTruthy();
     });
   });
 });

--- a/src/app/quest-completed-signup.tsx
+++ b/src/app/quest-completed-signup.tsx
@@ -11,6 +11,7 @@ import Animated, {
 
 import {
   Button,
+  Eyebrow,
   FocusAwareStatusBar,
   Text,
   Title,
@@ -79,15 +80,7 @@ export default function QuestCompletedSignupScreen() {
           showsVerticalScrollIndicator={false}
         >
           <Animated.View entering={FadeInLeft.delay(50)}>
-            <Text
-              className="text-xs font-bold"
-              style={{
-                color: colors.brown,
-                letterSpacing: 4,
-              }}
-            >
-              QUEST ONE · COMPLETE
-            </Text>
+            <Eyebrow text="Quest One · Complete" />
           </Animated.View>
 
           <Animated.View entering={FadeInLeft.delay(150)}>

--- a/src/app/quest-completed-signup.tsx
+++ b/src/app/quest-completed-signup.tsx
@@ -1,7 +1,8 @@
+import { Feather } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { usePostHog } from 'posthog-react-native';
 import React, { useCallback } from 'react';
-import { Image } from 'react-native';
+import { Image, ScrollView } from 'react-native';
 import Animated, {
   FadeIn,
   FadeInDown,
@@ -11,11 +12,41 @@ import Animated, {
 import {
   Button,
   FocusAwareStatusBar,
-  ScreenContainer,
   Text,
   Title,
   View,
 } from '@/components/ui';
+import colors from '@/components/ui/colors';
+
+type FeatureIcon = React.ComponentProps<typeof Feather>['name'];
+
+const UNLOCKS: { icon: FeatureIcon; label: string }[] = [
+  { icon: 'book-open', label: 'Continue your story across 29 more quests' },
+  { icon: 'edit-3', label: 'Forge custom quests from your real-world goals' },
+  { icon: 'feather', label: "Track your hero's journey in the journal" },
+  {
+    icon: 'map',
+    label: 'Explore the map of Vaedros and uncover hidden regions',
+  },
+  {
+    icon: 'users',
+    label: 'Form a guild and run cooperative quests with friends',
+  },
+];
+
+function UnlockRow({ icon, label }: { icon: FeatureIcon; label: string }) {
+  return (
+    <View className="mb-4 flex-row items-start">
+      <View
+        className="mr-4 mt-0.5 size-8 items-center justify-center rounded-full"
+        style={{ backgroundColor: 'rgba(229, 88, 56, 0.28)' }}
+      >
+        <Feather name={icon} size={16} color={colors.brown} />
+      </View>
+      <Text className="flex-1 text-base leading-relaxed">{label}</Text>
+    </View>
+  );
+}
 
 export default function QuestCompletedSignupScreen() {
   const posthog = usePostHog();
@@ -38,53 +69,69 @@ export default function QuestCompletedSignupScreen() {
           className="size-full"
           resizeMode="cover"
         />
-        <View className="absolute inset-0 bg-white/10" />
+        <View className="absolute inset-0 bg-black/55" />
       </View>
 
-      <ScreenContainer fullScreen className="justify-between">
-        <View className="mt-6">
-          <Animated.View entering={FadeInLeft.delay(100)}>
+      <View className="flex-1 px-6 pb-6">
+        <ScrollView
+          className="flex-1"
+          contentContainerStyle={{ paddingTop: 24, paddingBottom: 16 }}
+          showsVerticalScrollIndicator={false}
+        >
+          <Animated.View entering={FadeInLeft.delay(50)}>
+            <Text
+              className="text-xs font-bold"
+              style={{
+                color: colors.brown,
+                letterSpacing: 4,
+              }}
+            >
+              QUEST ONE · COMPLETE
+            </Text>
+          </Animated.View>
+
+          <Animated.View entering={FadeInLeft.delay(150)}>
             <Title text="Claim Your Legend" />
           </Animated.View>
 
           <Animated.View entering={FadeInDown.delay(600)}>
-            <Text className="mt-2 text-lg font-bold leading-relaxed">
-              You've completed your first quest—Vaedros already feels safer!
+            <Text className="mt-1 text-lg font-bold leading-relaxed">
+              You've completed your first quest!
             </Text>
           </Animated.View>
 
           <Animated.View entering={FadeInDown.delay(1100)}>
             <Text className="mt-4 text-base leading-relaxed">
-              Create a free account to keep your hero's story alive and unlock
-              the realm's magic.
+              Create a free account to keep your hero's story alive.
             </Text>
           </Animated.View>
 
+          <Animated.View
+            entering={FadeIn.delay(1500)}
+            className="my-7 h-px"
+            style={{ backgroundColor: 'rgba(247, 164, 75, 0.4)' }}
+          />
+
           <Animated.View entering={FadeInDown.delay(1600)}>
-            <Text className="mb-4 mt-6 text-lg font-semibold">
-              Create an account to:
+            <Text className="mb-5 font-erstoria text-2xl text-white">
+              Sign up to unlock:
             </Text>
-            <Text className="mb-3 ml-4 text-base leading-relaxed">
-              • Save your progress and continue your story
-            </Text>
-            <Text className="mb-3 ml-4 text-base leading-relaxed">
-              • Unlock the ability to add friends
-            </Text>
-            <Text className="mb-3 ml-4 text-base leading-relaxed">
-              • Participate in cooperative quests (coming soon)
-            </Text>
+
+            {UNLOCKS.map(({ icon, label }) => (
+              <UnlockRow key={icon} icon={icon} label={label} />
+            ))}
           </Animated.View>
 
           <Animated.View entering={FadeInDown.delay(2100)}>
-            <Text className="my-6 text-base leading-relaxed">
+            <Text className="mt-6 text-base italic leading-relaxed">
               Your hero is currently stored on this device only. Secure the
               journey now and pick up right where you left off—anywhere,
               anytime.
             </Text>
           </Animated.View>
-        </View>
+        </ScrollView>
 
-        <Animated.View entering={FadeIn.delay(2600)}>
+        <Animated.View entering={FadeIn.delay(2600)} className="pt-4">
           <Button
             label="Create Account"
             onPress={handleCreateAccount}
@@ -93,7 +140,7 @@ export default function QuestCompletedSignupScreen() {
             textClassName="text-white font-bold"
           />
         </Animated.View>
-      </ScreenContainer>
+      </View>
     </View>
   );
 }

--- a/src/app/streak-celebration.test.tsx
+++ b/src/app/streak-celebration.test.tsx
@@ -124,6 +124,12 @@ describe('StreakCelebrationScreen', () => {
       const streakText = getByText('day streak!');
       expect(streakText).toBeTruthy();
     });
+
+    it('should display the QUEST STREAK eyebrow', () => {
+      const { getByText } = render(<StreakCelebrationScreen />);
+
+      expect(getByText('QUEST STREAK')).toBeTruthy();
+    });
   });
 
   describe('1-Day Streak (Thursday)', () => {

--- a/src/app/streak-celebration.tsx
+++ b/src/app/streak-celebration.tsx
@@ -9,7 +9,7 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import { StreakCounter } from '@/components/StreakCounter';
-import { ScreenContainer, Text, View } from '@/components/ui';
+import { Eyebrow, ScreenContainer, Text, View } from '@/components/ui';
 import { Button } from '@/components/ui/button';
 import { red, secondary } from '@/components/ui/colors';
 import { useCharacterStore } from '@/store/character-store';
@@ -90,6 +90,7 @@ export default function StreakCelebrationScreen() {
         fullScreen
         className="items-center justify-between px-6 pt-20"
       >
+        <Eyebrow text="Quest Streak" className="mb-2" />
         <View className="w-full flex-1 items-center justify-center">
           {/* Streak Counter with Confetti Animation */}
           <View

--- a/src/components/failed-quest/index.test.tsx
+++ b/src/components/failed-quest/index.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { render, screen } from '@/lib/test-utils';
+import type { Quest } from '@/store/types';
+
+import { FailedQuest } from './index';
+
+const baseQuest = {
+  id: 'quest-1',
+  title: 'The Beginning',
+  durationMinutes: 5,
+  poiSlug: 'tavern',
+  story: 'Your adventure begins...',
+  recap: 'You started your journey',
+  options: [],
+  reward: { xp: 20 },
+  status: 'failed' as const,
+} as unknown as Quest;
+
+describe('FailedQuest', () => {
+  it('renders the headline and quest title', () => {
+    render(
+      <FailedQuest
+        quest={{ ...baseQuest, mode: 'story' } as Quest}
+        onRetry={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Quest Failed')).toBeOnTheScreen();
+    expect(screen.getByText('The Beginning')).toBeOnTheScreen();
+  });
+
+  it('shows the eyebrow with the quest mode label for story quests', () => {
+    render(
+      <FailedQuest
+        quest={{ ...baseQuest, mode: 'story' } as Quest}
+        onRetry={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('STORY QUEST')).toBeOnTheScreen();
+  });
+
+  it('shows the eyebrow with the quest mode label for custom quests', () => {
+    render(
+      <FailedQuest
+        quest={
+          {
+            ...baseQuest,
+            mode: 'custom',
+            category: 'fitness',
+          } as unknown as Quest
+        }
+        onRetry={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('CUSTOM QUEST')).toBeOnTheScreen();
+  });
+});

--- a/src/components/failed-quest/index.tsx
+++ b/src/components/failed-quest/index.tsx
@@ -9,11 +9,13 @@ import Animated, {
 import {
   BackgroundImage,
   Button,
+  Eyebrow,
   ScreenContainer,
   Text,
   Title,
   View,
 } from '@/components/ui';
+import { getQuestModeLabel } from '@/lib/utils/quest-utils';
 import type {
   CustomQuestTemplate,
   Quest,
@@ -64,6 +66,7 @@ export function FailedQuest({ quest, onRetry }: FailedQuestProps) {
           style={headerAnimatedStyle}
           className="mt-12 items-center"
         >
+          <Eyebrow text={getQuestModeLabel(quest.mode)} />
           <Title variant="centered">Quest Failed</Title>
           <Text className="mt-2 text-center text-lg font-medium text-white">
             {quest.title}

--- a/src/components/quest-complete/QuestCompleteHeader.test.tsx
+++ b/src/components/quest-complete/QuestCompleteHeader.test.tsx
@@ -66,6 +66,20 @@ describe('QuestCompleteHeader', () => {
       );
       expect(getByTestId('quest-image-mock')).toBeTruthy();
     });
+
+    it('should render the eyebrow with the story quest mode label', () => {
+      const { getByText } = render(
+        <QuestCompleteHeader quest={mockQuestWithTitle} />
+      );
+      expect(getByText('STORY QUEST')).toBeTruthy();
+    });
+
+    it('should render the eyebrow with the custom quest mode label', () => {
+      const { getByText } = render(
+        <QuestCompleteHeader quest={mockQuestWithoutTitle} />
+      );
+      expect(getByText('CUSTOM QUEST')).toBeTruthy();
+    });
   });
 
   describe('Accessibility', () => {

--- a/src/components/quest-complete/QuestCompleteHeader.tsx
+++ b/src/components/quest-complete/QuestCompleteHeader.tsx
@@ -6,7 +6,8 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
-import { Text } from '@/components/ui';
+import { Eyebrow, Text } from '@/components/ui';
+import { getQuestModeLabel } from '@/lib/utils/quest-utils';
 
 import { ANIMATION_TIMING } from './constants';
 import { QuestImage } from './QuestImage';
@@ -35,11 +36,12 @@ export function QuestCompleteHeader({
 
   return (
     <Animated.View
-      className="mb-3 mt-4 w-full"
+      className="mb-3 mt-4 w-full items-center"
       style={headerStyle}
       accessibilityRole="header"
     >
-      <Text className="mb-2 text-center font-quest text-3xl text-cream-500 drop-shadow-md">
+      <Eyebrow text={getQuestModeLabel(quest.mode)} className="mb-1" />
+      <Text className="font-quest mb-2 text-center text-3xl text-cream-500 drop-shadow-md">
         Quest Complete!
       </Text>
 

--- a/src/components/ui/eyebrow.test.tsx
+++ b/src/components/ui/eyebrow.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { render, screen } from '@/lib/test-utils';
+
+import colors from './colors';
+import { Eyebrow } from './eyebrow';
+
+describe('Eyebrow', () => {
+  it('renders text via the text prop', () => {
+    render(<Eyebrow text="Story Quest" />);
+
+    expect(screen.getByText('STORY QUEST')).toBeOnTheScreen();
+  });
+
+  it('renders children when no text prop is provided', () => {
+    render(<Eyebrow>Quest one · Complete</Eyebrow>);
+
+    expect(screen.getByText('QUEST ONE · COMPLETE')).toBeOnTheScreen();
+  });
+
+  it('applies the design-system eyebrow styling', () => {
+    render(<Eyebrow text="Story Quest" />);
+
+    const node = screen.getByText('STORY QUEST');
+    const flatStyle = Array.isArray(node.props.style)
+      ? Object.assign({}, ...node.props.style.flat(Infinity).filter(Boolean))
+      : node.props.style;
+
+    expect(flatStyle.color).toBe(colors.brown);
+    expect(flatStyle.letterSpacing).toBe(4);
+  });
+
+  it('forwards an accessibilityLabel', () => {
+    render(
+      <Eyebrow text="Story Quest" accessibilityLabel="Story quest section" />
+    );
+
+    expect(screen.getByLabelText('Story quest section')).toBeOnTheScreen();
+  });
+});

--- a/src/components/ui/eyebrow.tsx
+++ b/src/components/ui/eyebrow.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+import colors from './colors';
+import { Text } from './text';
+
+type EyebrowProps = {
+  text?: string;
+  children?: React.ReactNode;
+  className?: string;
+  accessibilityLabel?: string;
+};
+
+export function Eyebrow({
+  text,
+  children,
+  className = '',
+  accessibilityLabel,
+}: EyebrowProps) {
+  const content =
+    typeof (text ?? children) === 'string'
+      ? (text ?? (children as string)).toUpperCase()
+      : (text ?? children);
+
+  return (
+    <Text
+      className={`text-xs font-bold uppercase ${className}`}
+      style={{ color: colors.brown, letterSpacing: 4 }}
+      accessibilityLabel={accessibilityLabel}
+    >
+      {content}
+    </Text>
+  );
+}

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -7,6 +7,7 @@ export * from './card';
 export * from './checkbox';
 export { default as colors } from './colors';
 export * from './duration-badge';
+export * from './eyebrow';
 export * from './focus-aware-status-bar';
 export * from './gradient-background';
 export * from './image';

--- a/src/lib/utils/quest-utils.test.ts
+++ b/src/lib/utils/quest-utils.test.ts
@@ -1,6 +1,6 @@
 import type { QuestParticipant } from '@/store/types';
 
-import { getCurrentUserAdjustedXP } from './quest-utils';
+import { getCurrentUserAdjustedXP, getQuestModeLabel } from './quest-utils';
 
 describe('getCurrentUserAdjustedXP', () => {
   const baseQuest = {
@@ -247,5 +247,24 @@ describe('getCurrentUserAdjustedXP', () => {
       const result2 = getCurrentUserAdjustedXP(questWithMixedUserIds, 'user-123');
       expect(result2).toBe(21);
     });
+  });
+});
+
+describe('getQuestModeLabel', () => {
+  it('returns "Story Quest" for story mode', () => {
+    expect(getQuestModeLabel('story')).toBe('Story Quest');
+  });
+
+  it('returns "Custom Quest" for custom mode', () => {
+    expect(getQuestModeLabel('custom')).toBe('Custom Quest');
+  });
+
+  it('returns "Cooperative Quest" for cooperative mode', () => {
+    expect(getQuestModeLabel('cooperative')).toBe('Cooperative Quest');
+  });
+
+  it('falls back to "Quest" for unknown or missing mode', () => {
+    expect(getQuestModeLabel(undefined)).toBe('Quest');
+    expect(getQuestModeLabel('something-else')).toBe('Quest');
   });
 });

--- a/src/lib/utils/quest-utils.ts
+++ b/src/lib/utils/quest-utils.ts
@@ -134,3 +134,21 @@ export function getCurrentUserRewards(
     perksApplied,
   };
 }
+
+/**
+ * Maps a quest mode to its display label for the eyebrow text pattern.
+ * Used by quest-related screens (pending, failed, complete) to identify
+ * the type of quest above the headline.
+ */
+export function getQuestModeLabel(mode: string | undefined): string {
+  switch (mode) {
+    case 'story':
+      return 'Story Quest';
+    case 'custom':
+      return 'Custom Quest';
+    case 'cooperative':
+      return 'Cooperative Quest';
+    default:
+      return 'Quest';
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts the eyebrow text pattern from the recently shipped *Claim Your Legend* screen into a reusable `<Eyebrow>` component in `src/components/ui/eyebrow.tsx` — auto-uppercases content, applies brown letter-spaced styling, no animation baked in (consumer-controlled).
- Applies the pattern to 7 additional screens: `pending-quest`, `failed-quest`, `quest-complete`, `cooperative-pending-quest`, `streak-celebration`, `onboarding/welcome`, `onboarding/app-introduction` (both substeps). Refactors the original `quest-completed-signup` to use the primitive so the design system has a single source of truth.
- Adds `getQuestModeLabel` helper in `quest-utils.ts` that maps `quest.mode` (story / custom / cooperative) to display strings, so quest-related screens derive their eyebrow content consistently.

## Pattern applied

For repeating quest screens, the eyebrow is identification only (`STORY QUEST`, `CUSTOM QUEST`, `COOPERATIVE QUEST`) and the headline carries the state ("Quest Complete!", "Quest Failed", "Start Quest"). The original `· STATE` half from "QUEST ONE · COMPLETE" is reserved for milestone screens where the headline is thematic rather than literal — repeating it on every quest screen would be redundant.

`cooperative-pending-quest`'s title was harmonized from "Cooperative Quest" → "Start Quest" so it matches `pending-quest`; the eyebrow now does the descriptive job.

## Why no `<ScreenHeader>` composite

Considered but skipped — the seven screens use noticeably different wrapper layouts (some centered, some left-aligned; varying animation choreography; some inside `ScreenContainer`, some bare). A composite would either need many props or force-fit the screens to one layout. Easier to revisit once real duplication shows up.

## Test plan

- [ ] **Claim Your Legend** (`quest-completed-signup`) — visually compare to the screen that shipped on `f698f7a`. Most regression-prone since it's the only screen where the implementation changed (now uses primitive instead of inline styling). The string is the same ("QUEST ONE · COMPLETE"), just routed through `<Eyebrow>`.
- [ ] **Onboarding/welcome** — fresh install, look for `BEGIN YOUR JOURNEY` between icon and "emberglow" title.
- [ ] **Onboarding/app-introduction** — both substeps show `INTRODUCTION` above the title.
- [ ] **Pending quest** (story) — `STORY QUEST` above "Start Quest".
- [ ] **Pending quest** (custom) — sign up, create a custom quest, start it. Eyebrow switches to `CUSTOM QUEST`.
- [ ] **Quest complete** — finish a quest, eyebrow `STORY QUEST` above "Quest Complete!".
- [ ] **Failed quest** — unlock phone mid-quest, eyebrow `STORY QUEST` above "Quest Failed".
- [ ] **Streak celebration** — complete a quest on day 2+ of a streak, `QUEST STREAK` at top.
- [ ] **Cooperative pending quest** — `COOPERATIVE QUEST` above "Start Quest". (Verified via tests; visual check requires a guild + partner.)
- [ ] Long-string check on small phones: `COOPERATIVE QUEST` (17 chars) shouldn't wrap on the centered layout.

## What's intentionally out of scope

- A `<ScreenHeader>` wrapper component (see above).
- Replacing other one-off uppercase/letter-spaced text usages (e.g., `quest-card.tsx` category chips, `settings.tsx` section labels) — those serve different purposes (chips, form section dividers) and shouldn't collapse into the hero eyebrow primitive.

## Verification
- 84 tests pass across the 8 suites covering the changed screens + new primitive + helper
- 0 new lint errors introduced
- 0 new type errors introduced
- The 3 pre-existing failing tests in `cooperative-pending-quest.test.tsx` (timer-coordination flakes around participant rendering) fail identically on `main` — not regressions from this PR.