### PR TITLE
feat(analytics): identify users and add signup, lifecycle, and purchase events

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -239,6 +239,23 @@ jest.mock('posthog-react-native', () => ({
   usePostHog: () => ({
     capture: jest.fn(),
   }),
+  PostHogProvider: ({ children }: { children: React.ReactNode }) => children,
+  default: jest.fn().mockImplementation(() => ({
+    capture: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+  })),
+}));
+
+// Shared module-level client (src/lib/posthog.ts) — mocked globally so
+// services and stores that import it can run under test; suites assert on
+// these fns directly.
+jest.mock('@/lib/posthog', () => ({
+  posthogClient: {
+    capture: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+  },
 }));
 
 // Mock BlurView from expo-blur

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { OneSignal } from 'react-native-onesignal';
 
 import { signIn } from '@/lib/auth';
+import { posthogClient } from '@/lib/posthog';
 import { getUserDetails } from '@/lib/services/user';
 import { getItem, removeItem } from '@/lib/storage';
 import { useCharacterStore } from '@/store/character-store';
@@ -132,6 +133,10 @@ export const verifyMagicLinkAndSignIn = async (
       // Store user data in user store
       if (userResponse && userResponse.id && userResponse.email) {
         useUserStore.getState().setUser(userResponse);
+
+        // Same id as OneSignal/RevenueCat — merges the anonymous history
+        // into the server-side user in PostHog.
+        posthogClient.identify(userResponse.id);
 
         // Link OneSignal with the user's MongoDB ID
         if ((global as any).isOneSignalInitialized) {

--- a/src/app/(app)/index.tsx
+++ b/src/app/(app)/index.tsx
@@ -528,6 +528,7 @@ export default function Home() {
       {/* Premium Paywall Modal */}
       <PremiumPaywall
         isVisible={showPaywallModal}
+        source="home"
         onClose={() => {
           setShowPaywallModal(false);
         }}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -508,12 +508,7 @@ function Providers({
         >
           <KeyboardProvider>
             <ThemeProvider value={theme}>
-              <PostHogProviderWrapper
-                apiKey={Env.POSTHOG_API_KEY}
-                options={{
-                  host: 'https://us.i.posthog.com',
-                }}
-              >
+              <PostHogProviderWrapper>
                 <APIProvider>
                   <LazyWebSocketProvider>
                     <BottomSheetModalProvider>

--- a/src/app/auth/magiclink/verify.test.tsx
+++ b/src/app/auth/magiclink/verify.test.tsx
@@ -30,6 +30,13 @@ jest.mock('@/lib/auth', () => ({
 // Mock axios
 jest.mock('axios');
 
+// Stable capture fn so assertions can see calls (the global jest-setup mock
+// returns a fresh object per usePostHog call).
+const mockPosthogCapture = jest.fn();
+jest.mock('posthog-react-native', () => ({
+  usePostHog: () => ({ capture: mockPosthogCapture }),
+}));
+
 describe('MagicLinkVerifyScreen', () => {
   let mockReplace: jest.Mock;
 
@@ -104,6 +111,35 @@ describe('MagicLinkVerifyScreen', () => {
 
     // Verify that verifyMagicLinkAndSignIn was called with the correct token
     expect(verifyMagicLinkAndSignIn).toHaveBeenCalledWith('valid-token');
+  });
+
+  it('should capture signup_completed after successful verification', async () => {
+    (useLocalSearchParams as jest.Mock).mockReturnValue({
+      token: 'valid-token',
+    });
+    (verifyMagicLinkAndSignIn as jest.Mock).mockResolvedValue('app');
+
+    render(<MagicLinkVerifyScreen />);
+
+    await waitFor(() => {
+      expect(mockPosthogCapture).toHaveBeenCalledWith('signup_completed');
+    });
+  });
+
+  it('should not capture signup_completed when verification fails', async () => {
+    (useLocalSearchParams as jest.Mock).mockReturnValue({
+      token: 'bad-token',
+    });
+    (verifyMagicLinkAndSignIn as jest.Mock).mockRejectedValue(
+      new Error('expired')
+    );
+
+    render(<MagicLinkVerifyScreen />);
+
+    await waitFor(() => {
+      expect(signOut).toHaveBeenCalled();
+    });
+    expect(mockPosthogCapture).not.toHaveBeenCalledWith('signup_completed');
   });
 
   it('should redirect to onboarding when verification returns onboarding target', async () => {

--- a/src/app/auth/magiclink/verify.tsx
+++ b/src/app/auth/magiclink/verify.tsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { FlameKindling } from 'lucide-react-native';
+import { usePostHog } from 'posthog-react-native';
 import React, { useEffect, useRef, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import Animated, {
@@ -52,6 +53,7 @@ const ERROR_BODY_MAX_WIDTH = 240;
 
 export default function VerifyMagicLinkScreen() {
   const router = useRouter();
+  const posthog = usePostHog();
   const params = useLocalSearchParams();
   const token = params.token as string;
   const [error, setError] = useState<string | null>(null);
@@ -98,6 +100,10 @@ export default function VerifyMagicLinkScreen() {
         // Call the comprehensive verification function
         const navigationTarget = await verifyMagicLinkAndSignIn(token);
 
+        // The magic link is the final signup step — this closes the
+        // onboarding funnel (magic_link_sent_success → signup_completed).
+        posthog.capture('signup_completed');
+
         // Navigate based on the returned target
         if (navigationTarget === 'app') {
           router.replace('/(app)/');
@@ -136,7 +142,7 @@ export default function VerifyMagicLinkScreen() {
     // `params` stays in the deps despite being unread in the body now:
     // removing it would change when verification re-runs (a behavior change
     // beyond this presentation pass); the ref guard above absorbs the churn.
-  }, [token, router, params]);
+  }, [token, router, params, posthog]);
 
   if (error) {
     return (

--- a/src/components/paywall/premium-paywall.test.tsx
+++ b/src/components/paywall/premium-paywall.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import RevenueCatUI from 'react-native-purchases-ui';
+
+import { render, waitFor } from '@/lib/test-utils';
+
+import { PremiumPaywall } from './premium-paywall';
+
+// Override the global jest-setup mock: the component branches on the
+// PAYWALL_RESULT enum, which the global mock does not provide.
+jest.mock('react-native-purchases-ui', () => ({
+  PAYWALL_RESULT: {
+    NOT_PRESENTED: 'NOT_PRESENTED',
+    ERROR: 'ERROR',
+    CANCELLED: 'CANCELLED',
+    PURCHASED: 'PURCHASED',
+    RESTORED: 'RESTORED',
+  },
+  presentPaywall: jest.fn(),
+}));
+
+const mockPosthogCapture = jest.fn();
+jest.mock('posthog-react-native', () => ({
+  usePostHog: () => ({ capture: mockPosthogCapture }),
+}));
+
+jest.mock('@/lib/services/revenuecat-service', () => ({
+  revenueCatService: {
+    refreshCustomerInfo: jest.fn().mockResolvedValue({}),
+    hasPremiumAccess: jest.fn().mockResolvedValue(true),
+    enableTestMode: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/services/user', () => ({
+  refreshPremiumStatus: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('react-native-flash-message', () => ({
+  showMessage: jest.fn(),
+}));
+
+const mockPresentPaywall = RevenueCatUI.presentPaywall as jest.Mock;
+
+describe('PremiumPaywall analytics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('captures paywall_viewed and purchase_completed when purchased', async () => {
+    mockPresentPaywall.mockResolvedValue('PURCHASED');
+    const onClose = jest.fn();
+    const onSuccess = jest.fn();
+
+    render(
+      <PremiumPaywall
+        isVisible
+        onClose={onClose}
+        onSuccess={onSuccess}
+        source="skill_tree"
+      />
+    );
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    expect(mockPosthogCapture).toHaveBeenCalledWith('paywall_viewed', {
+      source: 'skill_tree',
+    });
+    expect(mockPosthogCapture).toHaveBeenCalledWith('purchase_completed', {
+      source: 'skill_tree',
+      method: 'paywall',
+    });
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('captures purchase_cancelled when the user dismisses the paywall', async () => {
+    mockPresentPaywall.mockResolvedValue('CANCELLED');
+    const onClose = jest.fn();
+
+    render(<PremiumPaywall isVisible onClose={onClose} source="home" />);
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    expect(mockPosthogCapture).toHaveBeenCalledWith('paywall_viewed', {
+      source: 'home',
+    });
+    expect(mockPosthogCapture).toHaveBeenCalledWith('purchase_cancelled', {
+      source: 'home',
+      method: 'paywall',
+    });
+  });
+
+  it('captures nothing when not visible', async () => {
+    render(<PremiumPaywall isVisible={false} onClose={jest.fn()} />);
+
+    expect(mockPresentPaywall).not.toHaveBeenCalled();
+    expect(mockPosthogCapture).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/paywall/premium-paywall.tsx
+++ b/src/components/paywall/premium-paywall.tsx
@@ -1,3 +1,4 @@
+import { usePostHog } from 'posthog-react-native';
 import { useEffect, useState } from 'react';
 import { Alert } from 'react-native';
 import { showMessage } from 'react-native-flash-message';
@@ -10,13 +11,18 @@ interface PremiumPaywallProps {
   isVisible: boolean;
   onClose: () => void;
   onSuccess?: () => void;
+  /** Where the paywall was opened from — becomes the `source` property on
+   * paywall/purchase events so conversion can be compared per placement. */
+  source?: string;
 }
 
 export function PremiumPaywall({
   isVisible,
   onClose,
   onSuccess,
+  source = 'unknown',
 }: PremiumPaywallProps) {
+  const posthog = usePostHog();
   console.log('[PremiumPaywall] Component rendered with isVisible:', isVisible);
   const [hasPresented, setHasPresented] = useState(false);
 
@@ -38,6 +44,8 @@ export function PremiumPaywall({
       // Present the paywall immediately when visible
       const presentPaywall = async () => {
         try {
+          posthog.capture('paywall_viewed', { source });
+
           const paywallResult = await RevenueCatUI.presentPaywall();
           console.log(
             '[PremiumPaywall] Paywall presentation result:',
@@ -46,6 +54,7 @@ export function PremiumPaywall({
 
           // Handle any immediate presentation errors
           if (paywallResult === RevenueCatUI.PAYWALL_RESULT.ERROR) {
+            posthog.capture('purchase_failed', { source, method: 'paywall' });
             Alert.alert(
               'Error',
               'Unable to show subscription options. Please try again later.',
@@ -60,12 +69,22 @@ export function PremiumPaywall({
               [{ text: 'OK', onPress: onClose }]
             );
           } else if (paywallResult === RevenueCatUI.PAYWALL_RESULT.CANCELLED) {
+            posthog.capture('purchase_cancelled', {
+              source,
+              method: 'paywall',
+            });
             console.log('[PremiumPaywall] User cancelled the paywall');
             onClose();
           } else if (
             paywallResult === RevenueCatUI.PAYWALL_RESULT.PURCHASED ||
             paywallResult === RevenueCatUI.PAYWALL_RESULT.RESTORED
           ) {
+            posthog.capture(
+              paywallResult === RevenueCatUI.PAYWALL_RESULT.RESTORED
+                ? 'restore_purchases_succeeded'
+                : 'purchase_completed',
+              { source, method: 'paywall' }
+            );
             console.log(
               '[PremiumPaywall] Purchase/Restore successful:',
               paywallResult
@@ -127,6 +146,11 @@ export function PremiumPaywall({
             onClose();
           }
         } catch (error: any) {
+          posthog.capture('purchase_failed', {
+            source,
+            method: 'paywall',
+            error_code: error?.code ?? error?.message,
+          });
           console.error('[PremiumPaywall] Error presenting paywall:', error);
 
           // In development, check for common issues
@@ -175,7 +199,7 @@ export function PremiumPaywall({
 
       presentPaywall();
     }
-  }, [isVisible, hasPresented, onClose, onSuccess]);
+  }, [isVisible, hasPresented, onClose, onSuccess, posthog, source]);
 
   // This component doesn't render anything visible
   return null;

--- a/src/components/providers/posthog-provider-wrapper.tsx
+++ b/src/components/providers/posthog-provider-wrapper.tsx
@@ -1,27 +1,20 @@
 import { PostHogProvider } from 'posthog-react-native';
 import React from 'react';
 
+import { posthogClient } from '@/lib/posthog';
+
 interface PostHogProviderWrapperProps {
-  apiKey: string;
-  options: {
-    host: string;
-  };
   children: React.ReactNode;
 }
 
 export function PostHogProviderWrapper({
-  apiKey,
-  options,
   children,
 }: PostHogProviderWrapperProps) {
   return (
     <PostHogProvider
-      apiKey={apiKey}
-      options={{
-        ...options,
-        // Disable PostHog in development to prevent annoying error messages
-        disabled: __DEV__,
-      }}
+      // Shared module-level client so non-React code (services, stores) can
+      // capture through the same instance — see src/lib/posthog.ts.
+      client={posthogClient}
       // Disable autocapture to prevent navigation errors
       autocapture={false}
     >

--- a/src/components/skill-tree/skill-tree-screen.tsx
+++ b/src/components/skill-tree/skill-tree-screen.tsx
@@ -350,6 +350,7 @@ export function SkillTreeScreen() {
         isVisible={showPaywall}
         onClose={handlePaywallClose}
         onSuccess={handlePaywallSuccess}
+        source="skill_tree"
       />
     </View>
   );

--- a/src/lib/auth/index.tsx
+++ b/src/lib/auth/index.tsx
@@ -3,6 +3,7 @@ import { OneSignal } from 'react-native-onesignal';
 import { create } from 'zustand';
 
 import { storeTokens } from '@/api/token';
+import { posthogClient } from '@/lib/posthog';
 import { revenueCatService } from '@/lib/services/revenuecat-service';
 import { getUserDetails } from '@/lib/services/user';
 import { getItem } from '@/lib/storage';
@@ -40,6 +41,7 @@ const _useAuth = create<AuthState>((set, get) => ({
 
     // Login to RevenueCat with user ID
     if (loginResponse.user?.id) {
+      posthogClient.identify(loginResponse.user.id);
       try {
         await revenueCatService.loginUser(loginResponse.user.id);
         console.log(
@@ -63,6 +65,10 @@ const _useAuth = create<AuthState>((set, get) => ({
 
     // Clear user store
     useUserStore.getState().clearUser();
+
+    // Detach the PostHog person so a next login on this device doesn't
+    // inherit this user's identity.
+    posthogClient.reset();
 
     // Logout from RevenueCat
     try {
@@ -170,6 +176,7 @@ const _useAuth = create<AuthState>((set, get) => ({
 
           // Login to RevenueCat with user ID
           if (user.id) {
+            posthogClient.identify(user.id);
             try {
               await revenueCatService.loginUser(user.id);
               console.log(

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -1,0 +1,22 @@
+import { Env } from '@env';
+import PostHog from 'posthog-react-native';
+
+/**
+ * Module-level PostHog client, shared between React (via the `client` prop on
+ * PostHogProviderWrapper) and non-React code (services, stores, API layer).
+ * Non-React code must import this instead of calling usePostHog.
+ *
+ * distinct_id convention: identify() is always called with the server-side
+ * user id (Mongo id) — the same id passed to OneSignal.login and
+ * revenueCatService.loginUser — so server-emitted PostHog events stitch to
+ * the same person.
+ */
+export const posthogClient = new PostHog(Env.POSTHOG_API_KEY, {
+  host: 'https://us.i.posthog.com',
+  // Application Installed / Opened / Backgrounded — the baseline events for
+  // retention insights. Manual $screen tracking stays in
+  // PostHogNavigationTracker; touch/screen autocapture stays off.
+  captureAppLifecycleEvents: true,
+  // Disable PostHog in development to prevent annoying error messages
+  disabled: __DEV__,
+});

--- a/src/lib/services/revenuecat-service.test.ts
+++ b/src/lib/services/revenuecat-service.test.ts
@@ -1,0 +1,165 @@
+import Purchases from 'react-native-purchases';
+import RevenueCatUI from 'react-native-purchases-ui';
+
+import { posthogClient } from '@/lib/posthog';
+
+import { revenueCatService } from './revenuecat-service';
+
+// Override the global jest-setup mock: the service's paywall flow needs the
+// PAYWALL_RESULT enum, which the global mock does not provide.
+jest.mock('react-native-purchases-ui', () => ({
+  PAYWALL_RESULT: {
+    NOT_PRESENTED: 'NOT_PRESENTED',
+    ERROR: 'ERROR',
+    CANCELLED: 'CANCELLED',
+    PURCHASED: 'PURCHASED',
+    RESTORED: 'RESTORED',
+  },
+  presentPaywall: jest.fn(),
+  presentPaywallIfNeeded: jest.fn(),
+}));
+
+const mockPurchases = Purchases as jest.Mocked<typeof Purchases>;
+const mockPresentPaywall = RevenueCatUI.presentPaywall as jest.Mock;
+
+const testPackage = {
+  identifier: 'monthly',
+  product: {
+    identifier: 'emberglow_monthly',
+    price: 4.99,
+    currencyCode: 'USD',
+  },
+} as any;
+
+describe('RevenueCatService analytics', () => {
+  beforeAll(() => {
+    revenueCatService.initialize();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('purchasePackage', () => {
+    it('captures purchase_initiated and purchase_completed on success', async () => {
+      (mockPurchases.purchasePackage as jest.Mock).mockResolvedValue({
+        customerInfo: {},
+      });
+
+      await revenueCatService.purchasePackage(testPackage);
+
+      expect(posthogClient.capture).toHaveBeenCalledWith('purchase_initiated', {
+        package_id: 'monthly',
+        product_id: 'emberglow_monthly',
+        price: 4.99,
+        currency: 'USD',
+      });
+      expect(posthogClient.capture).toHaveBeenCalledWith('purchase_completed', {
+        package_id: 'monthly',
+        product_id: 'emberglow_monthly',
+        price: 4.99,
+        currency: 'USD',
+      });
+    });
+
+    it('captures purchase_cancelled when the user cancels', async () => {
+      (mockPurchases.purchasePackage as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('cancelled'), { userCancelled: true })
+      );
+
+      await expect(
+        revenueCatService.purchasePackage(testPackage)
+      ).rejects.toThrow();
+
+      expect(posthogClient.capture).toHaveBeenCalledWith('purchase_cancelled', {
+        package_id: 'monthly',
+      });
+      expect(posthogClient.capture).not.toHaveBeenCalledWith(
+        'purchase_completed',
+        expect.anything()
+      );
+    });
+
+    it('captures purchase_failed with the error code on failure', async () => {
+      (mockPurchases.purchasePackage as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('store blew up'), { code: 'STORE_PROBLEM' })
+      );
+
+      await expect(
+        revenueCatService.purchasePackage(testPackage)
+      ).rejects.toThrow();
+
+      expect(posthogClient.capture).toHaveBeenCalledWith('purchase_failed', {
+        package_id: 'monthly',
+        error_code: 'STORE_PROBLEM',
+      });
+    });
+  });
+
+  describe('restorePurchases', () => {
+    it('captures attempted and succeeded on success', async () => {
+      (mockPurchases.restorePurchases as jest.Mock).mockResolvedValue({});
+
+      await revenueCatService.restorePurchases();
+
+      expect(posthogClient.capture).toHaveBeenCalledWith(
+        'restore_purchases_attempted'
+      );
+      expect(posthogClient.capture).toHaveBeenCalledWith(
+        'restore_purchases_succeeded'
+      );
+    });
+
+    it('captures attempted and failed on failure', async () => {
+      (mockPurchases.restorePurchases as jest.Mock).mockRejectedValue(
+        new Error('network')
+      );
+
+      await expect(revenueCatService.restorePurchases()).rejects.toThrow();
+
+      expect(posthogClient.capture).toHaveBeenCalledWith(
+        'restore_purchases_attempted'
+      );
+      expect(posthogClient.capture).toHaveBeenCalledWith(
+        'restore_purchases_failed'
+      );
+    });
+  });
+
+  describe('presentPaywall', () => {
+    it('captures paywall_viewed and purchase_completed when purchased', async () => {
+      mockPresentPaywall.mockResolvedValue('PURCHASED');
+      (mockPurchases.getCustomerInfo as jest.Mock).mockResolvedValue({});
+
+      await revenueCatService.presentPaywall('settings');
+
+      expect(posthogClient.capture).toHaveBeenCalledWith('paywall_viewed', {
+        source: 'settings',
+      });
+      expect(posthogClient.capture).toHaveBeenCalledWith('purchase_completed', {
+        source: 'settings',
+        method: 'paywall',
+      });
+    });
+
+    it('captures paywall_viewed and purchase_cancelled when cancelled', async () => {
+      mockPresentPaywall.mockResolvedValue('CANCELLED');
+
+      await revenueCatService.presentPaywall('settings');
+
+      expect(posthogClient.capture).toHaveBeenCalledWith('paywall_viewed', {
+        source: 'settings',
+      });
+      expect(posthogClient.capture).toHaveBeenCalledWith('purchase_cancelled', {
+        source: 'settings',
+        method: 'paywall',
+      });
+    });
+  });
+});

--- a/src/lib/services/revenuecat-service.ts
+++ b/src/lib/services/revenuecat-service.ts
@@ -8,6 +8,8 @@ import Purchases, {
 } from 'react-native-purchases';
 import RevenueCatUI from 'react-native-purchases-ui';
 
+import { posthogClient } from '@/lib/posthog';
+
 export class RevenueCatService {
   private static instance: RevenueCatService;
   private isInitialized = false;
@@ -208,28 +210,50 @@ export class RevenueCatService {
   }
 
   async purchasePackage(pkg: PurchasesPackage): Promise<CustomerInfo> {
+    const purchaseProps = {
+      package_id: pkg.identifier,
+      product_id: pkg.product.identifier,
+      price: pkg.product.price,
+      currency: pkg.product.currencyCode,
+    };
+    posthogClient.capture('purchase_initiated', purchaseProps);
+
     try {
       const { customerInfo } = await Purchases.purchasePackage(pkg);
       this.customerInfo = customerInfo;
+      posthogClient.capture('purchase_completed', purchaseProps);
       return customerInfo;
-    } catch (error) {
+    } catch (error: any) {
+      if (error?.userCancelled) {
+        posthogClient.capture('purchase_cancelled', {
+          package_id: pkg.identifier,
+        });
+      } else {
+        posthogClient.capture('purchase_failed', {
+          package_id: pkg.identifier,
+          error_code: error?.code ?? error?.message,
+        });
+      }
       console.error('Failed to purchase package:', error);
       throw error;
     }
   }
 
   async restorePurchases(): Promise<CustomerInfo> {
+    posthogClient.capture('restore_purchases_attempted');
     try {
       const customerInfo = await Purchases.restorePurchases();
       this.customerInfo = customerInfo;
+      posthogClient.capture('restore_purchases_succeeded');
       return customerInfo;
     } catch (error) {
+      posthogClient.capture('restore_purchases_failed');
       console.error('Failed to restore purchases:', error);
       throw error;
     }
   }
 
-  async presentPaywall(): Promise<boolean> {
+  async presentPaywall(source: string = 'unknown'): Promise<boolean> {
     // Ensure SDK is initialized
     if (!this.isInitialized) {
       console.error('RevenueCat not initialized. Cannot present paywall.');
@@ -245,19 +269,39 @@ export class RevenueCatService {
     }
 
     try {
+      posthogClient.capture('paywall_viewed', { source });
+
       const paywallResult = await RevenueCatUI.presentPaywall();
       console.log('Paywall result:', paywallResult);
 
       switch (paywallResult) {
         case RevenueCatUI.PAYWALL_RESULT.PURCHASED:
-        case RevenueCatUI.PAYWALL_RESULT.RESTORED:
+          posthogClient.capture('purchase_completed', {
+            source,
+            method: 'paywall',
+          });
           // Refresh customer info after successful purchase/restore
           await this.refreshCustomerInfo();
           return true;
+        case RevenueCatUI.PAYWALL_RESULT.RESTORED:
+          posthogClient.capture('restore_purchases_succeeded', {
+            source,
+            method: 'paywall',
+          });
+          await this.refreshCustomerInfo();
+          return true;
         case RevenueCatUI.PAYWALL_RESULT.CANCELLED:
+          posthogClient.capture('purchase_cancelled', {
+            source,
+            method: 'paywall',
+          });
           console.log('User cancelled paywall');
           return false;
         case RevenueCatUI.PAYWALL_RESULT.ERROR:
+          posthogClient.capture('purchase_failed', {
+            source,
+            method: 'paywall',
+          });
           console.error('Error presenting paywall');
           return false;
         case RevenueCatUI.PAYWALL_RESULT.NOT_PRESENTED:
@@ -280,10 +324,15 @@ export class RevenueCatService {
             'Development mode: Configuration issue detected, enabling test mode'
           );
           this.testModeEnabled = true;
-          return this.presentPaywall(); // Retry with test mode
+          return this.presentPaywall(source); // Retry with test mode
         }
       }
 
+      posthogClient.capture('purchase_failed', {
+        source,
+        method: 'paywall',
+        error_code: error?.code ?? error?.message ?? 'unknown',
+      });
       throw error;
     }
   }

--- a/src/lib/services/user.test.ts
+++ b/src/lib/services/user.test.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import { apiClient } from '@/api/common/client';
+import { posthogClient } from '@/lib/posthog';
 import { setItem } from '@/lib/storage';
 
 import {
@@ -110,6 +111,25 @@ describe('User Service', () => {
       expect(result.type).toBe('druid');
       expect(result.level).toBe(3);
       expect(result.xp).toBe(150);
+    });
+  });
+
+  describe('createProvisionalUser', () => {
+    it('identifies the user in PostHog with the server user id', async () => {
+      mockUuidv4.mockReturnValue('test-uuid' as any);
+      mockApiClient.post.mockResolvedValue({
+        data: {
+          user: { id: 'user-123' },
+          tokens: {},
+        },
+      });
+
+      await createProvisionalUser({
+        type: 'alchemist',
+        name: 'Tester',
+      } as any);
+
+      expect(posthogClient.identify).toHaveBeenCalledWith('user-123');
     });
   });
 

--- a/src/lib/services/user.ts
+++ b/src/lib/services/user.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import { apiClient } from '@/api/common/client';
+import { posthogClient } from '@/lib/posthog';
 import { setItem } from '@/lib/storage';
 import type { Character } from '@/store/types';
 
@@ -371,6 +372,10 @@ export async function createProvisionalUser(
     // Store the user ID and tokens
     console.log('setting provisional user id', response.data.user.id);
     setItem('provisionalUserId', response.data.user.id);
+
+    // Identify as early as possible so all onboarding events attach to the
+    // server-side user id (same id given to OneSignal and RevenueCat).
+    posthogClient.identify(response.data.user.id);
 
     // Store the access token separately from regular auth tokens
     if (response.data.tokens?.access?.token) {


### PR DESCRIPTION
## Summary

Closes the client-side instrumentation gaps from the analytics audit (`docs/reports/analytics-funnels-and-telemetry.md`, untracked):

- **Shared module-level PostHog client** (`src/lib/posthog.ts`) passed to `PostHogProvider` via the `client` prop, so services/stores outside React capture through the same instance.
- **Identity stitching**: `posthog.identify(userId)` at every point the codebase already calls `OneSignal.login`/`revenueCatService.loginUser` (provisional creation, magic-link sign-in, auth-store signIn, hydration), plus `reset()` on signOut. distinct_id = server Mongo id, matching the server-side events in tommyshellberg/emberglow-server#57.
- **`signup_completed`** on successful magic-link verification — the onboarding funnel's missing final step.
- **App lifecycle events** enabled (`Application Installed/Opened`) for retention baselines; screen/touch autocapture stays off, PostHog stays disabled in `__DEV__`.
- **Purchase-flow events** (`paywall_viewed`, `purchase_initiated/_completed/_cancelled/_failed`, `restore_purchases_*`) in the `PremiumPaywall` component (the live path — it calls RevenueCatUI directly) and `RevenueCatService`, with per-placement `source` (`home`, `skill_tree`).

## Verification

- TDD: 11 new tests written red-first across 4 suites
- Full suite: 159 suites / 1701 tests green; `tsc` 0 errors; lint delta vs main = 0 new errors
- Pushed with `--no-verify` (owner-approved): the Maestro pre-push smoke fails on the currently-booted emulator's stale app state — known issue, unrelated; this diff is JS-only and not in the installed build

## Notes for verification on device

PostHog is disabled in `__DEV__` — verifying end-to-end needs a staging/production build with PostHog **Activity → Live** open. Suggested checks: `$identify` fires after character creation; `Application Opened` on cold start; `signup_completed` after magic-link verify; `paywall_viewed` with `source` when opening the paywall from home vs skill tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)