### PR TITLE
test: establish coverage baseline and add initial unit tests

### DIFF
--- a/src/api/common/get-api-url.test.ts
+++ b/src/api/common/get-api-url.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for getApiUrl — the platform-aware API URL resolver.
+ *
+ * Branches under test:
+ * 1. production/staging → always returns Env.API_URL
+ * 2. development, Android emulator → 10.0.2.2 alias
+ * 3. development, iOS simulator → localhost
+ * 4. development, real device → Env.API_URL
+ * 5. extractPortAndPath fallback when URL parsing fails
+ *
+ * jest.doMock (not jest.mock) is used inside helper functions so the mock
+ * factories can legally close over test-local variables.
+ */
+
+/** Re-require getApiUrl with controlled environment/platform/device values. */
+function loadGetApiUrl(opts: {
+  APP_ENV: string;
+  API_URL: string;
+  platformOS: string;
+  isRealDevice: boolean;
+}): () => string {
+  jest.resetModules();
+
+  jest.doMock('@env', () => ({
+    Env: { APP_ENV: opts.APP_ENV, API_URL: opts.API_URL },
+  }));
+  jest.doMock('react-native', () => ({
+    Platform: { OS: opts.platformOS },
+  }));
+  jest.doMock('expo-device', () => ({
+    isDevice: opts.isRealDevice,
+  }));
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require('./get-api-url').getApiUrl;
+}
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe('getApiUrl', () => {
+  describe('production environment', () => {
+    it('returns API_URL directly without modification', () => {
+      const getApiUrl = loadGetApiUrl({
+        APP_ENV: 'production',
+        API_URL: 'https://api.example.com/v1',
+        platformOS: 'ios',
+        isRealDevice: false,
+      });
+      expect(getApiUrl()).toBe('https://api.example.com/v1');
+    });
+
+    it('ignores platform when APP_ENV is production — Android emulator still gets prod URL', () => {
+      const getApiUrl = loadGetApiUrl({
+        APP_ENV: 'production',
+        API_URL: 'https://prod.example.com/v1',
+        platformOS: 'android',
+        isRealDevice: false,
+      });
+      expect(getApiUrl()).toBe('https://prod.example.com/v1');
+    });
+  });
+
+  describe('staging environment', () => {
+    it('returns API_URL directly without modification', () => {
+      const getApiUrl = loadGetApiUrl({
+        APP_ENV: 'staging',
+        API_URL: 'https://staging.example.com/v1',
+        platformOS: 'ios',
+        isRealDevice: false,
+      });
+      expect(getApiUrl()).toBe('https://staging.example.com/v1');
+    });
+  });
+
+  describe('development environment — Android emulator', () => {
+    it('uses 10.0.2.2 alias with correct port and path', () => {
+      const getApiUrl = loadGetApiUrl({
+        APP_ENV: 'development',
+        API_URL: 'http://localhost:3001/v1',
+        platformOS: 'android',
+        isRealDevice: false,
+      });
+      expect(getApiUrl()).toBe('http://10.0.2.2:3001/v1');
+    });
+
+    it('preserves custom port from API_URL', () => {
+      const getApiUrl = loadGetApiUrl({
+        APP_ENV: 'development',
+        API_URL: 'http://localhost:8080/api',
+        platformOS: 'android',
+        isRealDevice: false,
+      });
+      expect(getApiUrl()).toBe('http://10.0.2.2:8080/api');
+    });
+  });
+
+  describe('development environment — iOS simulator', () => {
+    it('uses localhost with correct port and path', () => {
+      const getApiUrl = loadGetApiUrl({
+        APP_ENV: 'development',
+        API_URL: 'http://192.168.1.5:3001/v1',
+        platformOS: 'ios',
+        isRealDevice: false,
+      });
+      expect(getApiUrl()).toBe('http://localhost:3001/v1');
+    });
+
+    it('preserves nested path segments', () => {
+      const getApiUrl = loadGetApiUrl({
+        APP_ENV: 'development',
+        API_URL: 'http://192.168.1.5:4000/api/v2',
+        platformOS: 'ios',
+        isRealDevice: false,
+      });
+      expect(getApiUrl()).toBe('http://localhost:4000/api/v2');
+    });
+  });
+
+  describe('development environment — real device', () => {
+    it('returns API_URL without remapping for iOS real device', () => {
+      const apiUrl = 'http://192.168.1.5:3001/v1';
+      const getApiUrl = loadGetApiUrl({
+        APP_ENV: 'development',
+        API_URL: apiUrl,
+        platformOS: 'ios',
+        isRealDevice: true,
+      });
+      expect(getApiUrl()).toBe(apiUrl);
+    });
+
+    it('returns API_URL without remapping for Android real device', () => {
+      const apiUrl = 'http://192.168.1.5:3001/v1';
+      const getApiUrl = loadGetApiUrl({
+        APP_ENV: 'development',
+        API_URL: apiUrl,
+        platformOS: 'android',
+        isRealDevice: true,
+      });
+      expect(getApiUrl()).toBe(apiUrl);
+    });
+  });
+
+  describe('extractPortAndPath fallback — invalid API_URL', () => {
+    it('falls back to port 3001 and path /v1 on Android emulator', () => {
+      const getApiUrl = loadGetApiUrl({
+        APP_ENV: 'development',
+        API_URL: 'not-a-valid-url',
+        platformOS: 'android',
+        isRealDevice: false,
+      });
+      expect(getApiUrl()).toBe('http://10.0.2.2:3001/v1');
+    });
+
+    it('falls back to port 3001 and path /v1 on iOS simulator', () => {
+      const getApiUrl = loadGetApiUrl({
+        APP_ENV: 'development',
+        API_URL: 'not-a-valid-url',
+        platformOS: 'ios',
+        isRealDevice: false,
+      });
+      expect(getApiUrl()).toBe('http://localhost:3001/v1');
+    });
+  });
+});

