### PR TITLE
Fix #97: clear OS notifications when app comes to foreground

### DIFF
--- a/src/app/_layout.test.tsx
+++ b/src/app/_layout.test.tsx
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 import { render, waitFor } from '@testing-library/react-native';
 import React from 'react';
-import { Platform } from 'react-native';
+import { AppState, Platform } from 'react-native';
 
 // Import the component after mocks are set up
 import RootLayout from './_layout';
@@ -136,6 +136,7 @@ jest.mock('@/lib/hooks/useLockStateDetection', () => ({
 
 jest.mock('@/lib/services/notifications', () => ({
   scheduleStreakWarningNotification: jest.fn().mockResolvedValue(undefined),
+  clearAllNotifications: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('@/lib/services/quest-run-service', () => ({
@@ -598,5 +599,50 @@ describe('RootLayout', () => {
       expect(mockEvent.preventDefault).toHaveBeenCalled();
       expect(mockEvent.notification.display).toHaveBeenCalled();
     });
+  });
+
+  it('should clear all notifications when app comes to foreground', async () => {
+    const {
+      clearAllNotifications,
+    } = require('@/lib/services/notifications');
+
+    // Capture the change listener registered by RootLayout
+    const capturedListeners: Array<(state: string) => void> = [];
+    const addEventListenerSpy = jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((event: string, listener: any) => {
+        if (event === 'change') {
+          capturedListeners.push(listener);
+        }
+        return { remove: jest.fn() };
+      });
+
+    // Set currentState to background so the transition condition fires
+    Object.defineProperty(AppState, 'currentState', {
+      value: 'background',
+      writable: true,
+      configurable: true,
+    });
+
+    render(<RootLayout />);
+
+    // Wait for the AppState listener to be registered
+    await waitFor(() => {
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function)
+      );
+    });
+
+    // Simulate app transitioning from background to active
+    for (const listener of capturedListeners) {
+      await listener('active');
+    }
+
+    await waitFor(() => {
+      expect(clearAllNotifications).toHaveBeenCalled();
+    });
+
+    addEventListenerSpy.mockRestore();
   });
 });

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -34,7 +34,10 @@ import colors from '@/components/ui/colors';
 import { hydrateAuth, loadSelectedTheme, useAuth } from '@/lib';
 import { useTokenRefreshErrorHandler } from '@/lib/hooks/use-token-refresh-error-handler';
 import useLockStateDetection from '@/lib/hooks/useLockStateDetection';
-import { scheduleStreakWarningNotification } from '@/lib/services/notifications';
+import {
+  clearAllNotifications,
+  scheduleStreakWarningNotification,
+} from '@/lib/services/notifications';
 import { getQuestRunStatus } from '@/lib/services/quest-run-service';
 import { revenueCatService } from '@/lib/services/revenuecat-service';
 import { initializeTimezoneSync } from '@/lib/services/timezone-service';
@@ -291,6 +294,13 @@ function RootLayout() {
         ) {
           // App has come to foreground
           console.log('[App State] App foregrounded, checking quest status');
+
+          // Clear any stale notifications (e.g. quest-complete) from the OS
+          // tray so a lingering tap cannot re-open a screen that is already
+          // open, which would break audio narration and cause errors.
+          clearAllNotifications().catch((err) =>
+            console.error('[App State] Failed to clear notifications:', err)
+          );
 
           // Check if we have an active cooperative quest that might have failed
           const questStore = useQuestStore.getState();


### PR DESCRIPTION
Fixes #97.

## Summary
When the user leaves a quest-complete notification in the OS notification tray and later opens the app, the notification persists. Tapping it re-navigates to the quest-complete screen even though it is already open, which breaks audio narration and causes an error.

## Approach / Root cause
`src/lib/services/notifications.ts:70` — `clearAllNotifications()` already exists and calls `ExpoNotifications.dismissAllNotificationsAsync()`. It is invoked when the quest timer starts, but there was no call on app foreground. The root cause is that the existing `AppState` `change` listener in `src/app/_layout.tsx:283-327` only checks cooperative quest status on foreground — it never clears OS notifications.

## Change
Added `clearAllNotifications()` to the already-present foreground-transition branch of the `AppState` change listener in `src/app/_layout.tsx`. The call is fire-and-forget (errors are caught and logged) so it cannot block the existing cooperative quest status check.

Also updated `src/app/_layout.test.tsx` to:
- Add `clearAllNotifications` to the notifications service mock.
- Add a test that verifies `clearAllNotifications` is called when the app transitions from background to active.

## Verification
- `pnpm test src/app/_layout.test.tsx` — 16 tests pass (15 pre-existing + 1 new).
- `pnpm type-check` — all errors are pre-existing across unrelated files; zero new errors in touched files.
- `pnpm lint` — no errors in `_layout.tsx` or `_layout.test.tsx`; all other errors are pre-existing.

> Draft opened by morning-pm senior-developer. Human review + merge required.