### PR TITLE
fix: cooperative lobby ready events never propagate (screen-transition lobby:leave cancels the lobby)

### DIFF
--- a/src/app/cooperative-quest-lobby/[lobbyId].tsx
+++ b/src/app/cooperative-quest-lobby/[lobbyId].tsx
@@ -347,8 +347,11 @@ export default function CooperativeQuestLobby() {
       on(`invitation:${lobbyId}:accepted`, handleInvitationAccepted); // Specific invitation event
       on('lobby:ready-status', handleReadyStatus);
 
+      // No lobby:leave here: this cleanup also runs on the transition to the
+      // ready screen (and on any effect re-run), and the server cancels the
+      // whole lobby when the host leaves. Leaving is an explicit user action
+      // handled in handleBackPress.
       return () => {
-        emit('lobby:leave', { lobbyId });
         off('lobby:joined', handleLobbyJoined);
         off('lobby:participant-joined', handleParticipantJoined);
         off('lobby:participant-updated', handleParticipantUpdated);
@@ -593,6 +596,7 @@ export default function CooperativeQuestLobby() {
       {/* Header */}
       <View className="mb-6 mt-2 px-4">
         <TouchableOpacity
+          testID="lobby-back-button"
           onPress={handleBackPress}
           className="mb-4 flex-row items-center"
         >

--- a/src/app/cooperative-quest-lobby/lobby.test.tsx
+++ b/src/app/cooperative-quest-lobby/lobby.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Alert } from 'react-native';
 
 import { fireEvent, render, screen, waitFor } from '@/lib/test-utils';
 import { useCooperativeLobbyStore } from '@/store/cooperative-lobby-store';
@@ -239,13 +240,33 @@ describe('CooperativeQuestLobby', () => {
     expect(declineButton).toBeTruthy();
   });
 
-  it('should leave WebSocket room on unmount', () => {
+  // The lobby -> ready screen transition unmounts this screen while the same
+  // socket stays connected. A leave emitted here makes the server treat the
+  // host as having abandoned the lobby and cancel it for everyone, so leaving
+  // must only happen through the explicit back-out flow.
+  it('should NOT emit lobby:leave on unmount', () => {
     const { unmount } = render(<CooperativeQuestLobby />);
 
     unmount();
 
+    expect(mockEmit).not.toHaveBeenCalledWith('lobby:leave', expect.anything());
+  });
+
+  it('emits lobby:leave when the creator explicitly confirms leaving', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    render(<CooperativeQuestLobby />);
+
+    fireEvent.press(screen.getByTestId('lobby-back-button'));
+
+    const leaveButton = alertSpy.mock.calls[0]?.[2]?.find(
+      (button) => button.text === 'Leave'
+    );
+    expect(leaveButton).toBeTruthy();
+    leaveButton?.onPress?.();
+
     expect(mockEmit).toHaveBeenCalledWith('lobby:leave', {
       lobbyId: 'test-lobby-123',
+      userId: 'creator-123',
     });
   });
 });

--- a/src/app/cooperative-quest-ready.test.tsx
+++ b/src/app/cooperative-quest-ready.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+
+import { act, render, screen } from '@/lib/test-utils';
+import { useCooperativeLobbyStore } from '@/store/cooperative-lobby-store';
+import { useUserStore } from '@/store/user-store';
+
+import CooperativeQuestReady from './cooperative-quest-ready';
+
+// Mock the router. The object must be referentially stable across renders
+// (like the real expo-router router) — the screen keys effects on it.
+const mockReplace = jest.fn();
+const mockBack = jest.fn();
+const mockRouter = { replace: mockReplace, back: mockBack };
+
+jest.mock('expo-router', () => ({
+  useRouter: () => mockRouter,
+}));
+
+// Mock the WebSocket. The screen imports useWebSocket from
+// websocket-provider, which re-exports it from lazy-websocket-provider, so
+// mocking the lazy module covers both import paths.
+const mockEmit = jest.fn().mockReturnValue(true);
+const mockOn = jest.fn();
+const mockOff = jest.fn();
+
+jest.mock('@/components/providers/lazy-websocket-provider', () => ({
+  useLazyWebSocket: () => ({
+    emit: mockEmit,
+    on: mockOn,
+    off: mockOff,
+    joinQuestRoom: jest.fn(),
+    leaveQuestRoom: jest.fn(),
+    isConnected: true,
+    isEnabled: true,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    forceReconnect: jest.fn(),
+  }),
+  useWebSocket: () => ({
+    emit: mockEmit,
+    on: mockOn,
+    off: mockOff,
+    joinQuestRoom: jest.fn(),
+    leaveQuestRoom: jest.fn(),
+    isConnected: true,
+    forceReconnect: jest.fn(),
+    addListener: mockOn,
+    removeListener: mockOff,
+  }),
+  LazyWebSocketProvider: ({ children }: { children: any }) => children,
+}));
+
+jest.mock('@/lib/services/quest-timer', () => ({
+  __esModule: true,
+  default: {
+    prepareQuest: jest.fn(),
+  },
+}));
+
+describe('CooperativeQuestReady', () => {
+  const mockLobby = {
+    lobbyId: 'test-lobby-123',
+    questTitle: 'Test Quest',
+    questDuration: 30,
+    creatorId: 'creator-123',
+    participants: [
+      {
+        id: 'creator-123',
+        username: 'Creator',
+        invitationStatus: 'accepted',
+        isReady: false,
+        isCreator: true,
+        joinedAt: new Date(),
+      },
+      {
+        id: 'invitee-123',
+        username: 'Invitee',
+        invitationStatus: 'accepted',
+        isReady: false,
+        isCreator: false,
+        joinedAt: new Date(),
+      },
+    ],
+    status: 'waiting',
+    createdAt: new Date(),
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+  };
+
+  const mockUser = {
+    id: 'creator-123',
+    email: 'creator@test.com',
+    character: {
+      name: 'Creator',
+      type: 'knight',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEmit.mockReturnValue(true);
+
+    useCooperativeLobbyStore.setState({
+      currentLobby: mockLobby as any,
+      isInLobby: true,
+      countdownSeconds: null,
+    });
+
+    useUserStore.setState({
+      user: mockUser as any,
+    });
+  });
+
+  it('joins the lobby room on mount', () => {
+    render(<CooperativeQuestReady />);
+
+    expect(mockEmit).toHaveBeenCalledWith('lobby:join', {
+      lobbyId: 'test-lobby-123',
+    });
+  });
+
+  // Every ready-status update replaces currentLobby in the store. If the
+  // socket effect is keyed on anything derived from that object, the update
+  // re-runs it and the cleanup fires lobby:leave — which the server treats as
+  // the host abandoning the lobby and cancels it for everyone.
+  it('does not emit lobby:leave when the roster updates', () => {
+    render(<CooperativeQuestReady />);
+
+    act(() => {
+      useCooperativeLobbyStore.getState().markUserReady('invitee-123', true);
+    });
+
+    expect(mockEmit).not.toHaveBeenCalledWith('lobby:leave', expect.anything());
+  });
+
+  it('keeps listening for lobby:ready-status after roster updates', () => {
+    render(<CooperativeQuestReady />);
+
+    act(() => {
+      useCooperativeLobbyStore.getState().markUserReady('invitee-123', true);
+    });
+
+    const registered = mockOn.mock.calls.filter(
+      ([event]) => event === 'lobby:ready-status'
+    ).length;
+    const removed = mockOff.mock.calls.filter(
+      ([event]) => event === 'lobby:ready-status'
+    ).length;
+
+    expect(registered - removed).toBe(1);
+  });
+
+  it('does not emit lobby:leave on unmount', () => {
+    const { unmount } = render(<CooperativeQuestReady />);
+
+    unmount();
+
+    expect(mockEmit).not.toHaveBeenCalledWith('lobby:leave', expect.anything());
+  });
+
+  it('applies incoming lobby:ready-status events to the roster', () => {
+    render(<CooperativeQuestReady />);
+
+    const readyStatusHandler = mockOn.mock.calls.find(
+      ([event]) => event === 'lobby:ready-status'
+    )?.[1];
+    expect(readyStatusHandler).toBeTruthy();
+
+    act(() => {
+      readyStatusHandler({ userId: 'invitee-123', isReady: true });
+    });
+
+    expect(screen.getByText('Ready!')).toBeTruthy();
+  });
+});

--- a/src/app/cooperative-quest-ready.tsx
+++ b/src/app/cooperative-quest-ready.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'expo-router';
 import { Check, Circle, Clock } from 'lucide-react-native';
 import { usePostHog } from 'posthog-react-native';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, Alert } from 'react-native';
 
 import { useWebSocket } from '@/components/providers/websocket-provider';