--- a/src/app/streak-visualization.util.test.ts
+++ b/src/app/streak-visualization.util.test.ts
@@ -1,0 +1,159 @@
+import { DAY_NAMES, STREAK } from './streak-celebration.constants';
+import {
+  generateStreakVisualization,
+  isStreakActive,
+} from './streak-visualization.util';
+
+// Pin "today" to Wednesday (day index 3) so all tests are deterministic.
+const WEDNESDAY = 3;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  // Set the clock to a Wednesday at noon UTC.
+  jest.setSystemTime(new Date('2024-01-17T12:00:00Z')); // 2024-01-17 is a Wednesday
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('generateStreakVisualization', () => {
+  describe('0-day streak', () => {
+    it('returns 5 days starting from today with none completed', () => {
+      const result = generateStreakVisualization(0);
+
+      expect(result).toHaveLength(STREAK.DAYS_TO_SHOW);
+      expect(result.every((d) => !d.isCompleted)).toBe(true);
+    });
+
+    it('marks only the first entry as today', () => {
+      const result = generateStreakVisualization(0);
+
+      expect(result[0].isToday).toBe(true);
+      expect(result.slice(1).every((d) => !d.isToday)).toBe(true);
+    });
+
+    it('starts from the actual current day', () => {
+      const result = generateStreakVisualization(0);
+      const todayIndex = new Date().getDay();
+
+      expect(result[0].name).toBe(DAY_NAMES[todayIndex]);
+    });
+
+    it('wraps day names correctly past Saturday', () => {
+      // Set today to Saturday (day 6) so day 4 of the 5-day window wraps to Monday (1).
+      jest.setSystemTime(new Date('2024-01-20T12:00:00Z')); // Saturday
+      const result = generateStreakVisualization(0);
+
+      expect(result[0].name).toBe('Sa');
+      expect(result[1].name).toBe('Su');
+      expect(result[2].name).toBe('Mo');
+      expect(result[3].name).toBe('Tu');
+      expect(result[4].name).toBe('We');
+    });
+  });
+
+  describe('1-4 day streak (partial view)', () => {
+    it('marks the correct number of leading days as completed', () => {
+      for (let streak = 1; streak <= 4; streak++) {
+        const result = generateStreakVisualization(streak);
+
+        const completedCount = result.filter((d) => d.isCompleted).length;
+        expect(completedCount).toBe(streak);
+      }
+    });
+
+    it('marks today correctly within the partial streak window', () => {
+      // 2-day streak on a Wednesday: Tu(completed), We(today+completed), Th, Fr, Sa
+      const result = generateStreakVisualization(2);
+      const todayEntry = result.find((d) => d.isToday);
+
+      expect(todayEntry).toBeDefined();
+      expect(todayEntry!.isCompleted).toBe(true);
+      expect(todayEntry!.name).toBe('We');
+    });
+
+    it('places completed days before today and empty days after', () => {
+      const streak = 3;
+      const result = generateStreakVisualization(streak);
+
+      // First <streak> entries are completed; the rest are not.
+      result.slice(0, streak).forEach((d) => expect(d.isCompleted).toBe(true));
+      result.slice(streak).forEach((d) => expect(d.isCompleted).toBe(false));
+    });
+
+    it('always returns exactly 5 entries', () => {
+      [1, 2, 3, 4].forEach((streak) => {
+        expect(generateStreakVisualization(streak)).toHaveLength(
+          STREAK.DAYS_TO_SHOW
+        );
+      });
+    });
+  });
+
+  describe('5+ day streak (full view)', () => {
+    it('marks all 5 days as completed', () => {
+      [5, 6, 10, 30].forEach((streak) => {
+        const result = generateStreakVisualization(streak);
+        expect(result.every((d) => d.isCompleted)).toBe(true);
+      });
+    });
+
+    it('marks only the last entry as today', () => {
+      const result = generateStreakVisualization(5);
+
+      expect(result[result.length - 1].isToday).toBe(true);
+      expect(result.slice(0, -1).every((d) => !d.isToday)).toBe(true);
+    });
+
+    it('ends on the current day of the week', () => {
+      const result = generateStreakVisualization(7);
+      const todayIndex = new Date().getDay();
+
+      expect(result[result.length - 1].name).toBe(DAY_NAMES[todayIndex]);
+    });
+
+    it('wraps backwards correctly when streak window crosses Sunday→Saturday boundary', () => {
+      // Set today to Tuesday (day 2): window should be Fr, Sa, Su, Mo, Tu — all completed.
+      jest.setSystemTime(new Date('2024-01-16T12:00:00Z')); // Tuesday
+      const result = generateStreakVisualization(5);
+
+      expect(result.map((d) => d.name)).toEqual(['Fr', 'Sa', 'Su', 'Mo', 'Tu']);
+      expect(result.every((d) => d.isCompleted)).toBe(true);
+    });
+  });
+});
+
+describe('isStreakActive', () => {
+  it('returns false when timestamp is null', () => {
+    expect(isStreakActive(null)).toBe(false);
+  });
+
+  it('returns false when timestamp is 0 (falsy)', () => {
+    expect(isStreakActive(0)).toBe(false);
+  });
+
+  it('returns true when last completion was less than 24 hours ago', () => {
+    const oneHourAgo = Date.now() - 60 * 60 * 1000;
+    expect(isStreakActive(oneHourAgo)).toBe(true);
+  });
+
+  it('returns true when last completion was exactly 23h59m59s ago', () => {
+    const justUnder24h = Date.now() - (STREAK.MILLISECONDS_IN_DAY - 1000);
+    expect(isStreakActive(justUnder24h)).toBe(true);
+  });
+
+  it('returns false when last completion was exactly 24 hours ago', () => {
+    const exactly24h = Date.now() - STREAK.MILLISECONDS_IN_DAY;
+    expect(isStreakActive(exactly24h)).toBe(false);
+  });
+
+  it('returns false when last completion was more than 24 hours ago', () => {
+    const twoDaysAgo = Date.now() - 2 * STREAK.MILLISECONDS_IN_DAY;
+    expect(isStreakActive(twoDaysAgo)).toBe(false);
+  });
+
+  it('returns true when last completion was just now', () => {
+    expect(isStreakActive(Date.now())).toBe(true);
+  });
+});

