### PR TITLE
feat(liveactivities): prepare-time id hardenings — fresh id (H1), register-at-prepare (H2), stale-run guard (M1)

### DIFF
--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -199,6 +199,33 @@ describe('QuestTimer', () => {
         JSON.stringify(mockQuestTemplate)
       );
     });
+
+    it('mints a fresh Live Activity id on every prepare (H1)', async () => {
+      // Arrange
+      const mockQuestTemplate: StoryQuestTemplate = {
+        id: 'test-quest-id',
+        title: 'Test Quest',
+        durationMinutes: 15,
+        mode: 'story',
+        recap: 'Test quest recap',
+        poiSlug: 'test-poi',
+        story: 'Test story content',
+        options: [{ id: 'option1', text: 'Option 1', nextQuestId: null }],
+        reward: { xp: 100 },
+      };
+
+      // Act
+      await QuestTimer.prepareQuest(mockQuestTemplate);
+      const firstId = (OneSignal.LiveActivities.startDefault as jest.Mock)
+        .mock.calls[0][0];
+      await QuestTimer.prepareQuest(mockQuestTemplate);
+      const secondId = (OneSignal.LiveActivities.startDefault as jest.Mock)
+        .mock.calls[1][0];
+
+      // Assert
+      expect(firstId).toBeTruthy();
+      expect(secondId).not.toBe(firstId);
+    });
   });
 
   describe('onPhoneLocked', () => {

--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -137,6 +137,11 @@ jest.mock('react-native-bg-actions', () => ({
 describe('QuestTimer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // clearAllMocks only clears call records, not implementations. Re-establish
+    // createQuestRun's default resolved value so a prior test's mockRejectedValue
+    // can't leak forward. (Previously masked by the static questRunId never being
+    // reset between tests; M1's prepare-time reset removes that masking.)
+    (createQuestRun as jest.Mock).mockResolvedValue({ id: 'mock-quest-run-id' });
     // Clear the mock storage
     Object.keys(mockStorage).forEach((key) => delete mockStorage[key]);
     // Reset Platform.OS to ios for most tests
@@ -252,6 +257,32 @@ describe('QuestTimer', () => {
         false,
         activityId
       );
+    });
+
+    it('does not register a stale prior run id when createQuestRun fails (M1)', async () => {
+      // Arrange
+      const mockQuestTemplate: StoryQuestTemplate = {
+        id: 'test-quest-id',
+        title: 'Test Quest',
+        durationMinutes: 15,
+        mode: 'story',
+        recap: 'Test quest recap',
+        poiSlug: 'test-poi',
+        story: 'Test story content',
+        options: [{ id: 'option1', text: 'Option 1', nextQuestId: null }],
+        reward: { xp: 100 },
+      };
+
+      // Simulate a leftover questRunId from a prior quest
+      // @ts-ignore - private static
+      QuestTimer.questRunId = 'stale-prior-run-id';
+      (createQuestRun as jest.Mock).mockRejectedValue(new Error('server down'));
+
+      // Act
+      await QuestTimer.prepareQuest(mockQuestTemplate);
+
+      // Assert - H2 must NOT register the current card's id onto the stale prior run
+      expect(updatePhoneLockStatus).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -226,6 +226,33 @@ describe('QuestTimer', () => {
       expect(firstId).toBeTruthy();
       expect(secondId).not.toBe(firstId);
     });
+
+    it('registers the new activity id with the server at prepare (H2)', async () => {
+      // Arrange
+      const mockQuestTemplate: StoryQuestTemplate = {
+        id: 'test-quest-id',
+        title: 'Test Quest',
+        durationMinutes: 15,
+        mode: 'story',
+        recap: 'Test quest recap',
+        poiSlug: 'test-poi',
+        story: 'Test story content',
+        options: [{ id: 'option1', text: 'Option 1', nextQuestId: null }],
+        reward: { xp: 100 },
+      };
+
+      // Act
+      await QuestTimer.prepareQuest(mockQuestTemplate);
+      const activityId = (OneSignal.LiveActivities.startDefault as jest.Mock)
+        .mock.calls[0][0];
+
+      // Assert
+      expect(updatePhoneLockStatus).toHaveBeenCalledWith(
+        'mock-quest-run-id',
+        false,
+        activityId
+      );
+    });
   });
 
   describe('onPhoneLocked', () => {

--- a/src/lib/services/quest-timer.ts
+++ b/src/lib/services/quest-timer.ts
@@ -286,6 +286,25 @@ export default class QuestTimer {
       }
     }
 
+    // H2: register the new activity id with the server now (best-effort), before the
+    // phone is ever locked, so the stale-activity sweep can dismiss this card even if
+    // the quest is abandoned before locking. Uses locked:false — the phone isn't locked
+    // yet. Non-fatal: a failure here must not break quest preparation.
+    if (Platform.OS === 'ios' && this.questRunId && this.oneSignalActivityId) {
+      try {
+        await updatePhoneLockStatus(
+          this.questRunId,
+          false,
+          this.oneSignalActivityId
+        );
+      } catch (error) {
+        console.log(
+          '[QuestTimer] prepare-time live activity registration failed (non-fatal):',
+          error
+        );
+      }
+    }
+
     await this.saveQuestData();
 
     // Android Background Service Setup (remains the same)

--- a/src/lib/services/quest-timer.ts
+++ b/src/lib/services/quest-timer.ts
@@ -256,9 +256,9 @@ export default class QuestTimer {
 
     if (Platform.OS === 'ios') {
       try {
-        if (!this.oneSignalActivityId) {
-          this.oneSignalActivityId = uuidv4();
-        }
+        // H1: always mint a fresh id for each new quest. Reusing a restored/stale id
+        // would let the server's stale-activity sweep dismiss the current quest's card.
+        this.oneSignalActivityId = uuidv4();
         // Construct attributes and content with status='pending'
         const attributes = {
           title: pendingQuestTitle,

--- a/src/lib/services/quest-timer.ts
+++ b/src/lib/services/quest-timer.ts
@@ -172,6 +172,11 @@ export default class QuestTimer {
     this.questTemplate = questTemplate;
     this.questStartTime = null;
 
+    // M1: reset the run id up front. A new prepare always establishes a new run id
+    // (coop param or createQuestRun); clearing it first ensures a failed createQuestRun
+    // can't leave a stale prior run id that H2 would then register the current card onto.
+    this.questRunId = null;
+
     // Use the provided cooperative quest run ID if available
     if (cooperativeQuestRunId) {
       console.log(


### PR DESCRIPTION
## Live Activity lifecycle hardenings (client side of Bug #3 fix)

Three focused changes to `QuestTimer.prepareQuest` that pair with the server-side stale-Live-Activity sweep (**emberglow-server PR #51**). They make the sweep safe and complete for solo quests. Isolated onto their own branch off `main` (the work was developed on `tweak/live-activities`; these are the only lifecycle-relevant commits, cherry-picked out for a focused review).

### Changes
- **H1 — always mint a fresh activity id per quest.** `prepareQuest` previously reused a restored/leftover id. If a new quest inherited an old id, the server sweep (which ends the user's *prior* ids) could dismiss the *current* card. Now every prepare mints a fresh `uuidv4()`, so the current card's id can never be in the swept set.
- **H2 — register the activity id at prepare-time.** The id previously reached the server only at phone-lock. If the user prepared a quest (card shown) then abandoned before locking, the server never learned the id and could never sweep that orphan card. `prepareQuest` now registers it immediately via `updatePhoneLockStatus(runId, false, id)` — best-effort, failures are non-fatal. (Depends on server PR #51's "persist liveActivityID on unlock" change.)
- **M1 — reset the run id at prepare entry.** Guards against a stale prior `questRunId` (left over when a previous quest's cleanup didn't run) combining with a failed `createQuestRun` to register the current id onto the wrong run. Fixing this also surfaced and fixed a latent test-isolation leak (`clearAllMocks` clears call records but not mock *implementations*, so a prior test's `mockRejectedValue` leaked forward — previously masked by the static `questRunId` never being reset).

### Testing
`quest-timer.test.ts` — **14/14 pass** (3 new tests: H1 fresh-id-per-prepare, H2 registration args, M1 stale-run guard). All three changes are scoped to `Platform.OS === 'ios'`, consistent with the rest of the Live Activity code.

### ⚠️ Deploy ordering
Merge/deploy **emberglow-server PR #51 first** — H2 calls the phone-unlock endpoint enhanced there. Without it, H2's registration is a harmless no-op (the id simply isn't persisted server-side).

### Follow-up (not blocking)
Co-op **invitees** aren't covered by the sweep yet — see emberglow-server#52.