@@ -76,21 +76,10 @@ export default function CooperativeQuestReady() {
   const markUserReady = useCooperativeLobbyStore(
     (state) => state.markUserReady
   );
-  const updateLobbyStatus = useCooperativeLobbyStore(
-    (state) => state.updateLobbyStatus
-  );
-  const updateParticipant = useCooperativeLobbyStore(
-    (state) => state.updateParticipant
-  );
-  const setCountdown = useCooperativeLobbyStore((state) => state.setCountdown);
-  const countdownSeconds = useCooperativeLobbyStore(
-    (state) => state.countdownSeconds
-  );
   const prepareQuest = useQuestStore((state) => state.prepareQuest);
 
   const { emit, on, off } = useWebSocket();
   const [isLoading, setIsLoading] = useState(false);
-  const [hasJoined, setHasJoined] = useState(false);
 
   // Define the quest created handler. Declared here (rather than after the
   // `if (!currentLobby...) return` below) because the effect below lists it
@@ -185,79 +174,86 @@ export default function CooperativeQuestReady() {
     [currentLobby, prepareQuest]
   );
 
+  // The quest-created handler closes over currentLobby, whose identity
+  // changes on every roster/ready update. The socket effect below must not
+  // re-run on those updates (its cleanup would tear down listeners), so the
+  // effect reaches the latest handler through a ref instead of a dependency.
+  const handleQuestCreatedRef = useRef(handleQuestCreatedResponse);
   useEffect(() => {
-    if (!currentLobby) {
+    handleQuestCreatedRef.current = handleQuestCreatedResponse;
+  });
+
+  const lobbyId = currentLobby?.lobbyId;
+  const hasLobby = !!currentLobby;
+
+  useEffect(() => {
+    if (!hasLobby) {
       router.replace('/');
+    }
+  }, [hasLobby, router]);
+
+  useEffect(() => {
+    if (!lobbyId) {
       return;
     }
 
-    // Prevent multiple joins
-    if (hasJoined) {
-      return;
-    }
-
-    // Join the lobby room to receive updates
+    // Join the lobby room to receive updates. Joining is idempotent
+    // server-side, so a remount after the lobby screen simply re-enters the
+    // same room.
     if (__DEV__) {
-      console.log('Ready screen joining lobby:', currentLobby.lobbyId);
+      console.log('Ready screen joining lobby:', lobbyId);
     }
-    emit('lobby:join', { lobbyId: currentLobby.lobbyId });
-    setHasJoined(true);
+    emit('lobby:join', { lobbyId });
 
-    // Listen for lobby joined event to get latest participant data
+    // Handlers read store actions via getState() so the effect needs no
+    // store-derived dependencies and stays mounted for the lobby's lifetime.
     const handleLobbyJoined = (data: any) => {
       if (__DEV__) {
         console.log('Ready screen - lobby joined data:', data);
       }
-      if (data.lobbyId === currentLobby.lobbyId && data.participants) {
-        // Update participant names and ready states from server
+      if (data.lobbyId === lobbyId && data.participants) {
+        const store = useCooperativeLobbyStore.getState();
         data.participants.forEach((p: any) => {
-          updateParticipant(p.userId, {
+          store.updateParticipant(p.userId, {
             username: p.characterName || p.username || p.userId,
           });
-          // Also update ready state from server data
           if (p.ready !== undefined) {
-            markUserReady(p.userId, p.ready);
+            store.markUserReady(p.userId, p.ready);
           }
         });
       }
     };
 
-    // Listen for ready status updates
     const handleReadyStatus = (data: LobbyReadyStatusPayload) => {
       if (__DEV__) {
         console.log('Ready status update:', data);
       }
-      markUserReady(data.userId, data.isReady);
+      useCooperativeLobbyStore
+        .getState()
+        .markUserReady(data.userId, data.isReady);
     };
 
-    // Listen for participant ready events (server sends these)
     const handleParticipantReady = (data: any) => {
-      if (__DEV__) {
-        console.log('Participant ready event:', data);
-      }
       if (data.userId && data.participant) {
-        markUserReady(data.userId, data.participant.ready || false);
+        useCooperativeLobbyStore
+          .getState()
+          .markUserReady(data.userId, data.participant.ready || false);
       }
     };
 
-    // Listen for all participants ready event
     const handleAllReady = (data: any) => {
-      if (__DEV__) {
-        console.log('All participants ready:', data);
-      }
-      if (data.allReady && data.lobbyId === currentLobby.lobbyId) {
-        updateLobbyStatus('ready');
+      if (data.allReady && data.lobbyId === lobbyId) {
+        useCooperativeLobbyStore.getState().updateLobbyStatus('ready');
       }
     };
 
-    // Listen for quest created event
-    const handleQuestCreated = async (data: any) => {
+    const handleQuestCreated = (data: any) => {
       if (__DEV__) {
         console.log('Quest created event received:', data);
       }
       // Server sends { questRun, startCountdown }
       if (data.questRun && data.startCountdown) {
-        handleQuestCreatedResponse(data.questRun);
+        handleQuestCreatedRef.current(data.questRun);
       }
     };
 
@@ -267,42 +263,32 @@ export default function CooperativeQuestReady() {
     on('lobby:all-participants-ready', handleAllReady);
     on('lobby:quest-created', handleQuestCreated);
 
+    // No lobby:leave here: this cleanup also runs when the screen transitions
+    // into the pending-quest flow while the same socket stays connected, and
+    // the server cancels the whole lobby when the host leaves. Leaving is the
+    // explicit user action handled in handleBackPress.
     return () => {
-      if (currentLobby?.lobbyId) {
-        emit('lobby:leave', { lobbyId: currentLobby.lobbyId });
-      }
       off('lobby:joined', handleLobbyJoined);
       off('lobby:ready-status', handleReadyStatus);
       off('lobby:participant-ready', handleParticipantReady);
       off('lobby:all-participants-ready', handleAllReady);
       off('lobby:quest-created', handleQuestCreated);
-      setHasJoined(false);
     };
-  }, [
-    currentLobby?.lobbyId, // Only depend on lobbyId, not the whole object
-    emit,
-    on,
-    off,
-    router,
-    handleQuestCreatedResponse, // Include to avoid stale closure
-  ]);
+  }, [lobbyId, emit, on, off]);
 
-  if (!currentLobby || !currentUser) {
-    return (
-      <View className="flex-1 items-center justify-center">
-        <ActivityIndicator size="large" />
-      </View>
-    );
-  }
-
-  const currentParticipant = currentLobby.participants.find(
-    (p) => p.id === currentUser.id
+  // Derived state and the hooks below must run on every render (including
+  // the loading/null-lobby render) so the hook order never changes.
+  const currentParticipant = currentLobby?.participants.find(
+    (p) => p.id === currentUser?.id
   );
   const isReady = currentParticipant?.isReady || false;
-  const acceptedParticipants = currentLobby.participants.filter(
-    (p) => p.invitationStatus === 'accepted'
-  );
-  const allReady = acceptedParticipants.every((p) => p.isReady);
+  const acceptedParticipants =
+    currentLobby?.participants.filter(
+      (p) => p.invitationStatus === 'accepted'
+    ) ?? [];
+  const allReady =
+    acceptedParticipants.length > 0 &&
+    acceptedParticipants.every((p) => p.isReady);
   const isCreator = currentParticipant?.isCreator || false;
 
   // When all are ready, creator should create the quest
@@ -358,7 +344,7 @@ export default function CooperativeQuestReady() {
         },
       ]
     );
-  }, [currentLobby, currentUser, emit, leaveLobby, router]);
+  }, [currentLobby, currentUser, emit, leaveLobby, posthog, router]);
 
   const handleReadyToggle = () => {
     if (!currentUser || !currentLobby) return;
@@ -392,6 +378,14 @@ export default function CooperativeQuestReady() {
 
     setIsLoading(false);
   };
+
+  if (!currentLobby || !currentUser) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
 
   return (
     <ScreenContainer fullScreen noPadding>

--- a/src/components/providers/lazy-websocket-provider.test.tsx
+++ b/src/components/providers/lazy-websocket-provider.test.tsx
@@ -1,0 +1,76 @@
+import { act, render } from '@testing-library/react-native';
+import React from 'react';
+
+import { webSocketService } from '@/lib/services/websocket-service';
+
+import {
+  LazyWebSocketProvider,
+  useLazyWebSocket,
+} from './lazy-websocket-provider';
+
+jest.mock('@/lib/services/websocket-service', () => ({
+  webSocketService: {
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+    joinQuestRoom: jest.fn(),
+    leaveQuestRoom: jest.fn(),
+    forceReconnect: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/auth', () => ({
+  useAuth: (selector: any) => selector({ status: 'signIn' }),
+}));
+
+jest.mock('@/lib/storage', () => ({
+  getItem: jest.fn(() => null),
+}));
+
+describe('LazyWebSocketProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Screens key their socket effects on emit/on/off. If the provider hands
+  // out new identities on re-render (e.g. connection status flips), every
+  // consumer effect re-runs its cleanup — which historically emitted
+  // lobby:leave and killed cooperative lobbies.
+  it('provides referentially stable emit/on/off across re-renders', () => {
+    const captured: any[] = [];
+    function Probe() {
+      captured.push(useLazyWebSocket());
+      return null;
+    }
+
+    render(
+      <LazyWebSocketProvider>
+        <Probe />
+      </LazyWebSocketProvider>
+    );
+
+    // Fire the provider's own 'connect' listener to flip isConnected and
+    // force a provider re-render.
+    const connectHandler = (webSocketService.on as jest.Mock).mock.calls.find(
+      ([event]) => event === 'connect'
+    )?.[1];
+    expect(connectHandler).toBeTruthy();
+
+    act(() => {
+      connectHandler();
+    });
+
+    expect(captured.length).toBeGreaterThan(1);
+    const first = captured[0];
+    const last = captured[captured.length - 1];
+
+    expect(last.isConnected).toBe(true);
+    expect(last.emit).toBe(first.emit);
+    expect(last.on).toBe(first.on);
+    expect(last.off).toBe(first.off);
+    expect(last.joinQuestRoom).toBe(first.joinQuestRoom);
+    expect(last.leaveQuestRoom).toBe(first.leaveQuestRoom);
+  });
+});

--- a/src/components/providers/lazy-websocket-provider.tsx
+++ b/src/components/providers/lazy-websocket-provider.tsx
@@ -1,7 +1,9 @@
 import React, {
   createContext,
+  useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -91,7 +93,7 @@ export const LazyWebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [authStatus]);
 
   // Manual connect function
-  const connect = () => {
+  const connect = useCallback(() => {
     if (__DEV__) {
       console.log(
         '[LazyWebSocket] Connect called - authStatus:',
@@ -111,16 +113,16 @@ export const LazyWebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
     } else if (__DEV__) {
       console.log('[LazyWebSocket] Not connecting - conditions not met');
     }
-  };
+  }, [authStatus, hasProvisionalToken, isEnabled]);
 
   // Manual disconnect function
-  const disconnect = () => {
+  const disconnect = useCallback(() => {
     if (__DEV__) {
       console.log('[LazyWebSocket] Manually disconnecting WebSocket...');
     }
     setIsEnabled(false);
     webSocketService.disconnect();
-  };
+  }, []);
 
   // Handle connection state changes
   useEffect(() => {
@@ -188,18 +190,31 @@ export const LazyWebSocketProvider: React.FC<{ children: React.ReactNode }> = ({
     };
   }, [isEnabled]);
 
-  const value: LazyWebSocketContextValue = {
-    isConnected,
-    isEnabled,
-    connect,
-    disconnect,
-    on: webSocketService.on.bind(webSocketService),
-    off: webSocketService.off.bind(webSocketService),
-    emit: webSocketService.emit.bind(webSocketService),
-    joinQuestRoom: webSocketService.joinQuestRoom.bind(webSocketService),
-    leaveQuestRoom: webSocketService.leaveQuestRoom.bind(webSocketService),
-    forceReconnect: webSocketService.forceReconnect.bind(webSocketService),
-  };
+  // Bind the service methods once. Screens key their socket effects on
+  // emit/on/off, so fresh identities on every provider re-render would re-run
+  // those effects (and their cleanup) on every connection-status flip.
+  const serviceMethods = useMemo(
+    () => ({
+      on: webSocketService.on.bind(webSocketService),
+      off: webSocketService.off.bind(webSocketService),
+      emit: webSocketService.emit.bind(webSocketService),
+      joinQuestRoom: webSocketService.joinQuestRoom.bind(webSocketService),
+      leaveQuestRoom: webSocketService.leaveQuestRoom.bind(webSocketService),
+      forceReconnect: webSocketService.forceReconnect.bind(webSocketService),
+    }),
+    []
+  );
+
+  const value: LazyWebSocketContextValue = useMemo(
+    () => ({
+      isConnected,
+      isEnabled,
+      connect,
+      disconnect,
+      ...serviceMethods,
+    }),
+    [isConnected, isEnabled, connect, disconnect, serviceMethods]
+  );
 
   return (
     <LazyWebSocketContext.Provider value={value}>


### PR DESCRIPTION
## Summary

Cooperative quest lobbies looked functional but could never start: participants saw each other, toggled "I'm Ready", and nothing propagated in either direction. Root cause is fully client-side and deterministic — the lobby was being **cancelled server-side by our own screen lifecycle**.

## Root cause

1. Both coop screens emitted `lobby:leave` from their effect **cleanup**, which fires on the lobby→ready `router.replace` transition (and on any effect re-run) — not just on real exits. The server treats a host `lobby:leave` as abandonment and cancels the invitation immediately.
2. Every subsequent `lobby:join` then fails with `lobby:error` — which no screen listens for — so both sockets silently end up outside the Socket.IO room. `lobby:ready` still persists to the DB and broadcasts into an empty room, which is why it looked half-working.
3. Independently, the ready screen's socket effect was keyed on a callback rebuilt from the whole `currentLobby` object, so a user's own optimistic ready-toggle re-ran the effect; its cleanup emitted another host-leave and the `hasJoined` guard then blocked re-join and listener re-registration (deaf socket).
4. `LazyWebSocketProvider` handed out fresh `.bind()` identities every render, multiplying the effect churn.

## Fix (three atomic commits)

- **provider**: memoize the context value so `emit`/`on`/`off` are referentially stable
- **lobby screen**: `lobby:leave` only from the explicit back-out flow, never from unmount cleanup
- **ready screen**: socket effect keyed on `lobbyId` alone (handlers via ref/`getState()`), no leave in cleanup; also hoists hooks above the null-lobby early return, fixing a pre-existing rules-of-hooks violation

Server untouched — its lobby handlers behave correctly; the designed "host explicitly leaves → cancel lobby" flow is preserved.

## Verification

- TDD: each behavior has a test that was watched failing first, including a new `cooperative-quest-ready.test.tsx` (screen previously had zero coverage)
- 87/87 tests across all 10 coop/websocket suites; eslint and tsc deltas clean vs `main`
- The pre-existing `lobby.test.tsx` unmount test pinned the buggy behavior (asserted the leave emit) and was rewritten to the product contract

## Notes for QA

- Two-device retest required; **both devices must run this build** — one unfixed client hosting still cancels the lobby for everyone
- Parked follow-ups: client listeners for `lobby:cancelled`/`lobby:error` (still silent today), optional server grace-window on host `lobby:leave` for old clients, server integration test for cross-socket ready propagation
