### PR TITLE
feat(spirit): Spirit meter, the Fading, and the Restoration flow (mobile)

### DIFF
--- a/env.js
+++ b/env.js
@@ -86,6 +86,9 @@ const client = z.object({
   POSTHOG_API_KEY: z.string(),
   REVENUECAT_APPLE_API_KEY: z.string(),
   REVENUECAT_GOOGLE_API_KEY: z.string(),
+  // Fail-safe: absent in an environment's build secrets ⇒ 'false' (fading disabled).
+  // Kept out of committed .env files (they hold secrets); set per-environment at build.
+  SPIRIT_FADING_ENABLED: z.string().optional().default('false'),
 });
 
 const buildTime = z.object({
@@ -111,6 +114,7 @@ const _clientEnv = {
   POSTHOG_API_KEY: process.env.POSTHOG_API_KEY,
   REVENUECAT_APPLE_API_KEY: process.env.REVENUECAT_APPLE_API_KEY,
   REVENUECAT_GOOGLE_API_KEY: process.env.REVENUECAT_GOOGLE_API_KEY,
+  SPIRIT_FADING_ENABLED: process.env.SPIRIT_FADING_ENABLED,
 };
 
 /**

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -112,6 +112,7 @@ jest.mock('expo-notifications', () => ({
   addNotificationResponseReceivedListener: jest.fn(),
   removeNotificationSubscription: jest.fn(),
   scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
   getExpoPushTokenAsync: jest.fn(),
   setNotificationChannelAsync: jest.fn(),
   cancelAllScheduledNotificationsAsync: jest.fn(),

--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -1,6 +1,7 @@
 import { signIn } from '@/lib/auth';
 import { getUserDetails } from '@/lib/services/user';
 import { getItem, removeItem } from '@/lib/storage';
+import { useCharacterStore } from '@/store/character-store';
 import { useUserStore } from '@/store/user-store';
 
 import {
@@ -289,6 +290,71 @@ describe('auth.ts', () => {
       });
       expect(result).toBe('app');
       // Character store logic is tested via integration tests due to dynamic import complexity
+    });
+
+    it('should sync spirit into the character store when server provides it', async () => {
+      // The character store is NOT mocked in this suite, so we assert on the real store.
+      useCharacterStore.setState({
+        serverSpirit: null,
+        serverSpiritAt: null,
+        spiritRestoredAt: null,
+        restorationCount: 0,
+      });
+
+      // Top-level type + name are required for the sync block to run.
+      const mockUser = {
+        id: 'user-123',
+        email: 'test@example.com',
+        type: 'knight',
+        name: 'Sir Test',
+        dailyQuestStreak: 3,
+        spirit: 40,
+        // spiritRestoredAt and restorationCount intentionally omitted
+      };
+
+      (getUserDetails as jest.Mock).mockResolvedValue(mockUser);
+      (useUserStore.getState as jest.Mock).mockReturnValue({
+        setUser: jest.fn(),
+      });
+
+      const before = Date.now();
+      await verifyMagicLinkAndSignIn('test-token');
+
+      const state = useCharacterStore.getState();
+      expect(state.serverSpirit).toBe(40);
+      expect(state.serverSpiritAt).toBeGreaterThanOrEqual(before);
+      // Fallbacks: absent spiritRestoredAt -> null, absent restorationCount -> 0
+      expect(state.spiritRestoredAt).toBeNull();
+      expect(state.restorationCount).toBe(0);
+    });
+
+    it('should not touch spirit state when server omits spirit', async () => {
+      useCharacterStore.setState({
+        serverSpirit: null,
+        serverSpiritAt: null,
+        spiritRestoredAt: null,
+        restorationCount: 0,
+      });
+
+      const mockUser = {
+        id: 'user-123',
+        email: 'test@example.com',
+        type: 'knight',
+        name: 'Sir Test',
+        dailyQuestStreak: 3,
+        // No spirit field
+      };
+
+      (getUserDetails as jest.Mock).mockResolvedValue(mockUser);
+      (useUserStore.getState as jest.Mock).mockReturnValue({
+        setUser: jest.fn(),
+      });
+
+      await verifyMagicLinkAndSignIn('test-token');
+
+      // Guard holds: undefined spirit leaves the anchor untouched (still null).
+      expect(useCharacterStore.getState().serverSpirit).toBeNull();
+      expect(useCharacterStore.getState().serverSpiritAt).toBeNull();
     });
 
     it('should continue even if user fetch fails', async () => {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -196,6 +196,15 @@ export const verifyMagicLinkAndSignIn = async (
             characterStore.setStreak(userResponse.dailyQuestStreak);
           }
 
+          // Sync server-reported spirit (guard so pre-deploy server responses don't clobber state)
+          if (userResponse.spirit !== undefined) {
+            characterStore.setSpiritState({
+              spirit: userResponse.spirit,
+              spiritRestoredAt: userResponse.spiritRestoredAt ?? null,
+              restorationCount: userResponse.restorationCount ?? 0,
+            });
+          }
+
           console.log('[Auth] Character data synchronized from server');
         } else {
           console.log('[Auth] No character data found in server response');

--- a/src/api/common/client.test.ts
+++ b/src/api/common/client.test.ts
@@ -1,0 +1,151 @@
+import { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
+
+import { refreshAccessToken } from '../auth';
+// Import after mocks are set up
+import { __resetRefreshAttempts, apiClient } from './client';
+
+// Mock dependencies
+jest.mock('@/lib/auth');
+jest.mock('@/lib/auth/utils');
+jest.mock('../auth');
+jest.mock('@/lib/storage');
+
+// Mock the token refresh error handler
+jest.mock('@/lib/hooks/use-token-refresh-error-handler', () => ({
+  handleTokenRefreshExhaustion: jest.fn(),
+}));
+
+// Mock queryClient singleton from api-provider (assigned inside factory,
+// mirroring the interceptor-capture pattern used for axios below)
+let mockInvalidateQueries: jest.Mock;
+jest.mock('@/api/common/api-provider', () => {
+  mockInvalidateQueries = jest.fn();
+  return { queryClient: { invalidateQueries: mockInvalidateQueries } };
+});
+
+// Mock expo-router imperative router
+let mockRouterReplace: jest.Mock;
+jest.mock('expo-router', () => {
+  mockRouterReplace = jest.fn();
+  return { router: { replace: mockRouterReplace } };
+});
+
+// Capture the response interceptor when the module loads
+let responseInterceptor: {
+  onFulfilled: (response: any) => any;
+  onRejected: (error: AxiosError) => Promise<any>;
+};
+
+// Mock axios
+jest.mock('axios', () => ({
+  create: jest.fn(() => {
+    const instance = {
+      interceptors: {
+        request: {
+          use: jest.fn(() => 1),
+        },
+        response: {
+          use: jest.fn((_onFulfilled, onRejected) => {
+            responseInterceptor = { onFulfilled: _onFulfilled, onRejected };
+            return 1;
+          }),
+        },
+      },
+      defaults: {
+        baseURL: 'https://api.test.com',
+        headers: { 'Content-Type': 'application/json' },
+      },
+    };
+
+    // Make instance callable for retry logic
+    return Object.assign(
+      jest
+        .fn()
+        .mockImplementation((config) =>
+          Promise.resolve({ data: 'retry success', config })
+        ),
+      instance
+    );
+  }),
+}));
+
+// Mock console methods
+const originalConsoleError = console.error;
+const originalConsoleLog = console.log;
+beforeAll(() => {
+  console.error = jest.fn();
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.error = originalConsoleError;
+  console.log = originalConsoleLog;
+});
+
+describe('apiClient spirit-faded backstop', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetRefreshAttempts();
+  });
+
+  it('invalidates user details and routes home on 403 SPIRIT_FADED', async () => {
+    const error = {
+      response: {
+        status: 403,
+        data: { errorCode: 'SPIRIT_FADED' },
+      },
+      config: { url: '/quests/start' } as any,
+    } as AxiosError;
+
+    await expect(responseInterceptor.onRejected(error)).rejects.toEqual(error);
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['user', 'details'],
+    });
+    expect(mockRouterReplace).toHaveBeenCalledWith('/(app)');
+  });
+
+  it('does not trigger spirit branch on 403 without SPIRIT_FADED errorCode', async () => {
+    const error = {
+      response: {
+        status: 403,
+        data: { errorCode: 'SOMETHING_ELSE' },
+      },
+      config: { url: '/quests/start' } as any,
+    } as AxiosError;
+
+    await expect(responseInterceptor.onRejected(error)).rejects.toEqual(error);
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger spirit branch on 401 (refresh path handles it)', async () => {
+    (refreshAccessToken as jest.Mock).mockResolvedValue({
+      access: { token: 'new-access-token' },
+      refresh: { token: 'new-refresh-token' },
+    });
+
+    const originalConfig = {
+      url: '/quests/start',
+      headers: { Authorization: 'Bearer old-token' },
+    } as any as InternalAxiosRequestConfig;
+
+    const error = {
+      response: { status: 401 },
+      config: originalConfig,
+    } as AxiosError;
+
+    await responseInterceptor.onRejected(error);
+
+    // Spirit backstop must NOT fire on 401
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+    // Refresh path should have run
+    expect(refreshAccessToken).toHaveBeenCalled();
+  });
+
+  it('still exports the configured axios instance', () => {
+    expect(apiClient).toBeDefined();
+    expect(apiClient.interceptors).toBeDefined();
+  });
+});

--- a/src/api/common/client.tsx
+++ b/src/api/common/client.tsx
@@ -1,5 +1,7 @@
 import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
+import { router } from 'expo-router';
 
+import { queryClient } from '@/api/common/api-provider';
 import { signOut } from '@/lib/auth';
 import { getToken } from '@/lib/auth/utils';
 import { getItem } from '@/lib/storage';
@@ -173,7 +175,9 @@ apiClient.interceptors.response.use(
           // Reset refresh attempts on success
           refreshAttempts = 0;
           if (__DEV__) {
-            console.log('[API Client] Token refresh successful, attempts reset');
+            console.log(
+              '[API Client] Token refresh successful, attempts reset'
+            );
           }
 
           return apiClient(originalRequest);
@@ -214,6 +218,20 @@ apiClient.interceptors.response.use(
       } finally {
         isRefreshing = false;
       }
+    }
+
+    // Spirit Fading backstop: a stale client that slipped past the local gate
+    // gets a 403 SPIRIT_FADED from the server. Refetch user details so the faded
+    // state is authoritative, then route home to show the FadingCard. `replace`
+    // (not `push`) so concurrent in-flight requests that both 403 don't stack
+    // duplicate home entries — home is the final state, not a stack step.
+    if (
+      error.response?.status === 403 &&
+      (error.response?.data as any)?.errorCode === 'SPIRIT_FADED'
+    ) {
+      queryClient.invalidateQueries({ queryKey: ['user', 'details'] });
+      router.replace('/(app)');
+      return Promise.reject(error);
     }
 
     return Promise.reject(error);

--- a/src/api/restoration/index.test.tsx
+++ b/src/api/restoration/index.test.tsx
@@ -1,0 +1,130 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+import { apiClient } from '@/api';
+import { provisionalApiClient } from '@/api/common/provisional-client';
+import { getItem } from '@/lib/storage';
+
+import {
+  createRestoration,
+  useCreateRestoration,
+  type RestorationBody,
+} from './index';
+
+// Mock the API clients
+jest.mock('@/api', () => ({
+  apiClient: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('@/api/common/provisional-client', () => ({
+  provisionalApiClient: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/storage', () => ({
+  getItem: jest.fn(),
+}));
+
+const mockApiClient = apiClient as jest.Mocked<typeof apiClient>;
+const mockProvisionalApiClient = provisionalApiClient as jest.Mocked<
+  typeof provisionalApiClient
+>;
+const mockGetItem = getItem as unknown as jest.Mock;
+
+const mockResponse = {
+  id: 'r1',
+  restorationNumber: 1,
+  spiritRestoredAt: '2026-07-03T00:00:00.000Z',
+  restorationCount: 1,
+  spirit: 100,
+};
+
+const body: RestorationBody = {
+  challenges: ['social'],
+  challengeText: 'phones at dinner',
+  journalText: 'felt good',
+  commitmentHour: 20,
+  commitmentMinute: 0,
+};
+
+describe('restoration API', () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0,
+        },
+      },
+    });
+
+    return ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetItem.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    queryClient?.clear();
+  });
+
+  describe('createRestoration', () => {
+    it('calls apiClient.post with /restorations/ and returns the data payload', async () => {
+      mockApiClient.post.mockResolvedValue({ data: mockResponse });
+
+      const result = await createRestoration(body);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith('/restorations/', body);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('uses provisionalApiClient when a provisional token is present', async () => {
+      mockGetItem.mockReturnValue('prov-token-abc');
+      mockProvisionalApiClient.post.mockResolvedValue({ data: mockResponse });
+
+      const result = await createRestoration(body);
+
+      expect(mockProvisionalApiClient.post).toHaveBeenCalledWith(
+        '/restorations/',
+        body
+      );
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('useCreateRestoration', () => {
+    it('invalidates the user details query on success', async () => {
+      mockApiClient.post.mockResolvedValue({ data: mockResponse });
+
+      const invalidateSpy = jest.spyOn(
+        QueryClient.prototype,
+        'invalidateQueries'
+      );
+
+      const { result } = renderHook(() => useCreateRestoration(), {
+        wrapper: createWrapper(),
+      });
+
+      result.current.mutate(body);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['user', 'details'],
+      });
+
+      invalidateSpy.mockRestore();
+    });
+  });
+});

--- a/src/api/restoration/index.ts
+++ b/src/api/restoration/index.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { apiClient } from '@/api';
+import { provisionalApiClient } from '@/api/common/provisional-client';
+import { getItem } from '@/lib/storage';
+
+export type RestorationBody = {
+  challenges: string[];
+  challengeText?: string;
+  journalText?: string;
+  commitmentHour: number;
+  commitmentMinute: number;
+};
+export type RestorationResponse = {
+  id: string;
+  restorationNumber: number;
+  spiritRestoredAt: string;
+  restorationCount: number;
+  spirit: number;
+};
+
+export async function createRestoration(
+  body: RestorationBody
+): Promise<RestorationResponse> {
+  const client = getItem('provisionalAccessToken')
+    ? provisionalApiClient
+    : apiClient;
+  const res = await client.post<RestorationResponse>('/restorations/', body);
+  return res.data;
+}
+
+export function useCreateRestoration() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createRestoration,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user', 'details'] as const });
+    },
+  });
+}

--- a/src/app/(app)/index.test.tsx
+++ b/src/app/(app)/index.test.tsx
@@ -248,6 +248,22 @@ describe('Home Component - Integration Tests', () => {
 
       unmount();
     });
+
+    it('shows the FadingCard and hides start buttons when the spirit has faded', () => {
+      mockUseSpirit.mockReturnValue({
+        spirit: 0,
+        faded: true,
+        active: true,
+        restorationCount: 0,
+      });
+
+      const { unmount } = render(<Home />);
+
+      expect(screen.getByText(/Begin the Restoration/i)).toBeTruthy();
+      expect(screen.queryByText(/Create Custom Quest/i)).toBeNull();
+
+      unmount();
+    });
   });
 
   describe('Integration with server quests', () => {

--- a/src/app/(app)/index.test.tsx
+++ b/src/app/(app)/index.test.tsx
@@ -145,6 +145,18 @@ jest.mock('@/lib/services/user', () => ({
   refreshPremiumStatus: jest.fn().mockResolvedValue({}),
 }));
 
+// Mock useSpirit - inactive by default so existing tests are unaffected;
+// individual tests opt into an active spirit to exercise SpiritMeter.
+const mockUseSpirit = jest.fn((): any => ({
+  spirit: null,
+  faded: false,
+  active: false,
+  restorationCount: 0,
+}));
+jest.mock('@/hooks/use-spirit', () => ({
+  useSpirit: () => mockUseSpirit(),
+}));
+
 // Import the Home component
 const Home = require('./index').default;
 
@@ -163,6 +175,13 @@ describe('Home Component - Integration Tests', () => {
     mockUseServerQuests.isLoading = false;
     mockUseServerQuests.serverQuests = [];
     mockUseServerQuests.options = [];
+
+    mockUseSpirit.mockReturnValue({
+      spirit: null,
+      faded: false,
+      active: false,
+      restorationCount: 0,
+    });
   });
 
   afterEach(() => {
@@ -211,6 +230,21 @@ describe('Home Component - Integration Tests', () => {
       expect(screen.queryByText('Create Custom Quest')).toBeNull();
       expect(screen.queryByText('Cooperative Quests')).toBeNull();
       expect(screen.queryByText('Unlock Cooperative Mode')).toBeNull();
+
+      unmount();
+    });
+
+    it('shows the spirit meter when spirit fading is active', () => {
+      mockUseSpirit.mockReturnValue({
+        spirit: 100,
+        faded: false,
+        active: true,
+        restorationCount: 0,
+      });
+
+      const { unmount } = render(<Home />);
+
+      expect(screen.getByTestId('spirit-meter')).toBeTruthy();
 
       unmount();
     });

--- a/src/app/(app)/index.tsx
+++ b/src/app/(app)/index.tsx
@@ -15,6 +15,7 @@ import Animated, {
 
 import { useResetStoryline } from '@/api/quest';
 import { AVAILABLE_QUESTS } from '@/app/data/quests';
+import { FadingCard } from '@/components/home/fading-card';
 import QuestCard from '@/components/home/quest-card';
 import { BranchingStoryAnnouncementModal } from '@/components/modals/branching-story-announcement-modal';
 import { GuildsAnnouncementModal } from '@/components/modals/guilds-announcement-modal';
@@ -48,6 +49,7 @@ import { useQuestSelection } from '@/features/home/hooks/use-quest-selection';
 import { useStoryOptions } from '@/features/home/hooks/use-story-options';
 import { useAudioPreloader } from '@/hooks/use-audio-preloader';
 import { useServerQuests } from '@/hooks/use-server-quests';
+import { useSpirit } from '@/hooks/use-spirit';
 import { usePremiumAccess } from '@/lib/hooks/use-premium-access';
 import QuestTimer from '@/lib/services/quest-timer';
 import { refreshPremiumStatus as refreshServerPremium } from '@/lib/services/user';
@@ -68,6 +70,10 @@ export default function Home() {
   // Premium access state
   const [showPaywallModal, setShowPaywallModal] = useState(false);
   const { handlePaywallSuccess } = usePremiumAccess();
+
+  // Spirit: when faded (server-anchored), the home swaps the quest carousel for
+  // the FadingCard and hides all start-quest entry points until a Restoration.
+  const { faded } = useSpirit();
 
   // Carousel state with paywall reset
   const {
@@ -437,34 +443,38 @@ export default function Home() {
 
         {/* Main content area */}
         <View className="flex-1 justify-center">
-          <Animated.View
-            style={[animatedScrollStyle, { height: CARD_HEIGHT + 20 }]}
-          >
-            <FlashList
-              data={carouselData}
-              horizontal
-              snapToInterval={SNAP_INTERVAL}
-              decelerationRate="fast"
-              showsHorizontalScrollIndicator={false}
-              keyExtractor={(item) => item.id}
-              initialScrollIndex={0} // Start at the first item
-              contentContainerStyle={{
-                paddingHorizontal: CAROUSEL_CONTENT_PADDING,
-                paddingVertical: CAROUSEL_VERTICAL_PADDING,
-              }}
-              ItemSeparatorComponent={() => (
-                <View style={{ width: CARD_SPACING }} />
-              )}
-              onMomentumScrollEnd={handleMomentumScrollEnd}
-              renderItem={renderCarouselItem}
-              estimatedItemSize={CARD_WIDTH}
-              removeClippedSubviews={true} // improves performance by clipping offscreen items
-            />
-          </Animated.View>
+          {faded ? (
+            <FadingCard />
+          ) : (
+            <Animated.View
+              style={[animatedScrollStyle, { height: CARD_HEIGHT + 20 }]}
+            >
+              <FlashList
+                data={carouselData}
+                horizontal
+                snapToInterval={SNAP_INTERVAL}
+                decelerationRate="fast"
+                showsHorizontalScrollIndicator={false}
+                keyExtractor={(item) => item.id}
+                initialScrollIndex={0} // Start at the first item
+                contentContainerStyle={{
+                  paddingHorizontal: CAROUSEL_CONTENT_PADDING,
+                  paddingVertical: CAROUSEL_VERTICAL_PADDING,
+                }}
+                ItemSeparatorComponent={() => (
+                  <View style={{ width: CARD_SPACING }} />
+                )}
+                onMomentumScrollEnd={handleMomentumScrollEnd}
+                renderItem={renderCarouselItem}
+                estimatedItemSize={CARD_WIDTH}
+                removeClippedSubviews={true} // improves performance by clipping offscreen items
+              />
+            </Animated.View>
+          )}
         </View>
 
         {/* Footer area with buttons */}
-        {!activeQuest && !pendingQuest && (
+        {!faded && !activeQuest && !pendingQuest && (
           <View
             className="items-center justify-center"
             style={{ minHeight: 140 }}

--- a/src/app/(app)/index.tsx
+++ b/src/app/(app)/index.tsx
@@ -20,6 +20,7 @@ import { BranchingStoryAnnouncementModal } from '@/components/modals/branching-s
 import { GuildsAnnouncementModal } from '@/components/modals/guilds-announcement-modal';
 import { SkillTreeAnnouncementModal } from '@/components/modals/skill-tree-announcement-modal';
 import { PremiumPaywall } from '@/components/paywall';
+import { SpiritMeter } from '@/components/spirit-meter';
 import { StreakCounter } from '@/components/StreakCounter';
 import {
   BackgroundImage,
@@ -411,6 +412,9 @@ export default function Home() {
         source={require('@/../assets/images/background/pending-quest-bg-alt.jpg')}
       >
         <StreakCounter size="small" position="topRight" />
+        <View className="absolute right-4 top-16 z-10">
+          <SpiritMeter />
+        </View>
         <Animated.View
           style={[
             backgroundStyle,

--- a/src/app/_layout.test.tsx
+++ b/src/app/_layout.test.tsx
@@ -376,9 +376,10 @@ describe('RootLayout', () => {
 
     // Safety check: if somehow this is >= 24 hours ago, use exactly 20 hours ago
     const hoursSince = (Date.now() - yesterday.getTime()) / (1000 * 60 * 60);
-    const lastCompletedTimestamp = hoursSince >= 24
-      ? Date.now() - (20 * 60 * 60 * 1000) // 20 hours ago
-      : yesterday.getTime();
+    const lastCompletedTimestamp =
+      hoursSince >= 24
+        ? Date.now() - 20 * 60 * 60 * 1000 // 20 hours ago
+        : yesterday.getTime();
 
     useQuestStore.getState.mockReturnValue({
       lastCompletedQuestTimestamp: lastCompletedTimestamp,
@@ -547,6 +548,152 @@ describe('RootLayout', () => {
 
     await waitFor(() => {
       expect(mockFailQuest).toHaveBeenCalled();
+    });
+  });
+
+  it('should navigate to home when spirit_faded notification is clicked', async () => {
+    jest.useFakeTimers();
+
+    const { OneSignal } = require('react-native-onesignal');
+
+    render(<RootLayout />);
+
+    await waitFor(() => {
+      expect(OneSignal.Notifications.addEventListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      );
+    });
+
+    const clickHandler: (event: any) => void = (
+      (OneSignal.Notifications.addEventListener as jest.Mock).mock.calls.find(
+        (call) => call[0] === 'click'
+      ) as any
+    )[1];
+
+    clickHandler({
+      notification: {
+        additionalData: {
+          type: 'spirit_faded',
+        },
+      },
+    });
+
+    jest.advanceTimersByTime(1000);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/(app)');
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('should navigate to home when spirit_warning notification is clicked', async () => {
+    jest.useFakeTimers();
+
+    const { OneSignal } = require('react-native-onesignal');
+
+    render(<RootLayout />);
+
+    await waitFor(() => {
+      expect(OneSignal.Notifications.addEventListener).toHaveBeenCalledWith(
+        'click',
+        expect.any(Function)
+      );
+    });
+
+    const clickHandler: (event: any) => void = (
+      (OneSignal.Notifications.addEventListener as jest.Mock).mock.calls.find(
+        (call) => call[0] === 'click'
+      ) as any
+    )[1];
+
+    clickHandler({
+      notification: {
+        additionalData: {
+          type: 'spirit_warning',
+        },
+      },
+    });
+
+    jest.advanceTimersByTime(1000);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/(app)');
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('should still display notification when spirit_faded arrives in foreground', async () => {
+    const { OneSignal } = require('react-native-onesignal');
+
+    render(<RootLayout />);
+
+    await waitFor(() => {
+      expect(OneSignal.Notifications.addEventListener).toHaveBeenCalledWith(
+        'foregroundWillDisplay',
+        expect.any(Function)
+      );
+    });
+
+    const foregroundHandler: (event: any) => void = (
+      (OneSignal.Notifications.addEventListener as jest.Mock).mock.calls.find(
+        (call) => call[0] === 'foregroundWillDisplay'
+      ) as any
+    )[1];
+
+    const mockEvent = {
+      notification: {
+        additionalData: {
+          type: 'spirit_faded',
+        },
+        display: jest.fn(),
+      },
+      preventDefault: jest.fn(),
+    };
+
+    foregroundHandler(mockEvent);
+
+    await waitFor(() => {
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(mockEvent.notification.display).toHaveBeenCalled();
+    });
+  });
+
+  it('should still display notification when spirit_warning arrives in foreground', async () => {
+    const { OneSignal } = require('react-native-onesignal');
+
+    render(<RootLayout />);
+
+    await waitFor(() => {
+      expect(OneSignal.Notifications.addEventListener).toHaveBeenCalledWith(
+        'foregroundWillDisplay',
+        expect.any(Function)
+      );
+    });
+
+    const foregroundHandler: (event: any) => void = (
+      (OneSignal.Notifications.addEventListener as jest.Mock).mock.calls.find(
+        (call) => call[0] === 'foregroundWillDisplay'
+      ) as any
+    )[1];
+
+    const mockEvent = {
+      notification: {
+        additionalData: {
+          type: 'spirit_warning',
+        },
+        display: jest.fn(),
+      },
+      preventDefault: jest.fn(),
+    };
+
+    foregroundHandler(mockEvent);
+
+    await waitFor(() => {
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(mockEvent.notification.display).toHaveBeenCalled();
     });
   });
 

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -223,6 +223,17 @@ function RootLayout() {
         ) {
           // Handle quest failure notification
           handleQuestFailure(additionalData.questRunId);
+        } else if (
+          additionalData?.type === 'spirit_warning' ||
+          additionalData?.type === 'spirit_faded'
+        ) {
+          // Deep-link to home so the Spirit meter (warning) or
+          // FadingCard (faded) can surface the message. The 1000ms
+          // delay mirrors the cooperative quest handler above, giving
+          // the app time to be ready/authenticated before navigating.
+          setTimeout(() => {
+            router.push('/(app)');
+          }, 1000);
         }
       });
 

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -431,6 +431,13 @@ function RootLayout() {
           }}
         />
         <Stack.Screen
+          name="restoration"
+          options={{
+            headerShown: false,
+            animation: 'fade',
+          }}
+        />
+        <Stack.Screen
           name="cooperative-quest-menu"
           options={{ headerShown: false }}
         />

--- a/src/app/cooperative-quest-ready.tsx
+++ b/src/app/cooperative-quest-ready.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui';
 import colors from '@/components/ui/colors';
 import { InfoCard } from '@/components/ui/info-card';
+import { isFadedNow } from '@/hooks/use-spirit';
 import QuestTimer from '@/lib/services/quest-timer';
 import type { LobbyReadyStatusPayload } from '@/lib/services/websocket-events.types';
 import { useCooperativeLobbyStore } from '@/store/cooperative-lobby-store';
@@ -273,6 +274,14 @@ export default function CooperativeQuestReady() {
         createdAt: questRun.createdAt || Date.now(),
         updatedAt: questRun.updatedAt || Date.now(),
       };
+
+      // Spirit-fading gate: a faded user cannot start a new quest. Checked
+      // before the store write so we don't leave a populated cooperative quest
+      // run with no pending quest for a user being sent home to the FadingCard.
+      if (isFadedNow()) {
+        router.push('/(app)'); // home shows the FadingCard
+        return;
+      }
 
       if (__DEV__) {
         console.log(

--- a/src/app/restoration.test.tsx
+++ b/src/app/restoration.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { render } from '@/lib/test-utils';
+
+import RestorationScreen from './restoration';
+
+describe('RestorationScreen', () => {
+  it('renders the Restoration title', () => {
+    const { getByText } = render(<RestorationScreen />);
+
+    expect(getByText('Restoration')).toBeTruthy();
+  });
+});

--- a/src/app/restoration.test.tsx
+++ b/src/app/restoration.test.tsx
@@ -31,6 +31,50 @@ jest.mock('react-native-reanimated', () =>
   require('react-native-reanimated/mock')
 );
 
+// Stores + notification service — mocked so we can assert side-effects cleanly
+// without touching real persisted state or expo-notifications.
+// Lazy getters on a globalThis-attached object let the jest.mock factory
+// resolve the right jest.fn() even though the factory runs before the const
+// initializers would otherwise complete.
+const mockSetStreakWarning = jest.fn();
+const mockSetSpiritState = jest.fn();
+const mockScheduleSpiritCommitmentReminders = jest.fn();
+
+const mockSettingsState = {
+  setStreakWarning: mockSetStreakWarning,
+};
+const mockCharacterState = {
+  setSpiritState: mockSetSpiritState,
+  serverSpirit: null,
+  serverSpiritAt: null,
+  restorationCount: 0,
+};
+
+(globalThis as any).__mocks = (globalThis as any).__mocks || {};
+(globalThis as any).__mocks.settings = mockSettingsState;
+(globalThis as any).__mocks.character = mockCharacterState;
+(globalThis as any).__mocks.scheduleSpiritCommitmentReminders =
+  mockScheduleSpiritCommitmentReminders;
+
+jest.mock('@/store/settings-store', () => ({
+  __esModule: true,
+  useSettingsStore: Object.assign(jest.fn(), {
+    getState: () => (globalThis as any).__mocks.settings,
+  }),
+}));
+
+jest.mock('@/store/character-store', () => ({
+  __esModule: true,
+  useCharacterStore: Object.assign(jest.fn(), {
+    getState: () => (globalThis as any).__mocks.character,
+  }),
+}));
+
+jest.mock('@/lib/services/notifications', () => ({
+  scheduleSpiritCommitmentReminders: (...args: any[]) =>
+    (globalThis as any).__mocks.scheduleSpiritCommitmentReminders(...args),
+}));
+
 describe('RestorationScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -167,5 +211,69 @@ describe('RestorationScreen', () => {
 
     // At restorationCount 2+ the journal prompt is the "deeper" variant.
     expect(screen.getByText(/deeper/i)).toBeTruthy();
+  });
+
+  describe('submit side-effects', () => {
+    const successResponse = {
+      id: 'r1',
+      restorationNumber: 1,
+      spiritRestoredAt: '2026-07-03T00:00:00.000Z',
+      restorationCount: 1,
+      spirit: 100,
+    };
+
+    const walkToFinal = () => {
+      fireEvent.press(screen.getByText(/too busy/i));
+      fireEvent.press(screen.getByText(/next/i));
+      fireEvent.changeText(screen.getByTestId('journal-input'), 'read more');
+      fireEvent.press(screen.getByText(/next/i));
+      fireEvent.press(screen.getByText(/next/i));
+      fireEvent.press(screen.getByText(/return to vaedros/i));
+    };
+
+    it('schedules commitment reminders, sets streak warning, and refills spirit on success', async () => {
+      mockMutateAsync.mockResolvedValue(successResponse);
+      mockScheduleSpiritCommitmentReminders.mockResolvedValue(true);
+
+      render(<RestorationScreen />);
+
+      walkToFinal();
+
+      await waitFor(() => expect(mockMutateAsync).toHaveBeenCalled());
+
+      // 1. Local streak warning picks up the committed time
+      expect(mockSetStreakWarning).toHaveBeenCalledWith({
+        enabled: true,
+        time: { hour: 20, minute: 0 },
+      });
+
+      // 2. 3-day spirit commitment reminder bridge gets scheduled
+      expect(mockScheduleSpiritCommitmentReminders).toHaveBeenCalledWith(20, 0);
+
+      // 3. Spirit meter refills from server response
+      expect(mockSetSpiritState).toHaveBeenCalledWith({
+        spirit: 100,
+        spiritRestoredAt: '2026-07-03T00:00:00.000Z',
+        restorationCount: 1,
+      });
+    });
+
+    it('does not run any side-effects when the mutation rejects', async () => {
+      mockMutateAsync.mockRejectedValue(new Error('network down'));
+
+      render(<RestorationScreen />);
+
+      walkToFinal();
+
+      // Wait for mutateAsync to actually be invoked
+      await waitFor(() => expect(mockMutateAsync).toHaveBeenCalled());
+
+      // Give microtasks a chance to settle; then assert NO side-effects fired.
+      await new Promise((r) => setImmediate(r));
+
+      expect(mockSetStreakWarning).not.toHaveBeenCalled();
+      expect(mockScheduleSpiritCommitmentReminders).not.toHaveBeenCalled();
+      expect(mockSetSpiritState).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/restoration.test.tsx
+++ b/src/app/restoration.test.tsx
@@ -1,13 +1,171 @@
+import { fireEvent, render, screen, waitFor } from '@/lib/test-utils';
 import React from 'react';
-
-import { render } from '@/lib/test-utils';
 
 import RestorationScreen from './restoration';
 
-describe('RestorationScreen', () => {
-  it('renders the Restoration title', () => {
-    const { getByText } = render(<RestorationScreen />);
+const mockMutateAsync = jest.fn();
+const mockRouterReplace = jest.fn();
 
-    expect(getByText('Restoration')).toBeTruthy();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    replace: mockRouterReplace,
+    push: jest.fn(),
+    back: jest.fn(),
+  }),
+}));
+
+jest.mock('@/api/restoration', () => ({
+  useCreateRestoration: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+    reset: jest.fn(),
+  }),
+}));
+
+const mockUseSpirit = jest.fn();
+jest.mock('@/hooks/use-spirit', () => ({
+  useSpirit: () => mockUseSpirit(),
+}));
+
+jest.mock('react-native-reanimated', () =>
+  require('react-native-reanimated/mock')
+);
+
+describe('RestorationScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSpirit.mockReturnValue({
+      spirit: 0,
+      faded: true,
+      active: true,
+      restorationCount: 0,
+    });
+  });
+
+  it('walks the 4 steps and submits with the committed time', async () => {
+    mockMutateAsync.mockResolvedValue({
+      id: 'r1',
+      restorationNumber: 1,
+      spiritRestoredAt: '2026-07-03T00:00:00.000Z',
+      restorationCount: 1,
+      spirit: 100,
+    });
+
+    render(<RestorationScreen />);
+
+    // Step 1: pick the "Too busy" challenge
+    fireEvent.press(screen.getByText(/too busy/i));
+    fireEvent.press(screen.getByText(/next/i));
+
+    // Step 2: journal
+    fireEvent.changeText(screen.getByTestId('journal-input'), 'read more');
+    fireEvent.press(screen.getByText(/next/i));
+
+    // Step 3: commitment — drive the hour stepper twice (20 → 22) to exercise
+    // the wrap math and prove the picker value reaches the submission.
+    fireEvent.press(screen.getByTestId('commitment-hour-increment'));
+    fireEvent.press(screen.getByTestId('commitment-hour-increment'));
+    fireEvent.press(screen.getByText(/next/i));
+
+    // Step 4: submit
+    fireEvent.press(screen.getByText(/return to vaedros/i));
+
+    await waitFor(() =>
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          challenges: ['too_busy'],
+          journalText: 'read more',
+          commitmentHour: 22,
+          commitmentMinute: 0,
+        })
+      )
+    );
+  });
+
+  it('records both "too busy" variants independently when both are picked', async () => {
+    mockUseSpirit.mockReturnValue({
+      spirit: 0,
+      faded: true,
+      active: true,
+      restorationCount: 1, // unlocks the DEEPER_CHALLENGES variant
+    });
+    mockMutateAsync.mockResolvedValue({
+      id: 'r2',
+      restorationNumber: 2,
+      spiritRestoredAt: '2026-07-03T00:00:00.000Z',
+      restorationCount: 2,
+      spirit: 100,
+    });
+
+    render(<RestorationScreen />);
+
+    // Both chips are distinct ids; picking both records both.
+    fireEvent.press(screen.getByText(/^too busy$/i));
+    fireEvent.press(screen.getByText(/work kept pulling me back/i));
+    fireEvent.press(screen.getByText(/next/i));
+    fireEvent.press(screen.getByText(/next/i));
+    fireEvent.press(screen.getByText(/next/i));
+    fireEvent.press(screen.getByText(/return to vaedros/i));
+
+    await waitFor(() =>
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          challenges: ['too_busy', 'too_busy_work'],
+        })
+      )
+    );
+  });
+
+  it('surfaces an error message in the UI when the submission rejects', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('network down'));
+
+    render(<RestorationScreen />);
+
+    fireEvent.press(screen.getByText(/too busy/i));
+    fireEvent.press(screen.getByText(/next/i));
+    fireEvent.press(screen.getByText(/next/i));
+    fireEvent.press(screen.getByText(/next/i));
+    fireEvent.press(screen.getByText(/return to vaedros/i));
+
+    // The error surfaces in the UI (not just console.error) so the user
+    // knows the submit didn't go through.
+    await waitFor(() => {
+      expect(screen.getByTestId('submit-error')).toBeTruthy();
+    });
+    expect(screen.getByText(/try again/i)).toBeTruthy();
+  });
+
+  it('does not show a Next button on the final (visualization) step', () => {
+    render(<RestorationScreen />);
+
+    // Step 1: advance to journal
+    fireEvent.press(screen.getByText(/too busy/i));
+    fireEvent.press(screen.getByText(/next/i));
+    // Step 2: advance to commitment
+    fireEvent.press(screen.getByText(/next/i));
+    // Step 3: advance to visualization
+    fireEvent.press(screen.getByText(/next/i));
+
+    // Now on the final step: no Next button, only the submit CTA.
+    expect(screen.queryByText(/^next$/i)).toBeNull();
+    expect(screen.getByText(/return to vaedros/i)).toBeTruthy();
+  });
+
+  it('uses a deeper journal prompt at restorationCount 2+', () => {
+    mockUseSpirit.mockReturnValue({
+      spirit: 0,
+      faded: true,
+      active: true,
+      restorationCount: 2,
+    });
+
+    render(<RestorationScreen />);
+
+    // Advance through the first two steps to reach the journal step
+    fireEvent.press(screen.getByText(/too busy/i));
+    fireEvent.press(screen.getByText(/next/i));
+
+    // At restorationCount 2+ the journal prompt is the "deeper" variant.
+    expect(screen.getByText(/deeper/i)).toBeTruthy();
   });
 });

--- a/src/app/restoration.tsx
+++ b/src/app/restoration.tsx
@@ -1,11 +1,331 @@
-import React from 'react';
+import { useRouter } from 'expo-router';
+import React, { useState } from 'react';
+import { KeyboardAvoidingView, Platform, TextInput } from 'react-native';
 
-import { ScreenContainer, Text } from '@/components/ui';
+import { useCreateRestoration } from '@/api/restoration';
+import {
+  FocusAwareStatusBar,
+  ScreenContainer,
+  ScrollView,
+  Text,
+  Title,
+  TouchableOpacity,
+  View,
+} from '@/components/ui';
+import { Button } from '@/components/ui/button';
+import colors from '@/components/ui/colors';
+import { useSpirit } from '@/hooks/use-spirit';
+
+type ChallengeId =
+  | 'too_busy'
+  | 'too_busy_work'
+  | 'forgot'
+  | 'too_tired'
+  | 'overwhelmed';
+
+const CHALLENGES: { id: ChallengeId; label: string }[] = [
+  { id: 'too_busy', label: 'Too busy' },
+  { id: 'forgot', label: 'Forgot' },
+  { id: 'too_tired', label: 'Too tired' },
+  { id: 'overwhelmed', label: 'Felt overwhelmed' },
+];
+
+const DEEPER_CHALLENGES: { id: ChallengeId; label: string }[] = [
+  ...CHALLENGES,
+  { id: 'too_busy_work', label: 'Work kept pulling me back' },
+];
+
+const DEFAULT_COMMITMENT_HOUR = 20;
+const DEFAULT_COMMITMENT_MINUTE = 0;
+
+const wrapHour = (h: number) => ((h % 24) + 24) % 24;
+const wrapMinute = (m: number) => ((m % 60) + 60) % 60;
 
 export default function RestorationScreen() {
+  const router = useRouter();
+  const { restorationCount } = useSpirit();
+  const isDeep = restorationCount >= 2;
+  const isSecond = restorationCount >= 1;
+
+  const createRestoration = useCreateRestoration();
+
+  const [stepIndex, setStepIndex] = useState(0);
+  const [selectedChallenges, setSelectedChallenges] = useState<ChallengeId[]>(
+    []
+  );
+  const [challengeText, setChallengeText] = useState('');
+  const [journalText, setJournalText] = useState('');
+  const [commitmentHour, setCommitmentHour] = useState(DEFAULT_COMMITMENT_HOUR);
+  const [commitmentMinute, setCommitmentMinute] = useState(
+    DEFAULT_COMMITMENT_MINUTE
+  );
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const toggleChallenge = (id: ChallengeId) => {
+    setSelectedChallenges((prev) =>
+      prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id]
+    );
+  };
+
+  const handleSubmit = async () => {
+    setSubmitError(null);
+    try {
+      await createRestoration.mutateAsync({
+        challenges: selectedChallenges,
+        challengeText: challengeText.trim() || undefined,
+        journalText: journalText.trim() || undefined,
+        commitmentHour,
+        commitmentMinute,
+      });
+      router.replace('/(app)');
+    } catch (err) {
+      console.error('Failed to submit restoration', err);
+      setSubmitError(
+        "Couldn't reach Vaedros. Tap Return to Vaedros to try again."
+      );
+    }
+  };
+
   return (
-    <ScreenContainer>
-      <Text>Restoration</Text>
-    </ScreenContainer>
+    <View className="flex-1 bg-background">
+      <FocusAwareStatusBar />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        className="flex-1"
+      >
+        <ScreenContainer fullScreen className="flex-1">
+          <ScrollView
+            className="flex-1"
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View className="px-4 py-6">
+              {stepIndex === 0 && (
+                <View>
+                  <Title variant="centered" className="mb-2">
+                    Restoration
+                  </Title>
+                  <Text className="mb-6 text-base text-neutral-200">
+                    {isSecond
+                      ? "We've all been here before. What made this stretch hard?"
+                      : "No judgment. What's been making it hard to start a quest?"}
+                  </Text>
+                  <Text className="mb-3 text-lg font-semibold text-white">
+                    Pick anything that fits
+                  </Text>
+                  <View className="mb-6 flex-row flex-wrap">
+                    {(isSecond ? DEEPER_CHALLENGES : CHALLENGES).map((c) => (
+                      <TouchableOpacity
+                        key={c.id}
+                        onPress={() => toggleChallenge(c.id)}
+                        className={`mb-2 mr-2 rounded-full px-4 py-2 ${
+                          selectedChallenges.includes(c.id)
+                            ? 'bg-primary-300'
+                            : 'bg-neutral-400'
+                        }`}
+                      >
+                        <Text
+                          className={`text-sm ${
+                            selectedChallenges.includes(c.id)
+                              ? 'font-semibold text-white'
+                              : 'text-neutral-200'
+                          }`}
+                        >
+                          {c.label}
+                        </Text>
+                      </TouchableOpacity>
+                    ))}
+                  </View>
+                  <Text className="mb-2 text-lg font-semibold text-white">
+                    Something else? (optional)
+                  </Text>
+                  <TextInput
+                    testID="challenge-text-input"
+                    value={challengeText}
+                    onChangeText={setChallengeText}
+                    placeholder="Tell us in your own words"
+                    placeholderTextColor={colors.neutral[300]}
+                    style={{
+                      minHeight: 60,
+                      textAlignVertical: 'top',
+                      color: colors.white,
+                      padding: 12,
+                      borderRadius: 12,
+                      borderWidth: 1,
+                      borderColor: colors.neutral[300],
+                    }}
+                  />
+                </View>
+              )}
+
+              {stepIndex === 1 && (
+                <View>
+                  <Title variant="centered" className="mb-2">
+                    A moment of reflection
+                  </Title>
+                  <Text className="mb-3 text-base text-neutral-200">
+                    {isDeep
+                      ? 'Take a deeper look: what drained you most, and what pulled you back toward the screen?'
+                      : 'A short journal note for yourself. What drained you most?'}
+                  </Text>
+                  <TextInput
+                    testID="journal-input"
+                    multiline
+                    numberOfLines={5}
+                    value={journalText}
+                    onChangeText={setJournalText}
+                    placeholder="Write whatever comes to mind"
+                    placeholderTextColor={colors.neutral[300]}
+                    style={{
+                      minHeight: 140,
+                      textAlignVertical: 'top',
+                      color: colors.white,
+                      padding: 12,
+                      borderRadius: 12,
+                      borderWidth: 1,
+                      borderColor: colors.neutral[300],
+                    }}
+                  />
+                </View>
+              )}
+
+              {stepIndex === 2 && (
+                <View>
+                  <Title variant="centered" className="mb-2">
+                    Pick a return time
+                  </Title>
+                  <Text className="mb-6 text-base text-neutral-200">
+                    When tomorrow, at a time you can stick to, will you step
+                    back in?
+                  </Text>
+                  <View className="mb-6 flex-row items-center justify-center">
+                    <View className="items-center">
+                      <Text className="mb-2 text-sm text-neutral-200">
+                        Hour
+                      </Text>
+                      <View
+                        className="flex-row items-center rounded-xl bg-neutral-400 px-4 py-2"
+                        testID="commitment-hour"
+                      >
+                        <TouchableOpacity
+                          testID="commitment-hour-decrement"
+                          onPress={() =>
+                            setCommitmentHour((h) => wrapHour(h - 1))
+                          }
+                          className="px-3"
+                        >
+                          <Text className="text-2xl text-white">-</Text>
+                        </TouchableOpacity>
+                        <Text
+                          testID="commitment-hour-value"
+                          className="mx-3 text-2xl font-semibold text-white"
+                        >
+                          {String(commitmentHour).padStart(2, '0')}
+                        </Text>
+                        <TouchableOpacity
+                          testID="commitment-hour-increment"
+                          onPress={() =>
+                            setCommitmentHour((h) => wrapHour(h + 1))
+                          }
+                          className="px-3"
+                        >
+                          <Text className="text-2xl text-white">+</Text>
+                        </TouchableOpacity>
+                      </View>
+                    </View>
+                    <Text className="mx-4 text-3xl text-white">:</Text>
+                    <View className="items-center">
+                      <Text className="mb-2 text-sm text-neutral-200">
+                        Minute
+                      </Text>
+                      <View
+                        className="flex-row items-center rounded-xl bg-neutral-400 px-4 py-2"
+                        testID="commitment-minute"
+                      >
+                        <TouchableOpacity
+                          testID="commitment-minute-decrement"
+                          onPress={() =>
+                            setCommitmentMinute((m) => wrapMinute(m - 5))
+                          }
+                          className="px-3"
+                        >
+                          <Text className="text-2xl text-white">-</Text>
+                        </TouchableOpacity>
+                        <Text
+                          testID="commitment-minute-value"
+                          className="mx-3 text-2xl font-semibold text-white"
+                        >
+                          {String(commitmentMinute).padStart(2, '0')}
+                        </Text>
+                        <TouchableOpacity
+                          testID="commitment-minute-increment"
+                          onPress={() =>
+                            setCommitmentMinute((m) => wrapMinute(m + 5))
+                          }
+                          className="px-3"
+                        >
+                          <Text className="text-2xl text-white">+</Text>
+                        </TouchableOpacity>
+                      </View>
+                    </View>
+                  </View>
+                  <Text className="text-center text-sm text-neutral-200">
+                    We'll send a small reminder so you don't lose the thread.
+                  </Text>
+                </View>
+              )}
+
+              {stepIndex === 3 && (
+                <View>
+                  <Title variant="centered" className="mb-2">
+                    See it, then go
+                  </Title>
+                  <Text className="mb-4 text-base text-neutral-200">
+                    Picture yourself tomorrow at {commitmentHour}:
+                    {String(commitmentMinute).padStart(2, '0')}, phone down,
+                    starting a single quest. The Fading lifts, the streak
+                    remembers, and Vaedros is there waiting.
+                  </Text>
+                  {isDeep && (
+                    <Text className="mb-4 text-base text-neutral-200">
+                      You've come back from this before. This time, the small
+                      step is the only one that matters.
+                    </Text>
+                  )}
+                  {submitError && (
+                    <Text
+                      testID="submit-error"
+                      className="mb-4 text-center text-sm text-red-400"
+                    >
+                      {submitError}
+                    </Text>
+                  )}
+                </View>
+              )}
+            </View>
+          </ScrollView>
+
+          {stepIndex < 3 ? (
+            <Button
+              label="Next"
+              onPress={() => setStepIndex((i) => Math.min(3, i + 1))}
+              className="mb-2 bg-primary-400"
+            />
+          ) : (
+            <Button
+              label={
+                createRestoration.isPending
+                  ? 'Restoring...'
+                  : 'Return to Vaedros'
+              }
+              onPress={handleSubmit}
+              disabled={createRestoration.isPending}
+              loading={createRestoration.isPending}
+              className="mb-2 bg-primary-400"
+            />
+          )}
+        </ScreenContainer>
+      </KeyboardAvoidingView>
+    </View>
   );
 }

--- a/src/app/restoration.tsx
+++ b/src/app/restoration.tsx
@@ -15,6 +15,9 @@ import {
 import { Button } from '@/components/ui/button';
 import colors from '@/components/ui/colors';
 import { useSpirit } from '@/hooks/use-spirit';
+import { scheduleSpiritCommitmentReminders } from '@/lib/services/notifications';
+import { useCharacterStore } from '@/store/character-store';
+import { useSettingsStore } from '@/store/settings-store';
 
 type ChallengeId =
   | 'too_busy'
@@ -70,13 +73,29 @@ export default function RestorationScreen() {
   const handleSubmit = async () => {
     setSubmitError(null);
     try {
-      await createRestoration.mutateAsync({
+      const res = await createRestoration.mutateAsync({
         challenges: selectedChallenges,
         challengeText: challengeText.trim() || undefined,
         journalText: journalText.trim() || undefined,
         commitmentHour,
         commitmentMinute,
       });
+
+      // Side-effects on success: local streak warning picks up the committed
+      // time (settings screen only syncs from server on mount), 3-day
+      // commitment reminder bridge schedules local notifications, and the
+      // spirit meter refills immediately from the server's response.
+      useSettingsStore.getState().setStreakWarning({
+        enabled: true,
+        time: { hour: commitmentHour, minute: commitmentMinute },
+      });
+      await scheduleSpiritCommitmentReminders(commitmentHour, commitmentMinute);
+      useCharacterStore.getState().setSpiritState({
+        spirit: res.spirit,
+        spiritRestoredAt: res.spiritRestoredAt,
+        restorationCount: res.restorationCount,
+      });
+
       router.replace('/(app)');
     } catch (err) {
       console.error('Failed to submit restoration', err);

--- a/src/app/restoration.tsx
+++ b/src/app/restoration.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { ScreenContainer, Text } from '@/components/ui';
+
+export default function RestorationScreen() {
+  return (
+    <ScreenContainer>
+      <Text>Restoration</Text>
+    </ScreenContainer>
+  );
+}

--- a/src/components/custom-quest/hooks/use-quest-creation.test.ts
+++ b/src/components/custom-quest/hooks/use-quest-creation.test.ts
@@ -1,0 +1,83 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+const mockPush = jest.fn();
+const mockQuestStorePrepareQuest = jest.fn();
+const mockQuestTimerPrepareQuest = jest.fn().mockResolvedValue(undefined);
+const mockCapture = jest.fn();
+const mockLogError = jest.fn();
+
+// Controllable faded flag (mock-prefixed so jest.mock factory can reference it)
+let mockFaded = false;
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('posthog-react-native', () => ({
+  usePostHog: () => ({ capture: mockCapture }),
+}));
+
+jest.mock('@/lib/services/logger.service', () => ({
+  log: { error: mockLogError },
+}));
+
+jest.mock('@/lib/services/quest-timer', () => ({
+  prepareQuest: mockQuestTimerPrepareQuest,
+}));
+
+jest.mock('@/store/quest-store', () => ({
+  useQuestStore: {
+    getState: () => ({ prepareQuest: mockQuestStorePrepareQuest }),
+  },
+}));
+
+jest.mock('@/hooks/use-spirit', () => ({
+  isFadedNow: () => mockFaded,
+}));
+
+const { useQuestCreation } = require('./use-quest-creation');
+
+const validFormData = {
+  questName: 'Test Quest',
+  questDuration: 30,
+  questCategory: 'fitness',
+};
+
+describe('useQuestCreation - spirit fading gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFaded = false;
+  });
+
+  it('routes home and skips prepareQuest when faded', async () => {
+    // Arrange
+    mockFaded = true;
+    const { result } = renderHook(() => useQuestCreation());
+
+    // Act
+    await act(async () => {
+      await result.current.createQuest(validFormData);
+    });
+
+    // Assert
+    expect(mockPush).toHaveBeenCalledWith('/(app)');
+    expect(mockQuestTimerPrepareQuest).not.toHaveBeenCalled();
+    expect(mockQuestStorePrepareQuest).not.toHaveBeenCalled();
+  });
+
+  it('creates the quest when not faded', async () => {
+    // Arrange
+    mockFaded = false;
+    const { result } = renderHook(() => useQuestCreation());
+
+    // Act
+    await act(async () => {
+      await result.current.createQuest(validFormData);
+    });
+
+    // Assert
+    expect(mockPush).toHaveBeenCalledWith('/pending-quest');
+    expect(mockQuestTimerPrepareQuest).toHaveBeenCalled();
+    expect(mockQuestStorePrepareQuest).toHaveBeenCalled();
+  });
+});

--- a/src/components/custom-quest/hooks/use-quest-creation.ts
+++ b/src/components/custom-quest/hooks/use-quest-creation.ts
@@ -9,6 +9,7 @@ import { useRouter } from 'expo-router';
 import { usePostHog } from 'posthog-react-native';
 import { useState } from 'react';
 
+import { isFadedNow } from '@/hooks/use-spirit';
 import { log } from '@/lib/services/logger.service';
 import QuestTimer from '@/lib/services/quest-timer';
 import { useQuestStore } from '@/store/quest-store';
@@ -34,6 +35,12 @@ export function useQuestCreation() {
    */
   const createQuest = async (formData: CustomQuestFormData): Promise<void> => {
     try {
+      // Spirit-fading gate: a faded user cannot start a new quest.
+      if (isFadedNow()) {
+        router.push('/(app)'); // home shows the FadingCard
+        return;
+      }
+
       // Clear any previous errors
       setCreationState({ isCreating: true, error: null });
 

--- a/src/components/home/fading-card.test.tsx
+++ b/src/components/home/fading-card.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from '@/lib/test-utils';
+
+import { FadingCard } from './fading-card';
+
+// Mock the router (matches the repo convention used in index.test.tsx)
+const mockPush = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+describe('FadingCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the fading message and routes to /restoration on CTA', () => {
+    render(<FadingCard />);
+
+    expect(screen.getByText(/Your Spirit Is Fading/i)).toBeTruthy();
+
+    fireEvent.press(screen.getByText(/Begin the Restoration/i));
+
+    expect(mockPush).toHaveBeenCalledWith('/restoration');
+  });
+});

--- a/src/components/home/fading-card.tsx
+++ b/src/components/home/fading-card.tsx
@@ -1,0 +1,27 @@
+import { useRouter } from 'expo-router';
+
+import { Button, Card, Text } from '@/components/ui';
+
+export const FadingCard = () => {
+  const router = useRouter();
+
+  return (
+    <Card className="mx-4 items-center gap-4 border border-white/10 bg-black/30 p-6">
+      <Text className="text-center text-xl font-bold text-white opacity-80">
+        Your Spirit Is Fading
+      </Text>
+      <Text className="text-center text-base text-white opacity-60">
+        Vaedros grows quiet without you. Your spirit has dimmed, but it is not
+        gone — a Restoration will call it back to the light.
+      </Text>
+      <Button
+        label="Begin the Restoration"
+        onPress={() => router.push('/restoration')}
+        variant="secondary"
+        size="lg"
+        className="w-full rounded-xl p-3"
+        textClassName="text-sm text-white text-center font-bold"
+      />
+    </Card>
+  );
+};

--- a/src/components/profile/stats-card.tsx
+++ b/src/components/profile/stats-card.tsx
@@ -9,8 +9,10 @@ import {
   withTiming,
 } from 'react-native-reanimated';
 
-import { STATS_ANIMATION } from '@/features/profile/constants/profile-constants';
+import { SpiritMeter } from '@/components/spirit-meter';
 import { Card, Text, View } from '@/components/ui';
+import { STATS_ANIMATION } from '@/features/profile/constants/profile-constants';
+import { useSpirit } from '@/hooks/use-spirit';
 
 type StatsCardProps = {
   questCount: number;
@@ -65,6 +67,8 @@ export function StatsCard({
   minutesSaved,
   streakCount,
 }: StatsCardProps) {
+  const { active } = useSpirit();
+
   return (
     <Card className="mx-4 mt-4 p-5">
       <View className="flex-row justify-around">
@@ -136,6 +140,13 @@ export function StatsCard({
           <Text className="text-base text-neutral-200">Day Streak</Text>
         </Pressable>
       </View>
+
+      {active ? (
+        <View className="mt-4 items-center border-t border-neutral-300 pt-4">
+          <SpiritMeter />
+          <Text className="mt-2 text-base text-neutral-200">Spirit</Text>
+        </View>
+      ) : null}
     </Card>
   );
 }

--- a/src/components/spirit-meter.test.tsx
+++ b/src/components/spirit-meter.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@/lib/test-utils';
+
+import { SpiritMeter } from './spirit-meter';
+
+jest.mock('@/hooks/use-spirit');
+const mockUseSpirit = require('@/hooks/use-spirit').useSpirit as jest.Mock;
+
+describe('SpiritMeter', () => {
+  it('renders 5 segments with 3 filled at spirit 60', () => {
+    mockUseSpirit.mockReturnValue({
+      spirit: 60,
+      faded: false,
+      active: true,
+      restorationCount: 0,
+    });
+    render(<SpiritMeter />);
+    expect(screen.getAllByTestId('spirit-segment')).toHaveLength(5);
+    expect(screen.getAllByTestId('spirit-segment-filled')).toHaveLength(3);
+  });
+
+  it('renders 1 filled segment at spirit 20', () => {
+    mockUseSpirit.mockReturnValue({
+      spirit: 20,
+      faded: false,
+      active: true,
+      restorationCount: 0,
+    });
+    render(<SpiritMeter />);
+    expect(screen.getAllByTestId('spirit-segment-filled')).toHaveLength(1);
+  });
+
+  it('renders 0 filled at spirit 0 (faded)', () => {
+    mockUseSpirit.mockReturnValue({
+      spirit: 0,
+      faded: true,
+      active: true,
+      restorationCount: 0,
+    });
+    render(<SpiritMeter />);
+    expect(screen.queryAllByTestId('spirit-segment-filled')).toHaveLength(0);
+  });
+
+  it('renders nothing when inactive', () => {
+    mockUseSpirit.mockReturnValue({
+      spirit: null,
+      faded: false,
+      active: false,
+      restorationCount: 0,
+    });
+    const { toJSON } = render(<SpiritMeter />);
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/src/components/spirit-meter.tsx
+++ b/src/components/spirit-meter.tsx
@@ -1,0 +1,36 @@
+import { View } from 'react-native';
+
+import { useSpirit } from '@/hooks/use-spirit';
+import { DECAY_PER_DAY, MAX_SPIRIT } from '@/lib/spirit';
+
+// Derived from the server-parity constants so a change to the decay formula
+// loudly re-shapes the meter instead of silently desyncing (1 segment = 1 day).
+const POINTS_PER_SEGMENT = DECAY_PER_DAY;
+const SEGMENTS = MAX_SPIRIT / DECAY_PER_DAY;
+
+export const SpiritMeter = () => {
+  const { spirit, active } = useSpirit();
+
+  if (!active || spirit === null) return null;
+
+  const filled = Math.round(spirit / POINTS_PER_SEGMENT);
+
+  return (
+    <View testID="spirit-meter" className="flex-row gap-1">
+      {Array.from({ length: SEGMENTS }).map((_, i) => (
+        <View
+          key={i}
+          testID="spirit-segment"
+          className="h-2 w-4 rounded-sm bg-neutral-300"
+        >
+          {i < filled ? (
+            <View
+              testID="spirit-segment-filled"
+              className="size-full rounded-sm bg-primary-400"
+            />
+          ) : null}
+        </View>
+      ))}
+    </View>
+  );
+};

--- a/src/features/home/hooks/use-quest-selection.test.ts
+++ b/src/features/home/hooks/use-quest-selection.test.ts
@@ -1,0 +1,79 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+const mockPush = jest.fn();
+const mockPrepareQuest = jest.fn();
+const mockQuestTimerPrepareQuest = jest.fn().mockResolvedValue(undefined);
+const mockCapture = jest.fn();
+
+// Controllable faded flag (mock-prefixed so jest.mock factory can reference it)
+let mockFaded = false;
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('posthog-react-native', () => ({
+  usePostHog: () => ({ capture: mockCapture }),
+}));
+
+jest.mock('@/lib/services/quest-timer', () => ({
+  prepareQuest: mockQuestTimerPrepareQuest,
+}));
+
+jest.mock('@/store/quest-store', () => ({
+  useQuestStore: jest.fn((selector: any) =>
+    selector({ prepareQuest: mockPrepareQuest })
+  ),
+}));
+
+jest.mock('@/app/data/quests', () => ({
+  AVAILABLE_QUESTS: [{ id: 'quest-1', mode: 'story' }],
+}));
+
+jest.mock('@/hooks/use-spirit', () => ({
+  isFadedNow: () => mockFaded,
+}));
+
+const { useQuestSelection } = require('./use-quest-selection');
+
+describe('useQuestSelection - spirit fading gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFaded = false;
+  });
+
+  it('routes home and skips prepareQuest when faded', async () => {
+    // Arrange
+    mockFaded = true;
+    const { result } = renderHook(() =>
+      useQuestSelection({ serverQuests: [], serverOptions: [] })
+    );
+
+    // Act
+    await act(async () => {
+      await result.current.handleQuestOptionSelect('quest-1');
+    });
+
+    // Assert
+    expect(mockPush).toHaveBeenCalledWith('/(app)');
+    expect(mockQuestTimerPrepareQuest).not.toHaveBeenCalled();
+    expect(mockPrepareQuest).not.toHaveBeenCalled();
+  });
+
+  it('starts the quest when not faded', async () => {
+    // Arrange
+    mockFaded = false;
+    const { result } = renderHook(() =>
+      useQuestSelection({ serverQuests: [], serverOptions: [] })
+    );
+
+    // Act
+    await act(async () => {
+      await result.current.handleQuestOptionSelect('quest-1');
+    });
+
+    // Assert
+    expect(mockPush).toHaveBeenCalledWith('/pending-quest');
+    expect(mockQuestTimerPrepareQuest).toHaveBeenCalled();
+  });
+});

--- a/src/features/home/hooks/use-quest-selection.ts
+++ b/src/features/home/hooks/use-quest-selection.ts
@@ -3,6 +3,7 @@ import { usePostHog } from 'posthog-react-native';
 import { useCallback } from 'react';
 
 import { AVAILABLE_QUESTS } from '@/app/data/quests';
+import { isFadedNow } from '@/hooks/use-spirit';
 import QuestTimer from '@/lib/services/quest-timer';
 import { useQuestStore } from '@/store/quest-store';
 import { type StoryQuestTemplate } from '@/store/types';
@@ -39,6 +40,12 @@ export function useQuestSelection({
       posthog.capture('try_trigger_start_quest');
 
       if (!nextQuestId) {
+        return;
+      }
+
+      // Spirit-fading gate: a faded user cannot start a new quest.
+      if (isFadedNow()) {
+        router.push('/(app)'); // home shows the FadingCard
         return;
       }
 

--- a/src/features/profile/hooks/profile-hooks.test.ts
+++ b/src/features/profile/hooks/profile-hooks.test.ts
@@ -61,10 +61,22 @@ describe('useCharacterSync', () => {
       mockCharacterStore.mockImplementation((selector) => {
         if (selector) {
           return selector({
-            character: { name: 'TestHero', type: 'knight', level: 5, currentXP: 150 },
+            character: {
+              name: 'TestHero',
+              type: 'knight',
+              level: 5,
+              currentXP: 150,
+            },
           });
         }
-        return { character: { name: 'TestHero', type: 'knight', level: 5, currentXP: 150 } };
+        return {
+          character: {
+            name: 'TestHero',
+            type: 'knight',
+            level: 5,
+            currentXP: 150,
+          },
+        };
       });
 
       const { result } = renderHook(() =>
@@ -116,7 +128,10 @@ describe('useCharacterSync', () => {
       });
 
       await waitFor(() => {
-        expect(mockStoreInstance.createCharacter).toHaveBeenCalledWith('wizard', 'MerlinTheWise');
+        expect(mockStoreInstance.createCharacter).toHaveBeenCalledWith(
+          'wizard',
+          'MerlinTheWise'
+        );
       });
 
       expect(mockStoreInstance.updateCharacter).toHaveBeenCalledWith({
@@ -165,7 +180,10 @@ describe('useCharacterSync', () => {
       });
 
       await waitFor(() => {
-        expect(mockStoreInstance.createCharacter).toHaveBeenCalledWith('knight', 'BraveSir');
+        expect(mockStoreInstance.createCharacter).toHaveBeenCalledWith(
+          'knight',
+          'BraveSir'
+        );
       });
 
       expect(mockStoreInstance.updateCharacter).toHaveBeenCalledWith({
@@ -177,6 +195,96 @@ describe('useCharacterSync', () => {
 
       // Should not call setStreak if dailyQuestStreak is undefined
       expect(mockStoreInstance.setStreak).not.toHaveBeenCalled();
+    });
+
+    it('should sync spirit from server, defaulting missing restoration fields', async () => {
+      const mockUser = {
+        _id: 'user1',
+        email: 'test@example.com',
+        type: 'wizard',
+        name: 'MerlinTheWise',
+        level: 10,
+        xp: 500,
+        dailyQuestStreak: 7,
+        spirit: 60,
+        // spiritRestoredAt and restorationCount intentionally omitted
+      };
+
+      const mockStoreInstance = {
+        createCharacter: jest.fn(),
+        updateCharacter: jest.fn(),
+        setStreak: jest.fn(),
+        setSpiritState: jest.fn(),
+      };
+
+      mockGetUserDetails.mockResolvedValue(mockUser);
+      mockCharacterStore.getState.mockReturnValue(mockStoreInstance);
+
+      renderHook(() =>
+        useCharacterSync({
+          characterStore: mockCharacterStore,
+          getStorageItem: mockGetStorageItem,
+          getUserDetails: mockGetUserDetails,
+          router: mockRouter,
+        })
+      );
+
+      await waitFor(() => {
+        expect(mockGetUserDetails).toHaveBeenCalled();
+      });
+
+      await waitFor(() => {
+        expect(mockStoreInstance.setSpiritState).toHaveBeenCalledTimes(1);
+      });
+
+      // Fallbacks: absent spiritRestoredAt -> null, absent restorationCount -> 0
+      expect(mockStoreInstance.setSpiritState).toHaveBeenCalledWith({
+        spirit: 60,
+        spiritRestoredAt: null,
+        restorationCount: 0,
+      });
+    });
+
+    it('should not call setSpiritState when spirit is undefined', async () => {
+      const mockUser = {
+        _id: 'user1',
+        email: 'test@example.com',
+        type: 'knight',
+        name: 'BraveSir',
+        level: 3,
+        xp: 75,
+        // No spirit field
+      };
+
+      const mockStoreInstance = {
+        createCharacter: jest.fn(),
+        updateCharacter: jest.fn(),
+        setStreak: jest.fn(),
+        setSpiritState: jest.fn(),
+      };
+
+      mockGetUserDetails.mockResolvedValue(mockUser);
+      mockCharacterStore.getState.mockReturnValue(mockStoreInstance);
+
+      renderHook(() =>
+        useCharacterSync({
+          characterStore: mockCharacterStore,
+          getStorageItem: mockGetStorageItem,
+          getUserDetails: mockGetUserDetails,
+          router: mockRouter,
+        })
+      );
+
+      await waitFor(() => {
+        expect(mockGetUserDetails).toHaveBeenCalled();
+      });
+
+      await waitFor(() => {
+        expect(mockStoreInstance.createCharacter).toHaveBeenCalled();
+      });
+
+      // Guard holds: no spirit field means the store is never touched for spirit
+      expect(mockStoreInstance.setSpiritState).not.toHaveBeenCalled();
     });
 
     it('should default to level 1 if level is missing', async () => {
@@ -255,7 +363,9 @@ describe('useCharacterSync', () => {
 
       await waitFor(
         () => {
-          expect(mockRouter.replace).toHaveBeenCalledWith('/onboarding/choose-character');
+          expect(mockRouter.replace).toHaveBeenCalledWith(
+            '/onboarding/choose-character'
+          );
         },
         { timeout: 3000 }
       );
@@ -295,7 +405,9 @@ describe('useCharacterSync', () => {
 
       await waitFor(
         () => {
-          expect(mockRouter.replace).toHaveBeenCalledWith('/onboarding/choose-character');
+          expect(mockRouter.replace).toHaveBeenCalledWith(
+            '/onboarding/choose-character'
+          );
         },
         { timeout: 3000 }
       );
@@ -335,7 +447,9 @@ describe('useCharacterSync', () => {
 
       await waitFor(
         () => {
-          expect(mockRouter.replace).toHaveBeenCalledWith('/onboarding/choose-character');
+          expect(mockRouter.replace).toHaveBeenCalledWith(
+            '/onboarding/choose-character'
+          );
         },
         { timeout: 3000 }
       );

--- a/src/features/profile/hooks/profile-hooks.ts
+++ b/src/features/profile/hooks/profile-hooks.ts
@@ -74,6 +74,15 @@ export function useCharacterSync(dependencies?: {
             if (user.dailyQuestStreak !== undefined) {
               characterStoreInstance.setStreak(user.dailyQuestStreak);
             }
+
+            // Sync server-reported spirit (guard so pre-deploy server responses don't clobber state)
+            if (user.spirit !== undefined) {
+              characterStoreInstance.setSpiritState({
+                spirit: user.spirit,
+                spiritRestoredAt: user.spiritRestoredAt ?? null,
+                restorationCount: user.restorationCount ?? 0,
+              });
+            }
           } else {
             // Only redirect to onboarding if this is truly a new user
             // Check for provisional data to determine if they're in onboarding
@@ -101,7 +110,14 @@ export function useCharacterSync(dependencies?: {
 
       syncCharacterFromUser();
     }
-  }, [character, actualRouter, isRedirecting, characterStore, getStorageItem, getUserDetailsFunc]);
+  }, [
+    character,
+    actualRouter,
+    isRedirecting,
+    characterStore,
+    getStorageItem,
+    getUserDetailsFunc,
+  ]);
 
   return { isRedirecting };
 }

--- a/src/features/profile/types/profile-types.ts
+++ b/src/features/profile/types/profile-types.ts
@@ -37,6 +37,12 @@ export interface UserWithLegacyCharacter {
   totalQuestsCompleted?: number;
   /** Total minutes off phone (server stat) */
   totalMinutesOffPhone?: number;
+  /** Spirit meter value (Spirit Fading feature); null when inactive/dormant */
+  spirit?: number | null;
+  /** ISO timestamp of the last Restoration, if any */
+  spiritRestoredAt?: string | null;
+  /** Number of times spirit has been restored */
+  restorationCount?: number;
 }
 
 /**

--- a/src/hooks/use-spirit.test.ts
+++ b/src/hooks/use-spirit.test.ts
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useSpirit } from './use-spirit';
+
+jest.mock('@/lib/spirit', () => ({
+  ...jest.requireActual('@/lib/spirit'),
+  isSpiritFadingEnabled: jest.fn(() => true),
+}));
+jest.mock('@/store/character-store');
+
+const { useCharacterStore } = require('@/store/character-store');
+const { isSpiritFadingEnabled } = require('@/lib/spirit');
+
+const setStore = (
+  serverSpirit: number | null,
+  serverSpiritAt: number | null,
+  restorationCount = 0
+) =>
+  (useCharacterStore as jest.Mock).mockImplementation((sel: any) =>
+    sel({ serverSpirit, serverSpiritAt, restorationCount })
+  );
+
+describe('useSpirit', () => {
+  beforeEach(() => {
+    (isSpiritFadingEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('returns active spirit derived from server anchor', () => {
+    setStore(100, Date.now());
+    const { result } = renderHook(() => useSpirit());
+    expect(result.current.active).toBe(true);
+    expect(result.current.spirit).toBe(100);
+    expect(result.current.faded).toBe(false);
+  });
+
+  it('is inactive when the flag is off', () => {
+    (isSpiritFadingEnabled as jest.Mock).mockReturnValueOnce(false);
+    setStore(100, Date.now());
+    const { result } = renderHook(() => useSpirit());
+    expect(result.current.active).toBe(false);
+  });
+
+  it('exposes restorationCount from the store', () => {
+    setStore(100, Date.now(), 4);
+    const { result } = renderHook(() => useSpirit());
+    expect(result.current.restorationCount).toBe(4);
+  });
+});

--- a/src/hooks/use-spirit.ts
+++ b/src/hooks/use-spirit.ts
@@ -1,0 +1,20 @@
+import {
+  deriveDisplaySpirit,
+  isSpiritFadingEnabled,
+  type SpiritDisplay,
+} from '@/lib/spirit';
+import { useCharacterStore } from '@/store/character-store';
+
+export const useSpirit = (): SpiritDisplay & { restorationCount: number } => {
+  const serverSpirit = useCharacterStore((s) => s.serverSpirit);
+  const serverSpiritAt = useCharacterStore((s) => s.serverSpiritAt);
+  const restorationCount = useCharacterStore((s) => s.restorationCount);
+
+  if (!isSpiritFadingEnabled()) {
+    return { spirit: null, faded: false, active: false, restorationCount };
+  }
+  return {
+    ...deriveDisplaySpirit({ serverSpirit, serverSpiritAt }),
+    restorationCount,
+  };
+};

--- a/src/hooks/use-spirit.ts
+++ b/src/hooks/use-spirit.ts
@@ -18,3 +18,14 @@ export const useSpirit = (): SpiritDisplay & { restorationCount: number } => {
     restorationCount,
   };
 };
+
+/**
+ * Non-hook reader for the faded state. Use at quest-start call sites that are
+ * not inside a render body (e.g. inside event handlers / mutations) where a
+ * hook would be inappropriate. Reads the latest store snapshot directly.
+ */
+export const isFadedNow = (): boolean => {
+  if (!isSpiritFadingEnabled()) return false;
+  const { serverSpirit, serverSpiritAt } = useCharacterStore.getState();
+  return deriveDisplaySpirit({ serverSpirit, serverSpiritAt }).faded;
+};

--- a/src/lib/auth/index.test.tsx
+++ b/src/lib/auth/index.test.tsx
@@ -51,11 +51,13 @@ jest.mock('@/store/character-store', () => {
   const mockCreateCharacter = jest.fn();
   const mockUpdateCharacter = jest.fn();
   const mockSetStreak = jest.fn();
+  const mockSetSpiritState = jest.fn();
   const mockGetState = jest.fn(() => ({
     character: null,
     createCharacter: mockCreateCharacter,
     updateCharacter: mockUpdateCharacter,
     setStreak: mockSetStreak,
+    setSpiritState: mockSetSpiritState,
   }));
 
   return {
@@ -66,6 +68,7 @@ jest.mock('@/store/character-store', () => {
       mockCreateCharacter,
       mockUpdateCharacter,
       mockSetStreak,
+      mockSetSpiritState,
       mockGetState,
     },
   };
@@ -95,6 +98,7 @@ beforeEach(() => {
   characterStoreMocks.mockCreateCharacter.mockClear();
   characterStoreMocks.mockUpdateCharacter.mockClear();
   characterStoreMocks.mockSetStreak.mockClear();
+  characterStoreMocks.mockSetSpiritState.mockClear();
 
   // Reset character store to default state
   characterStoreMocks.mockGetState.mockReturnValue({
@@ -102,6 +106,7 @@ beforeEach(() => {
     createCharacter: characterStoreMocks.mockCreateCharacter,
     updateCharacter: characterStoreMocks.mockUpdateCharacter,
     setStreak: characterStoreMocks.mockSetStreak,
+    setSpiritState: characterStoreMocks.mockSetSpiritState,
   });
 });
 
@@ -284,6 +289,46 @@ describe('Auth Store', () => {
         currentXP: 250,
       });
       expect(characterStoreMocks.mockSetStreak).toHaveBeenCalledWith(10);
+    });
+
+    it('should sync spirit when server provides it, defaulting missing restoration fields', async () => {
+      const mockUser = {
+        id: 'user-123',
+        name: 'TestChar',
+        dailyQuestStreak: 4,
+        spirit: 60,
+        // spiritRestoredAt and restorationCount intentionally omitted
+      };
+
+      (getToken as jest.Mock).mockReturnValue({ access: 'token' });
+      (getUserDetails as jest.Mock).mockResolvedValue(mockUser);
+
+      await useAuth.getState().hydrate();
+
+      expect(characterStoreMocks.mockSetSpiritState).toHaveBeenCalledTimes(1);
+      // Fallbacks: absent spiritRestoredAt -> null, absent restorationCount -> 0
+      expect(characterStoreMocks.mockSetSpiritState).toHaveBeenCalledWith({
+        spirit: 60,
+        spiritRestoredAt: null,
+        restorationCount: 0,
+      });
+    });
+
+    it('should not call setSpiritState when server omits spirit', async () => {
+      const mockUser = {
+        id: 'user-123',
+        name: 'TestChar',
+        dailyQuestStreak: 4,
+        // No spirit field
+      };
+
+      (getToken as jest.Mock).mockReturnValue({ access: 'token' });
+      (getUserDetails as jest.Mock).mockResolvedValue(mockUser);
+
+      await useAuth.getState().hydrate();
+
+      // Guard holds: undefined spirit means the store is never touched for spirit
+      expect(characterStoreMocks.mockSetSpiritState).not.toHaveBeenCalled();
     });
 
     it('should handle character data in legacy format', async () => {

--- a/src/lib/auth/index.tsx
+++ b/src/lib/auth/index.tsx
@@ -231,6 +231,15 @@ const _useAuth = create<AuthState>((set, get) => ({
               characterStore.setStreak(user.dailyQuestStreak);
             }
 
+            // Sync server-reported spirit (guard so pre-deploy server responses don't clobber state)
+            if (user.spirit !== undefined) {
+              characterStore.setSpiritState({
+                spirit: user.spirit,
+                spiritRestoredAt: user.spiritRestoredAt ?? null,
+                restorationCount: user.restorationCount ?? 0,
+              });
+            }
+
             console.log('[Auth] Character data synchronized during hydration');
           } else {
             console.log('[Auth] No character data found during hydration');

--- a/src/lib/hooks/use-cooperative-quest.test.tsx
+++ b/src/lib/hooks/use-cooperative-quest.test.tsx
@@ -1,22 +1,35 @@
 import { useQuery } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react-native';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
 
 import { getQuestRunStatus } from '@/lib/services/quest-run-service';
 import { useQuestStore } from '@/store/quest-store';
 
 import {
   useCooperativeQuest,
+  useInvitationActions,
   useQuestRunStatus,
 } from './use-cooperative-quest';
+
+// Controllable faded flag (mock-prefixed so jest.mock factory can reference it)
+let mockFaded = false;
 
 // Mock dependencies
 jest.mock('@tanstack/react-query');
 jest.mock('@/lib/services/quest-run-service');
+jest.mock('@/lib/services/invitation-service');
 jest.mock('@/store/quest-store');
 jest.mock('expo-router', () => ({
   router: {
     replace: jest.fn(),
+    push: jest.fn(),
   },
+}));
+jest.mock('@/lib/services/quest-timer', () => ({
+  __esModule: true,
+  default: { prepareQuest: jest.fn().mockResolvedValue(undefined) },
+}));
+jest.mock('@/hooks/use-spirit', () => ({
+  isFadedNow: () => mockFaded,
 }));
 
 describe('use-cooperative-quest', () => {
@@ -250,6 +263,134 @@ describe('use-cooperative-quest', () => {
       // Assert - should disable polling for active quest (polling only for 'pending' status)
       expect(questRunStatusCall).toBeDefined();
       expect(questRunStatusCall[0].enabled).toBe(false);
+    });
+  });
+
+  describe('useInvitationActions - spirit fading gate', () => {
+    const { useMutation, useQueryClient } = require('@tanstack/react-query');
+    const { acceptInvitation } = require('@/lib/services/invitation-service');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const routerPush = () => require('expo-router').router.push;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const questTimerPrepareQuest = () =>
+      require('@/lib/services/quest-timer').default.prepareQuest;
+
+    const setupMutationCapture = () => {
+      const captured: any[] = [];
+      (useMutation as jest.Mock).mockImplementation((options: any) => {
+        captured.push(options);
+        return { mutate: jest.fn(), isPending: false, isError: false };
+      });
+      (useQueryClient as jest.Mock).mockReturnValue({
+        invalidateQueries: jest.fn(),
+      });
+      return captured;
+    };
+
+    beforeEach(() => {
+      mockFaded = false;
+      routerPush().mockClear();
+      questTimerPrepareQuest().mockClear();
+    });
+
+    it('routes home and does not call prepareQuest when faded', async () => {
+      // Arrange
+      mockFaded = true;
+      const captured = setupMutationCapture();
+
+      const mockQuestStore = {
+        setCurrentInvitation: jest.fn(),
+        setCooperativeQuestRun: jest.fn(),
+        prepareQuest: jest.fn(),
+      };
+      (useQuestStore as unknown as jest.Mock).mockImplementation(
+        (selector: any) => {
+          if (typeof selector === 'function') {
+            return selector(mockQuestStore);
+          }
+          return mockQuestStore;
+        }
+      );
+      (useQuestStore as any).getState = jest
+        .fn()
+        .mockReturnValue(mockQuestStore);
+
+      (getQuestRunStatus as jest.Mock).mockResolvedValue({
+        id: 'quest-run-1',
+        status: 'pending',
+        quest: { id: 'q-1', title: 'Coop', durationMinutes: 30 },
+        participants: [{ userId: 'host', ready: false, status: 'pending' }],
+      });
+
+      // Act
+      renderHook(() => useInvitationActions());
+
+      // The first captured mutation is the accept mutation
+      const acceptOptions = captured.find(
+        (o) => o.mutationFn === acceptInvitation
+      );
+      expect(acceptOptions).toBeDefined();
+
+      await act(async () => {
+        await acceptOptions.onSuccess({ questRunId: 'quest-run-1' });
+      });
+
+      // Assert
+      expect(routerPush()).toHaveBeenCalledWith('/(app)');
+      expect(mockQuestStore.prepareQuest).not.toHaveBeenCalled();
+      expect(questTimerPrepareQuest()).not.toHaveBeenCalled();
+    });
+
+    it('does not route home and reaches prepareQuest when not faded', async () => {
+      // Arrange — mockFaded is false (set in beforeEach)
+      const captured = setupMutationCapture();
+
+      const mockQuestStore = {
+        setCurrentInvitation: jest.fn(),
+        setCooperativeQuestRun: jest.fn(),
+        prepareQuest: jest.fn(),
+      };
+      (useQuestStore as unknown as jest.Mock).mockImplementation(
+        (selector: any) => {
+          if (typeof selector === 'function') {
+            return selector(mockQuestStore);
+          }
+          return mockQuestStore;
+        }
+      );
+      (useQuestStore as any).getState = jest
+        .fn()
+        .mockReturnValue(mockQuestStore);
+
+      (getQuestRunStatus as jest.Mock).mockResolvedValue({
+        id: 'quest-run-1',
+        status: 'pending',
+        quest: { id: 'q-1', title: 'Coop', durationMinutes: 30 },
+        participants: [{ userId: 'host', ready: false, status: 'pending' }],
+      });
+
+      // Act
+      renderHook(() => useInvitationActions());
+
+      const acceptOptions = captured.find(
+        (o) => o.mutationFn === acceptInvitation
+      );
+      expect(acceptOptions).toBeDefined();
+
+      // The non-faded path proceeds past the gate to prepareQuest. A pre-existing
+      // native dynamic import() in onSuccess (not transpiled by Jest's CJS babel
+      // config) rejects in the test env, so we assert the guard's conditionality
+      // via what ran BEFORE that import: the gate did not route home, and
+      // prepareQuest was reached.
+      await expect(
+        act(async () => {
+          await acceptOptions.onSuccess({ questRunId: 'quest-run-1' });
+        })
+      ).rejects.toThrow(/dynamic import/);
+
+      // Assert — gate did NOT fire; the quest reached prepareQuest
+      expect(routerPush()).not.toHaveBeenCalledWith('/(app)');
+      expect(mockQuestStore.prepareQuest).toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/hooks/use-cooperative-quest.ts
+++ b/src/lib/hooks/use-cooperative-quest.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import { useCallback, useEffect } from 'react';
 
+import { isFadedNow } from '@/hooks/use-spirit';
 import {
   acceptInvitation,
   declineInvitation,
@@ -81,6 +82,14 @@ export function useInvitationActions() {
         '[useInvitationActions] Accept invitation successful:',
         response
       );
+
+      // Spirit-fading gate: a faded user cannot start a new quest. Checked
+      // first so we neither fetch the quest run nor mutate the store for a
+      // user who will be sent home to the FadingCard anyway.
+      if (isFadedNow()) {
+        router.push('/(app)'); // home shows the FadingCard
+        return;
+      }
 
       // Handle the response format from the server
       const questRunId =

--- a/src/lib/services/notifications.test.ts
+++ b/src/lib/services/notifications.test.ts
@@ -1,0 +1,81 @@
+import * as ExpoNotifications from 'expo-notifications';
+
+import {
+  cancelSpiritCommitmentReminders,
+  scheduleSpiritCommitmentReminders,
+} from './notifications';
+
+jest.mock('@/lib/storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('react-native-onesignal', () => ({
+  OneSignal: {
+    Notifications: {
+      getPermissionAsync: jest.fn().mockResolvedValue(true),
+    },
+    User: {
+      pushSubscription: {
+        getOptedInAsync: jest.fn().mockResolvedValue(true),
+      },
+    },
+  },
+}));
+
+describe('spirit commitment reminders', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (
+      ExpoNotifications.scheduleNotificationAsync as jest.Mock
+    ).mockResolvedValue(undefined);
+    (
+      ExpoNotifications.cancelScheduledNotificationAsync as jest.Mock
+    ).mockResolvedValue(undefined);
+  });
+
+  it('schedules 3 reminders with fixed identifiers', async () => {
+    await scheduleSpiritCommitmentReminders(20, 0);
+
+    expect(ExpoNotifications.scheduleNotificationAsync).toHaveBeenCalledTimes(
+      3
+    );
+
+    const calls = (ExpoNotifications.scheduleNotificationAsync as jest.Mock)
+      .mock.calls;
+    const ids = calls.map((c: any) => c[0].identifier);
+
+    expect(ids).toEqual([
+      'spirit-commitment-1',
+      'spirit-commitment-2',
+      'spirit-commitment-3',
+    ]);
+
+    // Lock in the first call's routing payload and trigger type
+    const firstPayload = calls[0][0];
+    expect(firstPayload.content.data).toEqual({
+      type: 'spirit_commitment',
+      screen: '/(app)',
+    });
+    // 'timeInterval' is SchedulableTriggerInputTypes.TIME_INTERVAL
+    expect(firstPayload.trigger.type).toBe('timeInterval');
+  });
+
+  it('cancels all 3 reminders', async () => {
+    await cancelSpiritCommitmentReminders();
+
+    expect(
+      ExpoNotifications.cancelScheduledNotificationAsync
+    ).toHaveBeenCalledTimes(3);
+    expect(
+      ExpoNotifications.cancelScheduledNotificationAsync
+    ).toHaveBeenCalledWith('spirit-commitment-1');
+    expect(
+      ExpoNotifications.cancelScheduledNotificationAsync
+    ).toHaveBeenCalledWith('spirit-commitment-2');
+    expect(
+      ExpoNotifications.cancelScheduledNotificationAsync
+    ).toHaveBeenCalledWith('spirit-commitment-3');
+  });
+});

--- a/src/lib/services/notifications.ts
+++ b/src/lib/services/notifications.ts
@@ -372,3 +372,74 @@ export const cancelStreakWarningNotification = async (): Promise<boolean> => {
     return false;
   }
 };
+
+// Fixed identifiers for the 3 spirit_commitment "bridge" reminders scheduled
+// when a user commits to a return time during Restoration. Streak-independent.
+const SPIRIT_COMMITMENT_IDS = [
+  'spirit-commitment-1',
+  'spirit-commitment-2',
+  'spirit-commitment-3',
+];
+
+// Schedule 3 local reminders (next 3 days) at the user's committed return time.
+// Fixed identifiers mean a repeat Restoration replaces rather than stacks them.
+export const scheduleSpiritCommitmentReminders = async (
+  hour: number,
+  minute: number
+): Promise<boolean> => {
+  const enabled = await areNotificationsEnabled();
+  if (!enabled) {
+    return false;
+  }
+
+  try {
+    // Cancel any existing spirit commitment reminders first (replace, don't stack)
+    await cancelSpiritCommitmentReminders();
+
+    for (let day = 1; day <= 3; day++) {
+      const target = new Date();
+      target.setDate(target.getDate() + day);
+      target.setHours(hour, minute, 0, 0);
+
+      const seconds = Math.max(
+        1,
+        Math.floor((target.getTime() - Date.now()) / 1000)
+      );
+
+      await ExpoNotifications.scheduleNotificationAsync({
+        identifier: SPIRIT_COMMITMENT_IDS[day - 1],
+        content: {
+          title: 'Your quest awaits',
+          body: 'You set this time to return. A single quest keeps the Fading away.',
+          data: { type: 'spirit_commitment', screen: '/(app)' },
+          sound: true,
+        },
+        trigger: {
+          type: SchedulableTriggerInputTypes.TIME_INTERVAL,
+          seconds,
+          channelId: Platform.OS === 'android' ? QUEST_CHANNEL_ID : undefined,
+        },
+      });
+    }
+
+    return true;
+  } catch (error) {
+    console.error('Failed to schedule spirit commitment reminders:', error);
+    return false;
+  }
+};
+
+// Cancel all 3 spirit commitment reminders
+export const cancelSpiritCommitmentReminders = async (): Promise<boolean> => {
+  try {
+    await Promise.all(
+      SPIRIT_COMMITMENT_IDS.map((id) =>
+        ExpoNotifications.cancelScheduledNotificationAsync(id)
+      )
+    );
+    return true;
+  } catch (error) {
+    console.error('Failed to cancel spirit commitment reminders:', error);
+    return false;
+  }
+};

--- a/src/lib/services/user.ts
+++ b/src/lib/services/user.ts
@@ -24,6 +24,9 @@ export interface UserDetails {
   pendingFriends: any[];
   blockedUsers: any[];
   inventory: any[];
+  spirit: number | null;
+  spiritRestoredAt: string | null;
+  restorationCount: number;
 }
 
 export interface FriendCharacter {

--- a/src/lib/spirit.test.ts
+++ b/src/lib/spirit.test.ts
@@ -1,0 +1,73 @@
+import {
+  idleDaysBetween,
+  spiritFromIdleDays,
+  deriveDisplaySpirit,
+  isSpiritFadingEnabled,
+} from './spirit';
+
+describe('spirit formula (server parity)', () => {
+  it('spiritFromIdleDays matches 100 − 20·days floored at 0', () => {
+    expect(spiritFromIdleDays(0)).toBe(100);
+    expect(spiritFromIdleDays(1)).toBe(80);
+    expect(spiritFromIdleDays(4)).toBe(20);
+    expect(spiritFromIdleDays(5)).toBe(0);
+    expect(spiritFromIdleDays(9)).toBe(0);
+  });
+
+  it('idleDaysBetween counts local calendar days (0 same day)', () => {
+    const d = (s: string) => new Date(s).getTime();
+    expect(
+      idleDaysBetween(d('2026-06-01T08:00:00'), d('2026-06-01T23:00:00'))
+    ).toBe(0);
+    expect(
+      idleDaysBetween(d('2026-06-01T23:00:00'), d('2026-06-02T00:30:00'))
+    ).toBe(1);
+    expect(
+      idleDaysBetween(d('2026-06-01T08:00:00'), d('2026-06-06T08:00:00'))
+    ).toBe(5);
+  });
+});
+
+describe('deriveDisplaySpirit (server-anchored)', () => {
+  const at = (s: string) => new Date(s).getTime();
+
+  it('returns null when serverSpirit is null (inactive/dormant)', () => {
+    expect(
+      deriveDisplaySpirit({
+        serverSpirit: null,
+        serverSpiritAt: at('2026-06-01T08:00:00'),
+        now: at('2026-06-05T08:00:00'),
+      })
+    ).toEqual({ spirit: null, faded: false, active: false });
+  });
+
+  it('decays forward from the fetch time, never above the server value', () => {
+    expect(
+      deriveDisplaySpirit({
+        serverSpirit: 100,
+        serverSpiritAt: at('2026-06-01T08:00:00'),
+        now: at('2026-06-03T09:00:00'),
+      })
+    ).toEqual({ spirit: 60, faded: false, active: true });
+  });
+
+  it('a returning-lapsed user fetched at 100 is NOT faded even if their last quest was long ago', () => {
+    expect(
+      deriveDisplaySpirit({
+        serverSpirit: 100,
+        serverSpiritAt: at('2026-06-10T00:00:00'),
+        now: at('2026-06-10T06:00:00'),
+      }).faded
+    ).toBe(false);
+  });
+
+  it('is faded when the anchored decay reaches 0', () => {
+    expect(
+      deriveDisplaySpirit({
+        serverSpirit: 20,
+        serverSpiritAt: at('2026-06-01T08:00:00'),
+        now: at('2026-06-02T09:00:00'),
+      })
+    ).toEqual({ spirit: 0, faded: true, active: true });
+  });
+});

--- a/src/lib/spirit.ts
+++ b/src/lib/spirit.ts
@@ -1,0 +1,58 @@
+import { Env } from '@env';
+
+const DECAY_PER_DAY = 20;
+const MAX_SPIRIT = 100;
+
+export const isSpiritFadingEnabled = (): boolean =>
+  Env.SPIRIT_FADING_ENABLED === 'true';
+
+/** Whole local calendar days between two epoch-ms instants (0 if same local day). */
+export const idleDaysBetween = (fromMs: number, toMs: number): number => {
+  const from = new Date(fromMs);
+  const to = new Date(toMs);
+  const fromMidnight = new Date(
+    from.getFullYear(),
+    from.getMonth(),
+    from.getDate()
+  ).getTime();
+  const toMidnight = new Date(
+    to.getFullYear(),
+    to.getMonth(),
+    to.getDate()
+  ).getTime();
+  const days = Math.floor((toMidnight - fromMidnight) / 86_400_000);
+  return Math.max(0, days);
+};
+
+export const spiritFromIdleDays = (idleDays: number): number =>
+  Math.max(0, MAX_SPIRIT - DECAY_PER_DAY * idleDays);
+
+export type SpiritDisplay = {
+  spirit: number | null;
+  faded: boolean;
+  active: boolean;
+};
+
+/**
+ * Display spirit for the UI. Anchored to the server's last-reported value so a
+ * returning-lapsed user (server says 100 at launch) is never wrongly faded client-side.
+ * Decays only forward from serverSpiritAt.
+ */
+export const deriveDisplaySpirit = ({
+  serverSpirit,
+  serverSpiritAt,
+  now = Date.now(),
+}: {
+  serverSpirit: number | null;
+  serverSpiritAt: number | null;
+  now?: number;
+}): SpiritDisplay => {
+  if (serverSpirit === null || serverSpiritAt === null) {
+    return { spirit: null, faded: false, active: false };
+  }
+  const extraIdle = idleDaysBetween(serverSpiritAt, now);
+  const spirit = Math.max(0, serverSpirit - DECAY_PER_DAY * extraIdle);
+  return { spirit, faded: spirit === 0, active: true };
+};
+
+export { DECAY_PER_DAY, MAX_SPIRIT };

--- a/src/store/character-store.test.ts
+++ b/src/store/character-store.test.ts
@@ -422,4 +422,72 @@ describe('Character Store', () => {
       expect(result.current.dailyQuestStreak).toBe(1);
     });
   });
+
+  describe('spirit state', () => {
+    beforeEach(() => {
+      useCharacterStore.setState({
+        spiritRestoredAt: null,
+        restorationCount: 0,
+        serverSpirit: null,
+        serverSpiritAt: null,
+      });
+    });
+
+    it('setSpiritState records server spirit + a fetch timestamp', () => {
+      const before = Date.now();
+
+      act(() => {
+        useCharacterStore.getState().setSpiritState({
+          spirit: 100,
+          spiritRestoredAt: '2026-06-10T00:00:00Z',
+          restorationCount: 2,
+        });
+      });
+
+      const s = useCharacterStore.getState();
+      expect(s.serverSpirit).toBe(100);
+      expect(s.serverSpiritAt).toBeGreaterThanOrEqual(before);
+      expect(s.spiritRestoredAt).toBe('2026-06-10T00:00:00Z');
+      expect(s.restorationCount).toBe(2);
+    });
+
+    it('tolerates a null spirit (inactive user) and leaves the anchor null', () => {
+      // Seed a stale non-null anchor to prove the null case clears it.
+      act(() => {
+        useCharacterStore.setState({ serverSpirit: 50, serverSpiritAt: 123 });
+      });
+
+      act(() => {
+        useCharacterStore.getState().setSpiritState({
+          spirit: null,
+          spiritRestoredAt: null,
+          restorationCount: 0,
+        });
+      });
+
+      const s = useCharacterStore.getState();
+      expect(s.serverSpirit).toBeNull();
+      // No real spirit → no honest anchor timestamp to decay from.
+      expect(s.serverSpiritAt).toBeNull();
+    });
+
+    it('refillSpirit sets serverSpirit to 100 and re-anchors, leaving restorationCount untouched', () => {
+      act(() => {
+        useCharacterStore.setState({
+          restorationCount: 3,
+          serverSpirit: 20,
+          serverSpiritAt: 1,
+        });
+      });
+
+      act(() => {
+        useCharacterStore.getState().refillSpirit();
+      });
+
+      const s = useCharacterStore.getState();
+      expect(s.serverSpirit).toBe(100);
+      expect(s.serverSpiritAt).toBeGreaterThan(1);
+      expect(s.restorationCount).toBe(3);
+    });
+  });
 });

--- a/src/store/character-store.ts
+++ b/src/store/character-store.ts
@@ -9,6 +9,10 @@ interface CharacterState {
   character: Character | null;
   dailyQuestStreak: number;
   lastStreakCelebrationShown: number | null;
+  spiritRestoredAt: string | null;
+  restorationCount: number;
+  serverSpirit: number | null; // last server-reported spirit
+  serverSpiritAt: number | null; // epoch-ms when a non-null serverSpirit was recorded (null when spirit is null)
   createCharacter: (type: CharacterType, name: string) => void;
   updateCharacter: (updatedCharacter: Partial<Character>) => void;
   addXP: (amount: XP) => void;
@@ -17,6 +21,12 @@ interface CharacterState {
   resetStreak: () => void;
   resetCharacter: () => void;
   markStreakCelebrationShown: () => void;
+  setSpiritState: (args: {
+    spirit: number | null;
+    spiritRestoredAt: string | null;
+    restorationCount: number;
+  }) => void;
+  refillSpirit: () => void;
 }
 
 const INITIAL_CHARACTER: Omit<Character, 'type' | 'name'> = {
@@ -48,6 +58,10 @@ export const useCharacterStore = create<CharacterState>()(
       character: null,
       dailyQuestStreak: 0,
       lastStreakCelebrationShown: null,
+      spiritRestoredAt: null,
+      restorationCount: 0,
+      serverSpirit: null,
+      serverSpiritAt: null,
       createCharacter: (type, name) =>
         set({
           character: {
@@ -104,6 +118,10 @@ export const useCharacterStore = create<CharacterState>()(
           character: null,
           dailyQuestStreak: 0,
           lastStreakCelebrationShown: null,
+          spiritRestoredAt: null,
+          restorationCount: 0,
+          serverSpirit: null,
+          serverSpiritAt: null,
         }));
       },
 
@@ -172,6 +190,22 @@ export const useCharacterStore = create<CharacterState>()(
       markStreakCelebrationShown: () => {
         set({ lastStreakCelebrationShown: Date.now() });
       },
+
+      // Method to sync server-reported spirit (and restoration metadata) from a user fetch.
+      // Only stamp a real anchor timestamp when there's a real spirit value to decay from;
+      // a null spirit (inactive/dormant user) leaves the anchor null so the UI stays inactive.
+      setSpiritState: ({ spirit, spiritRestoredAt, restorationCount }) =>
+        set({
+          serverSpirit: spirit,
+          serverSpiritAt: spirit === null ? null : Date.now(),
+          spiritRestoredAt,
+          restorationCount,
+        }),
+
+      // Optimistic full refill after a quest completion. Touches ONLY the derivation anchor —
+      // NOT spiritRestoredAt/restorationCount (those change only via a Restoration).
+      refillSpirit: () =>
+        set({ serverSpirit: 100, serverSpiritAt: Date.now() }),
     }),
     {
       name: 'character-storage',

--- a/src/store/quest-store.test.ts
+++ b/src/store/quest-store.test.ts
@@ -91,6 +91,7 @@ jest.mock('@/app/data/quests', () => {
 const mockUpdateStreak = jest.fn();
 const mockAddXP = jest.fn();
 const mockResetStreak = jest.fn();
+const mockRefillSpirit = jest.fn();
 
 // Mock the character store
 jest.mock('@/store/character-store', () => ({
@@ -99,6 +100,7 @@ jest.mock('@/store/character-store', () => ({
       updateStreak: mockUpdateStreak,
       addXP: mockAddXP,
       resetStreak: mockResetStreak,
+      refillSpirit: mockRefillSpirit,
     }),
   },
 }));
@@ -128,6 +130,7 @@ jest.mock('@/api/common', () => ({
 jest.mock('@/lib/services/notifications', () => ({
   cancelStreakWarningNotification: jest.fn().mockResolvedValue(undefined),
   scheduleStreakWarningNotification: jest.fn().mockResolvedValue(undefined),
+  cancelSpiritCommitmentReminders: jest.fn().mockResolvedValue(true),
 }));
 
 // Create mock for POI store
@@ -598,6 +601,38 @@ describe('QuestStore - refreshAvailableQuests', () => {
       // Wait for the promise chain to complete
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(scheduleStreakWarningNotification).toHaveBeenCalledWith(true);
+    });
+
+    test('should refill spirit and cancel spirit commitment reminders on completion', async () => {
+      // Arrange
+      const startTime = Date.now() - 600000; // 10 minutes ago
+      const activeQuest = {
+        id: 'quest-1',
+        mode: 'story' as const,
+        title: 'Test Quest',
+        durationMinutes: 10,
+        reward: { xp: 100 },
+        startTime,
+        status: 'active' as const,
+      } as Quest;
+
+      useQuestStore.setState({
+        activeQuest,
+        completedQuests: [],
+        lastCompletedQuestTimestamp: null,
+      });
+
+      const {
+        cancelSpiritCommitmentReminders,
+      } = require('@/lib/services/notifications');
+
+      // Act
+      await useQuestStore.getState().completeQuest();
+
+      // Assert - Spirit refills and pending commitment reminders are cancelled
+      // on every completion, regardless of whether it's the first quest today.
+      expect(mockRefillSpirit).toHaveBeenCalled();
+      expect(cancelSpiritCommitmentReminders).toHaveBeenCalled();
     });
 
     test('should complete quest with ignoreDuration flag', async () => {
@@ -1170,7 +1205,9 @@ describe('QuestStore - refreshAvailableQuests', () => {
       });
 
       // Complete the quest
-      const completedQuest = await await useQuestStore.getState().completeQuest();
+      const completedQuest = await await useQuestStore
+        .getState()
+        .completeQuest();
 
       expect(completedQuest).not.toBeNull();
       expect(cancelStreakWarningNotification).toHaveBeenCalled();
@@ -1198,7 +1235,9 @@ describe('QuestStore - refreshAvailableQuests', () => {
         completedQuests: [],
       });
 
-      const completedQuest = await await useQuestStore.getState().completeQuest();
+      const completedQuest = await await useQuestStore
+        .getState()
+        .completeQuest();
 
       expect(completedQuest).not.toBeNull();
       expect(completedQuest?.status).toBe('completed');
@@ -1241,10 +1280,12 @@ describe('QuestStore - refreshAvailableQuests', () => {
       const { useCharacterStore } = require('@/store/character-store');
       const mockAddXP = jest.fn();
       const mockUpdateStreak = jest.fn();
+      const localMockRefillSpirit = jest.fn();
 
       useCharacterStore.getState = jest.fn(() => ({
         addXP: mockAddXP,
         updateStreak: mockUpdateStreak,
+        refillSpirit: localMockRefillSpirit,
       }));
 
       const testQuest: Quest = {
@@ -1264,7 +1305,9 @@ describe('QuestStore - refreshAvailableQuests', () => {
         lastCompletedQuestTimestamp: null,
       });
 
-      const completedQuest = await await useQuestStore.getState().completeQuest();
+      const completedQuest = await await useQuestStore
+        .getState()
+        .completeQuest();
 
       expect(completedQuest).not.toBeNull();
       expect(mockAddXP).toHaveBeenCalledWith(150);
@@ -1288,7 +1331,9 @@ describe('QuestStore - refreshAvailableQuests', () => {
         completedQuests: [],
       });
 
-      const completedQuest = await await useQuestStore.getState().completeQuest();
+      const completedQuest = await await useQuestStore
+        .getState()
+        .completeQuest();
 
       expect(completedQuest).not.toBeNull();
       expect(mockRevealLocation).toHaveBeenCalledWith('test-poi');

--- a/src/store/quest-store.ts
+++ b/src/store/quest-store.ts
@@ -5,6 +5,7 @@ import { queryClient } from '@/api/common';
 import type { QuestTemplate } from '@/api/quest/types';
 import { AVAILABLE_QUESTS } from '@/app/data/quests';
 import {
+  cancelSpiritCommitmentReminders,
   cancelStreakWarningNotification,
   scheduleStreakWarningNotification,
 } from '@/lib/services/notifications';
@@ -156,8 +157,13 @@ export const useQuestStore = create<QuestState>()(
             // Fetch quest run data from server to get participant rewards
             if (questRunId) {
               try {
-                console.log('[QuestStore] Fetching quest run data to get rewards:', questRunId);
-                const { getQuestRunStatus } = await import('@/lib/services/quest-run-service');
+                console.log(
+                  '[QuestStore] Fetching quest run data to get rewards:',
+                  questRunId
+                );
+                const { getQuestRunStatus } = await import(
+                  '@/lib/services/quest-run-service'
+                );
                 const questRunData = await getQuestRunStatus(questRunId);
 
                 console.log('[QuestStore] Quest run data received:', {
@@ -169,22 +175,32 @@ export const useQuestStore = create<QuestState>()(
 
                 // Add participants with rewards to the completed quest
                 if (questRunData.participants) {
-                  completedQuest.participants = questRunData.participants.map((p: any) => ({
-                    userId: typeof p === 'string' ? p : p.userId,
-                    ready: typeof p === 'object' ? p.ready : true,
-                    status: typeof p === 'object' ? p.status : 'completed',
-                    phoneLocked: typeof p === 'object' ? p.phoneLocked : undefined,
-                    rewards: typeof p === 'object' ? p.rewards : undefined,
-                  }));
+                  completedQuest.participants = questRunData.participants.map(
+                    (p: any) => ({
+                      userId: typeof p === 'string' ? p : p.userId,
+                      ready: typeof p === 'object' ? p.ready : true,
+                      status: typeof p === 'object' ? p.status : 'completed',
+                      phoneLocked:
+                        typeof p === 'object' ? p.phoneLocked : undefined,
+                      rewards: typeof p === 'object' ? p.rewards : undefined,
+                    })
+                  );
 
-                  console.log('[QuestStore] Added participant rewards to completed quest:', {
-                    questId: completedQuest.id,
-                    participantCount: completedQuest.participants.length,
-                    firstParticipantRewards: completedQuest.participants[0]?.rewards,
-                  });
+                  console.log(
+                    '[QuestStore] Added participant rewards to completed quest:',
+                    {
+                      questId: completedQuest.id,
+                      participantCount: completedQuest.participants.length,
+                      firstParticipantRewards:
+                        completedQuest.participants[0]?.rewards,
+                    }
+                  );
                 }
               } catch (error) {
-                console.error('[QuestStore] Failed to fetch quest run data for rewards:', error);
+                console.error(
+                  '[QuestStore] Failed to fetch quest run data for rewards:',
+                  error
+                );
                 // Continue with base completed quest if fetch fails
               }
             }
@@ -298,6 +314,14 @@ export const useQuestStore = create<QuestState>()(
             queryClient.invalidateQueries({
               queryKey: ['next-available-quests'] as const,
             });
+
+            // Any completion refills Spirit — optimistic local update; server confirms via ['user','details'] invalidation.
+            useCharacterStore.getState().refillSpirit();
+
+            // Cancel any pending Restoration bridge reminders — the user is questing again.
+            cancelSpiritCommitmentReminders().catch((err) =>
+              console.error('cancel spirit reminders', err)
+            );
 
             // If this is the first quest completed today, cancel today's warning
             // and schedule tomorrow's warning

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -93,6 +93,9 @@ export interface User {
   dailyQuestStreak: number;
   featureFlags: string[];
   isProvisional: boolean;
+  spirit: number | null;
+  spiritRestoredAt: string | null;
+  restorationCount: number;
 }
 
 export type POI = {


### PR DESCRIPTION
## Summary

Client half of the Spirit feature, entirely behind `SPIRIT_FADING_ENABLED` (**false in production**; true in dev/staging/preview):

- **SpiritMeter**: 5-segment meter on home (beside the streak counter) and profile stats; display value decays −20/day but is *anchored to the server's `spirit` from `/users/me`* and only decays forward from the fetch — a returning-lapsed user is never wrongly locked client-side
- **The Fading**: at spirit 0, a FadingCard replaces the home quest carousel; all quest-start paths (story selection, custom creation, coop start/ready) gate on `isFadedNow()`, with the server's `403 SPIRIT_FADED` handled in the Axios interceptor as a backstop (redirect home + invalidate `['user','details']`)
- **Restoration**: full-screen 4-step flow at `/restoration` (challenges → journal → commitment time → visualization) posting to `POST /v1/restorations`; on success it refills the local meter, writes the committed hour into streak-warning settings, and schedules 3 one-shot `spirit_commitment` local reminders (cancelled on next quest completion)
- OneSignal push routing for `spirit_warning` / `spirit_faded` → home
- Quest completion optimistically refills spirit locally; server stays authoritative

## Status

- All 19 plan tasks implemented TDD-style, one atomic commit per task
- Suite green in the branch worktree: 122 suites / 1,364 tests
- **Server must merge + deploy first (dormant)**: tommyshellberg/emberglow-server#59

## Known follow-ups (deferred by design — do not merge yet)

- **SDK 54 rebase**: branch is based pre-#339 (~143 commits behind v2.0.0 main); expect conflicts
- **Presence overlap**: 8 shared files with `feat/unified-quest-presence-mobile` (both quest-start gate sites, `quest-store`, `_layout`, `notifications`, types). Whichever lands second resolves; the invariant to preserve is `isFadedNow()` gating **both** lock-mode and presence-mode starts
- Final `pnpm check-all` + prettier pass on the rebased branch
- Go-live: flip `SPIRIT_FADING_ENABLED=true` in `.env.production` only when the server `SPIRIT_EPOCH` is set (see #59 rollout notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)