--- a/src/app/utils/character-utils.test.ts
+++ b/src/app/utils/character-utils.test.ts
@@ -1,0 +1,64 @@
+import { getCharacterAvatar } from '../utils/character-utils';
+
+// Image requires are stubbed by __mocks__/fileMock.js → 'test-file-stub'.
+// The CHARACTERS data array uses require() for images, so each character's
+// profileImage and image fields will equal 'test-file-stub' in tests.
+
+jest.mock('@/app/data/characters', () => [
+  {
+    id: 'alchemist',
+    type: 'Alchemist',
+    title: 'Master of Transformation',
+    description: 'Transforms idle time.',
+    image: 'test-file-stub',
+    profileImage: 'alchemist-profile-stub',
+  },
+  {
+    id: 'bard',
+    type: 'Bard',
+    title: 'Voice of Inspiration',
+    description: 'Creates harmony.',
+    image: 'bard-image-stub',
+    // No profileImage — tests the fallback to character.image
+  },
+  {
+    id: 'no-images',
+    type: 'Ghost',
+    title: 'No Images',
+    description: 'Missing everything.',
+    // Neither image nor profileImage
+  },
+]);
+
+describe('getCharacterAvatar', () => {
+  it('returns the default avatar when characterType is undefined', () => {
+    const result = getCharacterAvatar(undefined);
+    // require('@/../assets/images/characters/alchemist-profile.jpg') is mocked
+    expect(result).toBe('test-file-stub');
+  });
+
+  it('returns the default avatar when characterType is an empty string', () => {
+    const result = getCharacterAvatar('');
+    expect(result).toBe('test-file-stub');
+  });
+
+  it('returns profileImage when the character has one', () => {
+    const result = getCharacterAvatar('alchemist');
+    expect(result).toBe('alchemist-profile-stub');
+  });
+
+  it('falls back to character.image when profileImage is absent', () => {
+    const result = getCharacterAvatar('bard');
+    expect(result).toBe('bard-image-stub');
+  });
+
+  it('falls back to the default avatar when the character has neither image field', () => {
+    const result = getCharacterAvatar('no-images');
+    expect(result).toBe('test-file-stub');
+  });
+
+  it('returns the default avatar when characterType does not match any character', () => {
+    const result = getCharacterAvatar('wizard-nonexistent');
+    expect(result).toBe('test-file-stub');
+  });
+});


