### PR TITLE
Fix #316: restore green test suite (41 failing tests across 7 suites)

### DIFF
--- a/src/api/common/provisional-client.test.ts
+++ b/src/api/common/provisional-client.test.ts
@@ -5,6 +5,13 @@ jest.mock('@env', () => ({
   },
 }));
 
+// provisional-client derives its baseURL from getApiUrl() (platform-aware URL
+// resolution lives there and is tested separately). Mock it so this test
+// controls the baseURL deterministically regardless of platform/env.
+jest.mock('./get-api-url', () => ({
+  getApiUrl: jest.fn(() => 'https://api.example.com'),
+}));
+
 // Mock storage
 const mockGetItem = jest.fn();
 jest.mock('@/lib/storage', () => ({

--- a/src/app/(app)/profile.test.tsx
+++ b/src/app/(app)/profile.test.tsx
@@ -38,6 +38,17 @@ jest.mock('@/components/ui', () => {
     ),
     Pressable: RN.Pressable,
     ScrollView: RN.ScrollView,
+    Button: ({ label, onPress, testID, disabled }: any) => (
+      <RN.Pressable
+        testID={testID}
+        onPress={onPress}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+      >
+        <RN.Text>{label}</RN.Text>
+      </RN.Pressable>
+    ),
     FocusAwareStatusBar: () => null,
     ScreenContainer: ({ children }: any) => <RN.View>{children}</RN.View>,
     ScreenHeader: ({ title, subtitle }: any) => (
@@ -118,6 +129,12 @@ jest.mock('@/components/profile/delete-friend-modal', () => ({
 
 jest.mock('@/components/profile/rescind-invitation-modal', () => ({
   RescindInvitationModal: () => null,
+}));
+
+// GuildsSection renders the guild join/create modals; the profile screen tests
+// don't exercise guild internals, so stub it out like the other sections.
+jest.mock('@/features/guilds/components/guilds-section', () => ({
+  GuildsSection: () => null,
 }));
 
 // Mock hooks

--- a/src/app/cooperative-pending-quest.test.tsx
+++ b/src/app/cooperative-pending-quest.test.tsx
@@ -202,7 +202,7 @@ describe('CooperativePendingQuestScreen', () => {
 
   it('shows main quest screen after countdown', async () => {
     jest.useFakeTimers();
-    const { getByText, getByTestId, queryByText } = render(
+    const { getByText, queryByText } = render(
       <CooperativePendingQuestScreen />
     );
 
@@ -231,15 +231,14 @@ describe('CooperativePendingQuestScreen', () => {
       expect(queryByText('Get Ready!')).toBeFalsy();
       expect(getByText('COOPERATIVE QUEST')).toBeTruthy();
       expect(getByText('Start Quest')).toBeTruthy();
-      expect(getByTestId('quest-card')).toBeTruthy();
       expect(getByText('Test Cooperative Quest')).toBeTruthy();
-      expect(getByText('10 minutes')).toBeTruthy();
+      expect(getByText('10 min')).toBeTruthy();
     });
 
     jest.useRealTimers();
   });
 
-  it('displays participant list correctly', async () => {
+  it('displays the companion count and subtitle', async () => {
     jest.useFakeTimers();
     const { getByText } = render(<CooperativePendingQuestScreen />);
 
@@ -255,11 +254,15 @@ describe('CooperativePendingQuestScreen', () => {
       jest.advanceTimersByTime(500);
     });
 
+    // The screen shows a companion count badge and a cooperative subtitle
+    // (the per-participant list was replaced in the redesign).
     await waitFor(() => {
-      expect(getByText('Stronger Together')).toBeTruthy();
-      expect(getByText('2 companions embarking on this journey')).toBeTruthy();
-      expect(getByText('✨ You')).toBeTruthy();
-      expect(getByText('⚔️ Friend')).toBeTruthy();
+      expect(getByText('2 Companions')).toBeTruthy();
+      expect(
+        getByText(
+          'Stronger together — complete this quest with your companions'
+        )
+      ).toBeTruthy();
     });
 
     jest.useRealTimers();
@@ -350,7 +353,7 @@ describe('CooperativePendingQuestScreen', () => {
     expect(() => getByTestId('activity-indicator')).toBeTruthy();
   });
 
-  it('handles participants without names', async () => {
+  it('shows the companion count even when participants have no names', async () => {
     jest.useFakeTimers();
 
     const runWithoutNames = {
@@ -381,9 +384,10 @@ describe('CooperativePendingQuestScreen', () => {
       jest.advanceTimersByTime(500);
     });
 
+    // The redesigned screen shows a count rather than per-participant names,
+    // so it renders correctly regardless of whether names are present.
     await waitFor(() => {
-      expect(getByText('✨ You')).toBeTruthy();
-      expect(getByText('⚔️ Quest Companion')).toBeTruthy();
+      expect(getByText('2 Companions')).toBeTruthy();
     });
 
     jest.useRealTimers();

--- a/src/features/guilds/components/__tests__/create-guild-modal.test.tsx
+++ b/src/features/guilds/components/__tests__/create-guild-modal.test.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 
 import { CreateGuildModal } from '../modals/create-guild-modal';
-import { GUILD_FORM, GUILD_TITLES, GUILD_BUTTONS } from '../../constants/guild-strings';
+import {
+  GUILD_FORM,
+  GUILD_TITLES,
+  GUILD_BUTTONS,
+} from '../../constants/guild-strings';
 
 // Mock the gorhom bottom-sheet with all needed exports
 jest.mock('@gorhom/bottom-sheet', () => {
@@ -31,7 +35,13 @@ jest.mock('@gorhom/bottom-sheet', () => {
 
 // Mock the Modal component
 jest.mock('@/components/ui/modal', () => ({
-  Modal: ({ children, title }: { children: React.ReactNode; title: string }) => (
+  Modal: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
     <>
       <span>{title}</span>
       {children}
@@ -139,8 +149,11 @@ describe('CreateGuildModal', () => {
   });
 
   describe('form validation', () => {
-    it('should show error when name is empty on submit', async () => {
-      const { getByTestId, findByText } = render(
+    it('should not submit when name and icon are missing', () => {
+      // The form gates submission via a disabled button + a guard in
+      // handleSubmit (requires a non-empty name and a selected icon), rather
+      // than rendering an inline error message.
+      const { getByTestId } = render(
         <CreateGuildModal
           visible={true}
           onSubmit={mockOnSubmit}
@@ -151,7 +164,6 @@ describe('CreateGuildModal', () => {
 
       fireEvent.press(getByTestId('create-guild-submit'));
 
-      expect(await findByText('Guild name is required')).toBeTruthy();
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
   });
@@ -179,6 +191,9 @@ describe('CreateGuildModal', () => {
         'A test tagline'
       );
 
+      // Select an icon (required — the form no longer has a default icon)
+      fireEvent.press(getByTestId('icon-button-flame'));
+
       // Submit
       fireEvent.press(getByTestId('create-guild-submit'));
 
@@ -187,7 +202,7 @@ describe('CreateGuildModal', () => {
           expect.objectContaining({
             name: 'Test Guild',
             tagline: 'A test tagline',
-            icon: 'campfire', // Default icon
+            icon: 'flame',
           })
         );
       });

--- a/src/features/guilds/components/__tests__/guild-icon-selector.test.tsx
+++ b/src/features/guilds/components/__tests__/guild-icon-selector.test.tsx
@@ -32,22 +32,22 @@ describe('GuildIconSelector', () => {
   describe('rendering', () => {
     it('should render all 8 guild icons', () => {
       const { getAllByTestId } = render(
-        <GuildIconSelector selected="campfire" onSelect={mockOnSelect} />
+        <GuildIconSelector selected="camping" onSelect={mockOnSelect} />
       );
 
       const iconButtons = getAllByTestId(/^icon-button-/);
-      expect(iconButtons).toHaveLength(8);
+      expect(iconButtons).toHaveLength(10);
     });
 
     it('should render each icon', () => {
       const { getByTestId } = render(
-        <GuildIconSelector selected="campfire" onSelect={mockOnSelect} />
+        <GuildIconSelector selected="camping" onSelect={mockOnSelect} />
       );
 
       // Check a few specific icons
-      expect(getByTestId('guild-icon-campfire')).toBeTruthy();
+      expect(getByTestId('guild-icon-camping')).toBeTruthy();
       expect(getByTestId('guild-icon-flame')).toBeTruthy();
-      expect(getByTestId('guild-icon-island')).toBeTruthy();
+      expect(getByTestId('guild-icon-banner')).toBeTruthy();
     });
   });
 
@@ -66,8 +66,8 @@ describe('GuildIconSelector', () => {
         <GuildIconSelector selected="flame" onSelect={mockOnSelect} />
       );
 
-      // campfire is not selected, so no indicator
-      expect(queryByTestId('selected-indicator-campfire')).toBeNull();
+      // camping is not selected, so no indicator
+      expect(queryByTestId('selected-indicator-camping')).toBeNull();
       expect(queryByTestId('selected-indicator-axe')).toBeNull();
     });
   });
@@ -75,7 +75,7 @@ describe('GuildIconSelector', () => {
   describe('interactions', () => {
     it('should call onSelect with icon id when pressed', () => {
       const { getByTestId } = render(
-        <GuildIconSelector selected="campfire" onSelect={mockOnSelect} />
+        <GuildIconSelector selected="camping" onSelect={mockOnSelect} />
       );
 
       fireEvent.press(getByTestId('icon-button-flame'));
@@ -85,17 +85,17 @@ describe('GuildIconSelector', () => {
 
     it('should call onSelect even when pressing already selected icon', () => {
       const { getByTestId } = render(
-        <GuildIconSelector selected="campfire" onSelect={mockOnSelect} />
+        <GuildIconSelector selected="camping" onSelect={mockOnSelect} />
       );
 
-      fireEvent.press(getByTestId('icon-button-campfire'));
+      fireEvent.press(getByTestId('icon-button-camping'));
 
-      expect(mockOnSelect).toHaveBeenCalledWith('campfire');
+      expect(mockOnSelect).toHaveBeenCalledWith('camping');
     });
 
     it('should call onSelect with different icons', () => {
       const { getByTestId } = render(
-        <GuildIconSelector selected="campfire" onSelect={mockOnSelect} />
+        <GuildIconSelector selected="camping" onSelect={mockOnSelect} />
       );
 
       fireEvent.press(getByTestId('icon-button-magic'));
@@ -109,21 +109,21 @@ describe('GuildIconSelector', () => {
   describe('accessibility', () => {
     it('should have accessible labels for each icon', () => {
       const { getByLabelText } = render(
-        <GuildIconSelector selected="campfire" onSelect={mockOnSelect} />
+        <GuildIconSelector selected="camping" onSelect={mockOnSelect} />
       );
 
       // Each icon should have an accessible label
       expect(getByLabelText('Select Axe icon')).toBeTruthy();
-      expect(getByLabelText('Select Campfire icon')).toBeTruthy();
+      expect(getByLabelText('Select Camping icon')).toBeTruthy();
       expect(getByLabelText('Select Flame icon')).toBeTruthy();
     });
 
     it('should indicate selected state in accessibility', () => {
       const { getByLabelText } = render(
-        <GuildIconSelector selected="campfire" onSelect={mockOnSelect} />
+        <GuildIconSelector selected="camping" onSelect={mockOnSelect} />
       );
 
-      const selectedIcon = getByLabelText('Select Campfire icon');
+      const selectedIcon = getByLabelText('Select Camping icon');
       expect(selectedIcon.props.accessibilityState.selected).toBe(true);
     });
   });
@@ -131,7 +131,7 @@ describe('GuildIconSelector', () => {
   describe('layout', () => {
     it('should use a grid layout', () => {
       const { getByTestId } = render(
-        <GuildIconSelector selected="campfire" onSelect={mockOnSelect} />
+        <GuildIconSelector selected="camping" onSelect={mockOnSelect} />
       );
 
       const container = getByTestId('icon-selector-grid');

--- a/src/features/guilds/constants/__tests__/guild-icons.test.ts
+++ b/src/features/guilds/constants/__tests__/guild-icons.test.ts
@@ -5,24 +5,30 @@ import {
   getGuildIconSource,
   DEFAULT_GUILD_ICON,
 } from '../guild-icons';
-import type { GuildIcon } from '../../types/guild-types';
 
 describe('Guild Icons', () => {
+  // Derive the canonical id list from the source of truth so this test does
+  // not rot when icons are added or renamed.
+  const iconIds = GUILD_ICONS.map((icon) => icon.id);
+
   describe('GUILD_ICONS', () => {
-    it('should have 8 icons defined', () => {
-      expect(GUILD_ICONS).toHaveLength(8);
+    it('should have 10 icons defined', () => {
+      expect(GUILD_ICONS).toHaveLength(10);
     });
 
-    it('should include all expected icon types', () => {
-      const iconIds = GUILD_ICONS.map((icon) => icon.id);
-      expect(iconIds).toContain('axe');
-      expect(iconIds).toContain('bow');
-      expect(iconIds).toContain('campfire');
-      expect(iconIds).toContain('island');
-      expect(iconIds).toContain('flame');
-      expect(iconIds).toContain('explorer');
-      expect(iconIds).toContain('magic');
-      expect(iconIds).toContain('powerup');
+    it('should include the expected icon types', () => {
+      expect(iconIds).toEqual([
+        'axe',
+        'hammer',
+        'camping',
+        'mug',
+        'flame',
+        'explorer',
+        'magic',
+        'banner',
+        'scroll',
+        'diamond',
+      ]);
     });
 
     it('should have all required properties for each icon', () => {
@@ -38,19 +44,8 @@ describe('Guild Icons', () => {
   });
 
   describe('GUILD_ICON_MAP', () => {
-    it('should have SVG source for each icon type', () => {
-      const iconTypes: GuildIcon[] = [
-        'axe',
-        'bow',
-        'campfire',
-        'island',
-        'flame',
-        'explorer',
-        'magic',
-        'powerup',
-      ];
-
-      iconTypes.forEach((iconType) => {
+    it('should have an SVG source for every icon type', () => {
+      iconIds.forEach((iconType) => {
         expect(GUILD_ICON_MAP[iconType]).toBeDefined();
       });
     });
@@ -63,59 +58,43 @@ describe('Guild Icons', () => {
       expect(config.label).toBe('Axe');
     });
 
-    it('should return correct config for campfire icon', () => {
-      const config = getGuildIconConfig('campfire');
-      expect(config.id).toBe('campfire');
-      expect(config.label).toBe('Campfire');
+    it('should return correct config for camping icon', () => {
+      const config = getGuildIconConfig('camping');
+      expect(config.id).toBe('camping');
+      expect(config.label).toBe('Camping');
     });
 
     it('should return correct config for all icon types', () => {
-      const iconTypes: GuildIcon[] = [
-        'axe',
-        'bow',
-        'campfire',
-        'island',
-        'flame',
-        'explorer',
-        'magic',
-        'powerup',
-      ];
-
-      iconTypes.forEach((iconType) => {
+      iconIds.forEach((iconType) => {
         const config = getGuildIconConfig(iconType);
         expect(config.id).toBe(iconType);
       });
     });
 
-    it('should return default icon config for unknown icon', () => {
-      // This tests the fallback behavior when an invalid icon is passed
-      // TypeScript would prevent this in normal usage, but we test the runtime fallback
-      const config = getGuildIconConfig('unknown' as GuildIcon);
-      expect(config.id).toBe('campfire'); // campfire is the fallback (index 2)
+    it('should return the default icon config for an unknown icon', () => {
+      // Fallback is GUILD_ICONS[2] (see getGuildIconConfig implementation).
+      const config = getGuildIconConfig('unknown' as never);
+      expect(config).toEqual(GUILD_ICONS[2]);
     });
   });
 
   describe('getGuildIconSource', () => {
-    it('should return SVG source for campfire icon', () => {
-      const source = getGuildIconSource('campfire');
+    it('should return an SVG source for a known icon', () => {
+      const source = getGuildIconSource('camping');
       expect(source).toBeDefined();
     });
 
-    it('should return SVG source for island icon', () => {
-      const source = getGuildIconSource('island');
+    it('should return the fallback source for an unknown icon', () => {
+      const source = getGuildIconSource('unknown' as never);
       expect(source).toBeDefined();
-    });
-
-    it('should return fallback source for unknown icon', () => {
-      const source = getGuildIconSource('unknown' as GuildIcon);
-      expect(source).toBeDefined();
-      expect(source).toBe(GUILD_ICON_MAP.campfire);
+      // Fallback is the banner icon (see getGuildIconSource implementation).
+      expect(source).toBe(GUILD_ICON_MAP.banner);
     });
   });
 
   describe('DEFAULT_GUILD_ICON', () => {
-    it('should be campfire', () => {
-      expect(DEFAULT_GUILD_ICON).toBe('campfire');
+    it('should be banner', () => {
+      expect(DEFAULT_GUILD_ICON).toBe('banner');
     });
   });
 });

--- a/src/lib/auth/index.test.tsx
+++ b/src/lib/auth/index.test.tsx
@@ -346,10 +346,11 @@ describe('Auth Store', () => {
       // The implementation now keeps the user signed in on fetch failure
       expect(signOutSpy).not.toHaveBeenCalled();
 
-      // The implementation doesn't set status to signIn on user details fetch failure
-      // It remains as 'hydrating' but the user stays logged in with the token
+      // When a token exists but the user-details fetch fails, the implementation
+      // intentionally sets status to 'signIn' so the app can proceed offline
+      // (see the "CRITICAL: Must set status to signIn" path in hydrate()).
       const state = useAuth.getState();
-      expect(state.status).toBe('hydrating');
+      expect(state.status).toBe('signIn');
       expect(state.token).toEqual({ access: 'token' });
     });
 


### PR DESCRIPTION
Fixes #316.

## Root cause

Six test suites drifted out of sync with production code changes that landed during ~8 weeks of idle time on the re-engagement branch. The failures were authored and fixed on `feature/reenagement` (commits `38ab40a`–`a441835`) but were never backported to `main`, leaving `main` red. This PR cherry-picks exactly those 6 commits onto `main`.

Each suite's specific drift:

| Suite | Root cause (file:line) |
|---|---|
| `guild-icons.test.ts` | Icon set grew from 8 → 10 icons; `campfire` renamed to `camping`; default changed to `banner`. Tests asserted the old counts/names. |
| `guild-icon-selector.test.tsx` | Same icon-set expansion — tests expected 8 rendered icons, not 10. |
| `create-guild-modal.test.tsx` | Form no longer has a default icon; submit is now blocked via a disabled button + `handleSubmit` guard rather than an inline error message. |
| `auth/index.test.tsx` | `hydrate()` sets status to `'signIn'` (not `'hydrating'`) when user-details fetch fails, so the app can proceed offline. Test asserted the old intermediate status. |
| `provisional-client.test.ts` | `baseURL` is now derived from `getApiUrl()` (platform-aware), not `Env.API_URL` directly. Test lacked a mock for `getApiUrl`, making the assertion non-deterministic. |
| `profile.test.tsx` | `ProfileScreen` renders `GuildsSection` which mounts guild modals; unmocked `@/components/ui` Button resolved to `undefined` and crashed via `react-native-css-interop`. `GuildsSection` needed to be stubbed like the other sections. |
| `cooperative-pending-quest.test.tsx` | Screen was redesigned: QuestCard/participant-list replaced with an inline card (companion-count badge + reward preview); duration now reads "X min". Tests asserted old UI text. |

## Change

Cherry-picked 6 commits from `feature/reenagement` onto `main`. All changes are confined to `__tests__` / `*.test.ts(x)` files — zero production code touched.

## Verification

```
npx jest   # on fix/316
Test Suites: 112 passed, 112 total
Tests:       3 skipped, 1312 passed, 1315 total
```

Previously on `main` before this branch: 41 failed, 7 suites red.

> Draft opened by morning-pm bug-fixer. Human review + merge required.