### PR DESCRIPTION
## What's now covered

- **`streak-visualization.util.ts`** — `generateStreakVisualization` all 3 branches (0-day, 1–4 day partial view, 5+ day full view) with day-wrapping edge cases; `isStreakActive` (null, falsy-0, within-24h, boundary, over-24h). Function coverage for this file: 50% → 100%.
- **`api/common/get-api-url.ts`** — All platform/environment branches: production (returns URL as-is regardless of platform), staging (same), dev+Android emulator (10.0.2.2 alias), dev+iOS simulator (localhost), dev+real device (URL as-is), and the `extractPortAndPath` fallback when the URL cannot be parsed. Branch coverage for this file: 71% → 100%.
- **`app/utils/character-utils.ts`** — `getCharacterAvatar`: undefined input, empty-string, character with `profileImage`, character with only `image` (profileImage fallback path), character with neither, unknown characterType. Line coverage: 50% → 100%.

## Coverage delta

n/a → measured (baseline now established)

- Lines: 57.04% → 57.16%
- Statements: 56.93% → 57.06%
- Functions: 55.67% → 55.78%
- Branches: 48.64% → 48.87%

`coverage/coverage-summary.json` is now written on every `pnpm test:ci` run (script was already present; `json-summary` reporter was already configured in `jest.config.js`).

## Verification

```
pnpm test:ci
# Test Suites: 115 passed, 115 total
# Tests:       3 skipped, 1348 passed, 1351 total
```

All 115 suites green (was 112 before this PR). 36 net-new tests added.

## Flaky tests fixed

none

> Draft opened by morning-pm test-engineer. Human review + merge required.