### PR TITLE
fix: account creation only through onboarding

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -391,6 +391,7 @@ jest.mock('@react-native-google-signin/google-signin', () => ({
   GoogleSignin: {
     configure: jest.fn(),
     hasPlayServices: jest.fn().mockResolvedValue(true),
+    signOut: jest.fn().mockResolvedValue(undefined),
     signIn: jest.fn(),
   },
   statusCodes: { SIGN_IN_CANCELLED: 'SIGN_IN_CANCELLED' },

--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -1,5 +1,8 @@
 import { signIn } from '@/lib/auth';
-import { ExistingAccountConfirmationRequired } from '@/lib/auth/social';
+import {
+  ExistingAccountConfirmationRequired,
+  NoAccountForIdentity,
+} from '@/lib/auth/social';
 import { posthogClient } from '@/lib/posthog';
 import { getUserDetails } from '@/lib/services/user';
 import { getItem, removeItem } from '@/lib/storage';
@@ -584,6 +587,32 @@ describe('auth.ts', () => {
       (authClient.post as jest.Mock).mockRejectedValue(otherReason);
 
       await expect(socialSignIn(credential)).rejects.toBe(otherReason);
+    });
+
+    it('translates the no-account 404 into NoAccountForIdentity', async () => {
+      (getItem as jest.Mock).mockReturnValue(null);
+      (authClient.post as jest.Mock).mockRejectedValue(
+        axiosError(404, {
+          code: 404,
+          message: 'User not found',
+          details: {
+            reason: 'no-account-for-identity',
+            email: 'tommy@gmail.com',
+          },
+        })
+      );
+
+      const err = await socialSignIn(credential).catch((e) => e);
+
+      expect(err).toBeInstanceOf(NoAccountForIdentity);
+      expect(err).toMatchObject({ email: 'tommy@gmail.com' });
+    });
+
+    it('re-throws a 404 that carries no details', async () => {
+      const error = axiosError(404, {});
+      (authClient.post as jest.Mock).mockRejectedValue(error);
+
+      await expect(socialSignIn(credential)).rejects.toBe(error);
     });
 
     it('rethrows a non-axios failure as the very same object', async () => {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -6,7 +6,10 @@ import type {
   ExistingAccountSummary,
   SocialSignInOutcome,
 } from '@/lib/auth/social';
-import { ExistingAccountConfirmationRequired } from '@/lib/auth/social';
+import {
+  ExistingAccountConfirmationRequired,
+  NoAccountForIdentity,
+} from '@/lib/auth/social';
 import { posthogClient } from '@/lib/posthog';
 import { getUserDetails } from '@/lib/services/user';
 import { getItem, removeItem } from '@/lib/storage';
@@ -330,12 +333,23 @@ export const socialSignIn = async (
     // `any` — left off, a typo in `reason`/`account` below would read
     // `undefined` and silently fall through to the generic error copy.
     const details = axios.isAxiosError<{
-      details?: { reason?: string; account?: ExistingAccountSummary };
+      details?: {
+        reason?: string;
+        account?: ExistingAccountSummary;
+        email?: string;
+      };
     }>(error)
       ? error.response?.data?.details
       : undefined;
     if (details?.reason === 'existing-account-confirmation-required') {
       throw new ExistingAccountConfirmationRequired(details.account ?? {});
+    }
+    if (details?.reason === 'no-account-for-identity') {
+      // `?? ''` rather than a throw: the screen's copy already handles an empty
+      // address (it drops the "for <email>" clause), and failing the whole
+      // sign-in because a display string is missing would be a worse outcome
+      // than a slightly vaguer sentence.
+      throw new NoAccountForIdentity(details.email ?? '');
     }
     throw error;
   }

--- a/src/app/(app)/profile.test.tsx
+++ b/src/app/(app)/profile.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import type { Perk } from '@/api/skill-tree/types';
 import * as userService from '@/lib/services/user';
-import { cleanup, render, screen, setup, waitFor } from '@/lib/test-utils';
+import { act, cleanup, render, screen, setup, waitFor } from '@/lib/test-utils';
 import { useCharacterStore } from '@/store/character-store';
 import { useQuestStore } from '@/store/quest-store';
 import { useSkillTreeStore } from '@/store/skill-tree-store';
@@ -310,6 +310,41 @@ describe('ProfileScreen', () => {
       // Component should not render profile content
       expect(queryByText('Profile')).not.toBeOnTheScreen();
       expect(queryByText('Leaderboard')).not.toBeOnTheScreen();
+    });
+
+    // useCharacterSync restores a character asynchronously, so this component
+    // can re-render with one MORE hook than its previous render (useUserStore
+    // sits below the early return). React throws "Rendered more hooks than
+    // during the previous render" on exactly that transition.
+    it('survives a character arriving after the first render', () => {
+      useCharacterStore.setState({ character: null });
+      const { queryByTestId } = render(<ProfileScreen />);
+      expect(queryByTestId('profile-missing-character')).toBeOnTheScreen();
+
+      act(() => {
+        useCharacterStore.setState({
+          character: {
+            name: 'Tommy',
+            type: 'bard',
+            level: 1,
+            currentXP: 0,
+            xpToNextLevel: 100,
+          } as any,
+        });
+      });
+
+      expect(queryByTestId('profile-missing-character')).not.toBeOnTheScreen();
+    });
+
+    // A character-less account rendered `return null` here, which is
+    // indistinguishable from a crash: the screen was entirely blank, and the
+    // real defect stayed invisible until the server logs were read.
+    it('explains itself instead of rendering a blank screen when the character is missing', () => {
+      useCharacterStore.setState({ character: null });
+
+      const { getByTestId } = render(<ProfileScreen />);
+
+      expect(getByTestId('profile-missing-character')).toBeOnTheScreen();
     });
   });
 

--- a/src/app/(app)/profile.test.tsx
+++ b/src/app/(app)/profile.test.tsx
@@ -3,8 +3,17 @@ import React from 'react';
 
 import type { Perk } from '@/api/skill-tree/types';
 import * as userService from '@/lib/services/user';
-import { act, cleanup, render, screen, setup, waitFor } from '@/lib/test-utils';
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  setup,
+  waitFor,
+} from '@/lib/test-utils';
 import { useCharacterStore } from '@/store/character-store';
+import { OnboardingStep, useOnboardingStore } from '@/store/onboarding-store';
 import { useQuestStore } from '@/store/quest-store';
 import { useSkillTreeStore } from '@/store/skill-tree-store';
 import { useUserStore } from '@/store/user-store';
@@ -249,6 +258,11 @@ describe('ProfileScreen', () => {
     // ActionCards (unlike other profile sub-components) isn't mocked, so it
     // renders for real and reads the Skills & Perks subtitle from here.
     useSkillTreeStore.setState({ skillTreeData: null });
+
+    // The onboarding store is NOT mocked here — the no-hero tests rely on its
+    // real forward-only guard — so reset it or those tests leak a step into
+    // whatever runs next.
+    useOnboardingStore.setState({ currentStep: OnboardingStep.COMPLETED });
   });
 
   afterEach(() => {
@@ -334,6 +348,27 @@ describe('ProfileScreen', () => {
       });
 
       expect(queryByTestId('profile-missing-character')).not.toBeOnTheScreen();
+    });
+
+    // The message alone was a dead end: it told the user to restart, which
+    // changes nothing they can see, and it left them dependent on a background
+    // effect having already fired. Give them the action directly. Setting the
+    // step (rather than navigating here) is this repo's convention — see
+    // first-quest-result.tsx — so NavigationGate stays the only mover.
+    it('offers a way out that puts the user into character creation', () => {
+      useCharacterStore.setState({ character: null });
+      useOnboardingStore.setState({ currentStep: OnboardingStep.COMPLETED });
+
+      const { getByTestId } = render(<ProfileScreen />);
+      fireEvent.press(getByTestId('profile-create-hero'));
+
+      // NOT_STARTED, and asserted on the resulting STATE rather than on a
+      // setter having been called: setCurrentStep is forward-only, so a call
+      // asking to go back is silently discarded and a spy would still report
+      // success.
+      expect(useOnboardingStore.getState().currentStep).toBe(
+        OnboardingStep.NOT_STARTED
+      );
     });
 
     // A character-less account rendered `return null` here, which is

--- a/src/app/(app)/profile.tsx
+++ b/src/app/(app)/profile.tsx
@@ -16,6 +16,7 @@ import {
   ScreenContainer,
   ScreenHeader,
   ScrollView,
+  Text,
   View,
 } from '@/components/ui';
 import { GuildsSection } from '@/features/guilds/components/guilds-section';
@@ -81,13 +82,38 @@ export default function ProfileScreen() {
     }
   }, [fetchUserDetails, character]);
 
+  // Must stay ABOVE the early returns. useCharacterSync restores a character
+  // asynchronously, so this component re-renders from the no-character branch
+  // into the full one — and a hook below those returns would go from unmounted
+  // to mounted mid-life, which React rejects with "Rendered more hooks than
+  // during the previous render".
+  const user = useUserStore((state) => state.user);
+
   // Don't render anything while redirecting
-  if (!character || isRedirecting) {
+  if (isRedirecting) {
     return null; // Return empty instead of a loading view
   }
 
-  // Get user from store for server stats
-  const user = useUserStore((state) => state.user);
+  // No hero to show. Reaching here should be rare — the navigation resolver
+  // sends character-less accounts back to onboarding — but this used to
+  // `return null`, which rendered a wholly blank screen that was
+  // indistinguishable from a crash and hid a real defect for three days.
+  // Say what is wrong instead of showing nothing.
+  if (!character) {
+    return (
+      <View
+        className="flex-1 items-center justify-center bg-background px-6"
+        testID="profile-missing-character"
+      >
+        <FocusAwareStatusBar />
+        <Text className="mb-2 text-center text-xl font-bold">No hero yet</Text>
+        <Text className="text-center opacity-70">
+          This account hasn't created a character. Restart the app to pick your
+          hero and begin your journey.
+        </Text>
+      </View>
+    );
+  }
 
   // Calculate total minutes from completed quests
   // Use server stats if available, otherwise calculate from local data

--- a/src/app/(app)/profile.tsx
+++ b/src/app/(app)/profile.tsx
@@ -12,6 +12,7 @@ import { ProfileCard } from '@/components/profile/profile-card';
 import { RescindInvitationModal } from '@/components/profile/rescind-invitation-modal';
 import { StatsCard } from '@/components/profile/stats-card';
 import {
+  Button,
   FocusAwareStatusBar,
   ScreenContainer,
   ScreenHeader,
@@ -25,6 +26,7 @@ import { useCharacterSync } from '@/features/profile/hooks/profile-hooks';
 import { useFriendManagement } from '@/lib/hooks/use-friend-management';
 import { useProfileData } from '@/lib/hooks/use-profile-data';
 import { useCharacterStore } from '@/store/character-store';
+import { useOnboardingStore } from '@/store/onboarding-store';
 import { useQuestStore } from '@/store/quest-store';
 import { useUserStore } from '@/store/user-store';
 import { colors } from '@/theme';
@@ -35,6 +37,9 @@ export default function ProfileScreen() {
   const completedQuests = useQuestStore((state) => state.getCompletedQuests());
   const streakCount = useCharacterStore((state) => state.dailyQuestStreak);
   const contactsModalRef = React.useRef<ContactsImportModalRef>(null);
+  // resetOnboarding, not setCurrentStep: the latter is forward-only and would
+  // silently discard the move back from COMPLETED, leaving this button inert.
+  const resetOnboarding = useOnboardingStore((state) => state.resetOnboarding);
 
   // Character sync for users without local character data
   const { isRedirecting } = useCharacterSync();
@@ -107,10 +112,15 @@ export default function ProfileScreen() {
       >
         <FocusAwareStatusBar />
         <Text className="mb-2 text-center text-xl font-bold">No hero yet</Text>
-        <Text className="text-center opacity-70">
-          This account hasn't created a character. Restart the app to pick your
-          hero and begin your journey.
+        <Text className="mb-6 text-center opacity-70">
+          Your account is all set — you just haven't chosen a hero. Pick one to
+          begin your journey.
         </Text>
+        <Button
+          testID="profile-create-hero"
+          label="Choose your hero"
+          onPress={resetOnboarding}
+        />
       </View>
     );
   }

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -467,6 +467,7 @@ function RootLayout() {
           name="cooperative-quest-ready"
           options={{ headerShown: false }}
         />
+        <Stack.Screen name="no-hero" options={{ headerShown: false }} />
         <Stack.Screen
           name="scheduled-quest/index"
           options={{ headerShown: false }}

--- a/src/app/first-quest-result.test.tsx
+++ b/src/app/first-quest-result.test.tsx
@@ -90,6 +90,11 @@ jest.mock('@/store/onboarding-store', () => ({
   },
 }));
 
+const mockAuthState = { status: 'signOut' as 'signOut' | 'signIn' };
+jest.mock('@/lib/auth', () => ({
+  useAuth: (selector: any) => selector(mockAuthState),
+}));
+
 jest.mock('@/store/quest-store', () => ({
   useQuestStore: jest.fn(),
 }));
@@ -104,6 +109,8 @@ const mockUseQuestStore = useQuestStore as jest.MockedFunction<
 describe('FirstQuestResultScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default to the onboarding-era case: an unauthenticated first-quest run.
+    mockAuthState.status = 'signOut';
 
     mockUseOnboardingStore.mockImplementation((selector) =>
       selector(mockOnboardingStore as any)
@@ -114,6 +121,22 @@ describe('FirstQuestResultScreen', () => {
   });
 
   describe('Quest Completion Flow', () => {
+    // A character-less social account is sent back through onboarding while
+    // ALREADY signed in, so it reaches this screen authenticated. The signup
+    // prompt asks such a user to create the account they are currently using.
+    it('completes onboarding instead of prompting signup when already signed in', () => {
+      mockAuthState.status = 'signIn';
+
+      render(<FirstQuestResultScreen />);
+
+      expect(mockOnboardingStore.setCurrentStep).not.toHaveBeenCalledWith(
+        OnboardingStep.VIEWING_SIGNUP_PROMPT
+      );
+      expect(mockOnboardingStore.setCurrentStep).toHaveBeenCalledWith(
+        OnboardingStep.COMPLETED
+      );
+    });
+
     it('should call clearRecentCompletedQuest when Continue button is pressed', () => {
       const { getByTestId } = render(<FirstQuestResultScreen />);
 

--- a/src/app/first-quest-result.tsx
+++ b/src/app/first-quest-result.tsx
@@ -6,6 +6,7 @@ import { AVAILABLE_QUESTS } from '@/app/data/quests'; // Assuming quest-1 detail
 import { FailedQuest } from '@/components/failed-quest';
 import { QuestComplete } from '@/components/QuestComplete';
 import { Button, FocusAwareStatusBar, Text, View } from '@/components/ui';
+import { useAuth } from '@/lib/auth';
 import { OnboardingStep, useOnboardingStore } from '@/store/onboarding-store';
 import { useQuestStore } from '@/store/quest-store';
 import { type Quest } from '@/store/types'; // Import Quest type for better type safety
@@ -15,6 +16,17 @@ export default function FirstQuestResultScreen() {
     outcome: 'completed' | 'failed';
   }>();
   const setOnboardingStep = useOnboardingStore((state) => state.setCurrentStep);
+  const authStatus = useAuth((state) => state.status);
+
+  // The signup prompt is the last onboarding step ONLY for someone who does not
+  // have an account yet. A character-less social account is routed back through
+  // onboarding while already authenticated (see navigation-state-resolver), and
+  // asking that user to "create an account" is asking for the one they are
+  // signed into. Decided once so both transitions below stay in agreement.
+  const stepAfterFirstQuest =
+    authStatus === 'signIn'
+      ? OnboardingStep.COMPLETED
+      : OnboardingStep.VIEWING_SIGNUP_PROMPT;
   const resetFailedQuest = useQuestStore((state) => state.resetFailedQuest);
   const clearRecentCompletedQuest = useQuestStore(
     (state) => state.clearRecentCompletedQuest
@@ -27,10 +39,10 @@ export default function FirstQuestResultScreen() {
   React.useEffect(() => {
     if (outcome === 'completed') {
       posthog.capture('onboarding_trigger_completed_first_quest');
-      setOnboardingStep(OnboardingStep.VIEWING_SIGNUP_PROMPT);
+      setOnboardingStep(stepAfterFirstQuest);
     }
     // No specific onboarding step for failure here, as retrying might loop back
-  }, [outcome, setOnboardingStep]);
+  }, [outcome, setOnboardingStep, stepAfterFirstQuest]);
 
   const handleCompletedContinue = () => {
     // Clear the completed quest state to prevent stale state issues
@@ -38,7 +50,7 @@ export default function FirstQuestResultScreen() {
 
     // Update onboarding step - NavigationGate will handle the actual navigation
     // This prevents race conditions from duplicate navigation calls
-    setOnboardingStep(OnboardingStep.VIEWING_SIGNUP_PROMPT);
+    setOnboardingStep(stepAfterFirstQuest);
   };
 
   if (!firstQuestData) {

--- a/src/app/navigation-gate.test.tsx
+++ b/src/app/navigation-gate.test.tsx
@@ -61,6 +61,25 @@ describe('NavigationGate — user-initiated moves inside the signed-out area', (
     expect(mockReplace).not.toHaveBeenCalled();
   });
 
+  it('leaves a hero-less user who tapped "Choose your hero" on /no-hero', () => {
+    // Signed in, server account has no character — the resolver returns
+    // 'no-hero'. Tapping the button on that screen calls resetOnboarding()
+    // and router.replace('/onboarding/welcome'), but neither touches
+    // serverUser, so the resolver still returns 'no-hero' here. Without
+    // is-already-at-target.ts treating onboarding as good enough for this
+    // target, the gate would replace the user straight back onto /no-hero,
+    // making the button inert.
+    mockTarget = { type: 'no-hero' };
+
+    // no-hero.tsx has already run router.replace('/onboarding/welcome').
+    mockSegments = ['onboarding', 'welcome'];
+    mockPathname = '/onboarding/welcome';
+
+    render(<NavigationGate />);
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
   it('leaves a post-first-quest user who tapped "Create account" on /login', () => {
     // currentStep === VIEWING_SIGNUP_PROMPT, so the resolver returns
     // 'quest-completed-signup'.
@@ -106,5 +125,15 @@ describe('NavigationGate — evictions it must still perform', () => {
     render(<NavigationGate />);
 
     expect(mockReplace).toHaveBeenCalledWith('/onboarding');
+  });
+
+  it('evicts a hero-less account sitting in the app group to /no-hero', () => {
+    mockTarget = { type: 'no-hero' };
+    mockSegments = ['(app)'];
+    mockPathname = '/';
+
+    render(<NavigationGate />);
+
+    expect(mockReplace).toHaveBeenCalledWith('/no-hero');
   });
 });

--- a/src/app/navigation-gate.tsx
+++ b/src/app/navigation-gate.tsx
@@ -62,6 +62,9 @@ export default function NavigationGate() {
       case 'onboarding':
         router.replace('/onboarding');
         break;
+      case 'no-hero':
+        router.replace('/no-hero');
+        break;
       case 'login':
         router.replace('/login');
         break;

--- a/src/app/no-hero.test.tsx
+++ b/src/app/no-hero.test.tsx
@@ -16,16 +16,22 @@ jest.mock('expo-router', () => ({
   },
 }));
 
-it('resets onboarding and opens the welcome screen', () => {
+it('restarts onboarding at character selection, skipping the welcome tap', () => {
   useOnboardingStore.setState({ currentStep: OnboardingStep.COMPLETED });
 
   render(<NoHeroScreen />);
   fireEvent.press(screen.getByTestId('no-hero-choose-button'));
 
-  // The resulting STEP, not that a setter was called — COMPLETED to
-  // NOT_STARTED is a BACKWARD move, which setCurrentStep silently discards.
+  // The resulting STEP, not that a setter was called — and it must be
+  // SELECTING_CHARACTER, not NOT_STARTED: this screen already collected the
+  // "begin" intent, so landing on welcome would make the user tap it twice.
+  // The move is only legal as reset-then-forward: COMPLETED →
+  // SELECTING_CHARACTER directly is a BACKWARD move that setCurrentStep
+  // silently discards.
   expect(useOnboardingStore.getState().currentStep).toBe(
-    OnboardingStep.NOT_STARTED
+    OnboardingStep.SELECTING_CHARACTER
   );
-  expect(mockRouterReplace).toHaveBeenCalledWith('/onboarding/welcome');
+  expect(mockRouterReplace).toHaveBeenCalledWith(
+    '/onboarding/choose-character'
+  );
 });

--- a/src/app/no-hero.test.tsx
+++ b/src/app/no-hero.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, screen } from '@testing-library/react-native';
+import React from 'react';
+
+import { render } from '@/lib/test-utils';
+import { OnboardingStep, useOnboardingStore } from '@/store/onboarding-store';
+
+import NoHeroScreen from './no-hero';
+
+// The screen imports the top-level `router` singleton (not the useRouter()
+// hook), which requires expo-router's global navigation state to be ready —
+// unavailable under RNTL. Mocked the same way as quest-completed-signup.test.
+const mockRouterReplace = jest.fn();
+jest.mock('expo-router', () => ({
+  router: {
+    replace: (...args: any[]) => mockRouterReplace(...args),
+  },
+}));
+
+it('resets onboarding and opens the welcome screen', () => {
+  useOnboardingStore.setState({ currentStep: OnboardingStep.COMPLETED });
+
+  render(<NoHeroScreen />);
+  fireEvent.press(screen.getByTestId('no-hero-choose-button'));
+
+  // The resulting STEP, not that a setter was called — COMPLETED to
+  // NOT_STARTED is a BACKWARD move, which setCurrentStep silently discards.
+  expect(useOnboardingStore.getState().currentStep).toBe(
+    OnboardingStep.NOT_STARTED
+  );
+  expect(mockRouterReplace).toHaveBeenCalledWith('/onboarding/welcome');
+});

--- a/src/app/no-hero.tsx
+++ b/src/app/no-hero.tsx
@@ -5,7 +5,7 @@ import { Image, StyleSheet, Text, View } from 'react-native';
 
 import { Button, EyebrowLabel } from '@/components/emberglow';
 import { FocusAwareStatusBar } from '@/components/ui';
-import { useOnboardingStore } from '@/store/onboarding-store';
+import { OnboardingStep, useOnboardingStore } from '@/store/onboarding-store';
 import { colors, fontFamily, scrims, spacing } from '@/theme';
 
 // Same welcome.tsx-derived literals: pixel-perfect beats scale purity.
@@ -30,12 +30,18 @@ const BODY_MAX_WIDTH = 264;
  */
 export default function NoHeroScreen() {
   const resetOnboarding = useOnboardingStore((state) => state.resetOnboarding);
+  const setCurrentStep = useOnboardingStore((state) => state.setCurrentStep);
 
   const handleChooseHero = () => {
-    // resetOnboarding, not setCurrentStep: the latter is forward-only and
-    // silently discards a backward move (f90a968).
+    // Straight to character selection — this screen already collected the
+    // "begin" intent, so landing on welcome would demand the same tap twice.
+    // setCurrentStep is forward-only and silently discards backward moves
+    // (f90a968), so the jump has to be reset-then-forward: resetOnboarding()
+    // set()s NOT_STARTED directly, and NOT_STARTED → SELECTING_CHARACTER is
+    // the same legal forward move welcome's own button makes.
     resetOnboarding();
-    router.replace('/onboarding/welcome');
+    setCurrentStep(OnboardingStep.SELECTING_CHARACTER);
+    router.replace('/onboarding/choose-character');
   };
 
   return (

--- a/src/app/no-hero.tsx
+++ b/src/app/no-hero.tsx
@@ -1,0 +1,72 @@
+import { router } from 'expo-router';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { Button } from '@/components/emberglow';
+import { FocusAwareStatusBar } from '@/components/ui';
+import { useOnboardingStore } from '@/store/onboarding-store';
+import { colors, fontFamily, spacing } from '@/theme';
+
+/**
+ * Reached when a signed-in account has no hero on the server.
+ *
+ * With `/auth/social` no longer creating accounts this should be unreachable
+ * for anyone who signed up through the app — the remaining producer is the
+ * admin `POST /users` endpoint, which takes only an email and a role. It exists
+ * as a DESTINATION rather than a correction because the defect it replaces was
+ * a silent one: routing to `/` on auth status and bouncing once `serverUser`
+ * landed left the user teleported with no explanation.
+ */
+export default function NoHeroScreen() {
+  const resetOnboarding = useOnboardingStore((state) => state.resetOnboarding);
+
+  const handleChooseHero = () => {
+    // resetOnboarding, not setCurrentStep: the latter is forward-only and
+    // silently discards a backward move (f90a968).
+    resetOnboarding();
+    router.replace('/onboarding/welcome');
+  };
+
+  return (
+    <View style={styles.container}>
+      <FocusAwareStatusBar />
+      <Text style={styles.title}>This account doesn't have a hero yet</Text>
+      <Text style={styles.body}>
+        Let's create one — it only takes a moment.
+      </Text>
+      <Button
+        testID="no-hero-choose-button"
+        label="Choose your hero"
+        variant="primary"
+        size="lg"
+        fullWidth
+        onPress={handleChooseHero}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: spacing[6],
+    backgroundColor: colors.surface.app,
+  },
+  title: {
+    fontFamily: fontFamily.display,
+    fontSize: 28,
+    lineHeight: 28 * 1.15,
+    color: colors.text.primary,
+    textAlign: 'center',
+  },
+  body: {
+    fontFamily: fontFamily.regular,
+    fontSize: 17,
+    lineHeight: 17 * 1.5,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    marginTop: spacing[3],
+    marginBottom: spacing[8],
+  },
+});

--- a/src/app/no-hero.tsx
+++ b/src/app/no-hero.tsx
@@ -1,11 +1,18 @@
+import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Image, StyleSheet, Text, View } from 'react-native';
 
-import { Button } from '@/components/emberglow';
+import { Button, EyebrowLabel } from '@/components/emberglow';
 import { FocusAwareStatusBar } from '@/components/ui';
 import { useOnboardingStore } from '@/store/onboarding-store';
-import { colors, fontFamily, spacing } from '@/theme';
+import { colors, fontFamily, scrims, spacing } from '@/theme';
+
+// Same welcome.tsx-derived literals: pixel-perfect beats scale purity.
+const CONTENT_PADDING_HORIZONTAL = 28;
+const CONTENT_PADDING_BOTTOM = 36;
+const TITLE_MAX_WIDTH = 300; // keeps the Erstoria title to two poster lines
+const BODY_MAX_WIDTH = 264;
 
 /**
  * Reached when a signed-in account has no hero on the server.
@@ -16,6 +23,10 @@ import { colors, fontFamily, spacing } from '@/theme';
  * as a DESTINATION rather than a correction because the defect it replaces was
  * a silent one: routing to `/` on auth status and bouncing once `serverUser`
  * landed left the user teleported with no explanation.
+ *
+ * Visually it borrows welcome.tsx wholesale (same background art, scrims, and
+ * header stack) because its button drops the user into that exact flow — the
+ * two screens should read as one journey, not a detour.
  */
 export default function NoHeroScreen() {
   const resetOnboarding = useOnboardingStore((state) => state.resetOnboarding);
@@ -28,37 +39,104 @@ export default function NoHeroScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={styles.flex}>
       <FocusAwareStatusBar />
-      <Text style={styles.title}>This account doesn't have a hero yet</Text>
-      <Text style={styles.body}>
-        Let's create one — it only takes a moment.
-      </Text>
-      <Button
-        testID="no-hero-choose-button"
-        label="Choose your hero"
-        variant="primary"
-        size="lg"
-        fullWidth
-        onPress={handleChooseHero}
+
+      {/* Full-bleed background art — decorative, excluded from the
+          accessibility tree, same as welcome.tsx. */}
+      <Image
+        source={require('@/../assets/images/background/onboarding-bg.jpg')}
+        style={styles.backgroundImage}
+        resizeMode="cover"
       />
+      <LinearGradient
+        pointerEvents="none"
+        colors={scrims.top.colors}
+        start={scrims.top.start}
+        end={scrims.top.end}
+        style={styles.scrimTop}
+      />
+      <LinearGradient
+        pointerEvents="none"
+        colors={scrims.bottom.colors}
+        start={scrims.bottom.start}
+        end={scrims.bottom.end}
+        style={styles.scrimBottom}
+      />
+
+      <View style={styles.content}>
+        {/* Bias the text below the art's sun/castle focal point (~50% down),
+            mirroring welcome.tsx's spacer ratios. */}
+        <View style={styles.spacerTop} />
+
+        <EyebrowLabel>New journey awaits</EyebrowLabel>
+        <Text style={styles.title}>This account doesn't have a hero yet</Text>
+        <Text style={styles.body}>
+          Let's create one — it only takes a moment.
+        </Text>
+
+        <View style={styles.spacerCta} />
+
+        <Button
+          testID="no-hero-choose-button"
+          label="Choose your hero"
+          variant="primary"
+          size="lg"
+          fullWidth
+          onPress={handleChooseHero}
+        />
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  flex: {
     flex: 1,
-    justifyContent: 'center',
-    paddingHorizontal: spacing[6],
-    backgroundColor: colors.surface.app,
+  },
+  backgroundImage: {
+    ...StyleSheet.absoluteFillObject,
+    // Fabric: an absolutely-positioned <Image> sized only by absoluteFill
+    // insets renders at the asset's intrinsic pixel size — the definite
+    // frame is what makes resizeMode="cover" apply. Do not remove.
+    width: '100%',
+    height: '100%',
+  },
+  scrimTop: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: '30%',
+  },
+  scrimBottom: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: '58%',
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    paddingHorizontal: CONTENT_PADDING_HORIZONTAL,
+    paddingBottom: CONTENT_PADDING_BOTTOM,
+  },
+  spacerTop: {
+    flex: 5,
+  },
+  spacerCta: {
+    flex: 2,
   },
   title: {
     fontFamily: fontFamily.display,
-    fontSize: 28,
-    lineHeight: 28 * 1.15,
+    fontSize: 32,
+    // Repo convention for Erstoria: fontSize * 1.15, not leading.display.
+    lineHeight: 32 * 1.15,
     color: colors.text.primary,
     textAlign: 'center',
+    maxWidth: TITLE_MAX_WIDTH,
+    marginTop: spacing[3],
   },
   body: {
     fontFamily: fontFamily.regular,
@@ -66,7 +144,7 @@ const styles = StyleSheet.create({
     lineHeight: 17 * 1.5,
     color: colors.text.secondary,
     textAlign: 'center',
+    maxWidth: BODY_MAX_WIDTH,
     marginTop: spacing[3],
-    marginBottom: spacing[8],
   },
 });

--- a/src/app/onboarding/__tests__/choose-character.test.tsx
+++ b/src/app/onboarding/__tests__/choose-character.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import ChooseCharacterScreen from '../choose-character';
-import { createProvisionalUser } from '@/lib/services/user';
+import { getAccessToken } from '@/api/token';
+import {
+  createProvisionalUser,
+  updateUserCharacter,
+} from '@/lib/services/user';
 import { Dimensions } from 'react-native';
 import { useOnboardingStore, OnboardingStep } from '@/store/onboarding-store';
 import { useCharacterStore } from '@/store/character-store';
@@ -9,7 +13,12 @@ import { useCharacterStore } from '@/store/character-store';
 // Mock createProvisionalUser so we can simulate both success and failure.
 jest.mock('@/lib/services/user', () => ({
   createProvisionalUser: jest.fn(),
+  updateUserCharacter: jest.fn(),
 }));
+
+// Real-session discriminator: null = onboarding-from-scratch (provisional
+// path), a token = authenticated hero-less account (PATCH path).
+jest.mock('@/api/token', () => ({ getAccessToken: jest.fn(() => null) }));
 
 // Mock UI components
 jest.mock('@/components/ui/focus-aware-status-bar', () => ({
@@ -74,6 +83,8 @@ describe('ChooseCharacterScreen', () => {
     // Stub the store setter:
     useOnboardingStore.getState().setCurrentStep = jest.fn();
     (createProvisionalUser as jest.Mock).mockClear();
+    (updateUserCharacter as jest.Mock).mockClear();
+    (getAccessToken as jest.Mock).mockReset().mockReturnValue(null);
     mockCharacterStore.createCharacter.mockClear();
     mockCharacterStore.resetCharacter.mockClear();
   });
@@ -140,6 +151,47 @@ describe('ChooseCharacterScreen', () => {
       name: 'Arthur',
     });
 
+    expect(mockCharacterStore.createCharacter).toHaveBeenCalledWith(
+      'knight',
+      'Arthur'
+    );
+    expect(useOnboardingStore.getState().setCurrentStep).toHaveBeenCalledWith(
+      OnboardingStep.VIEWING_INTRO
+    );
+  });
+
+  it('PATCHes the character onto the real account (no provisional user) when a session exists', async () => {
+    // Named bug: Google-first signup landed here with a live session;
+    // creating a provisional user split quest data across two accounts.
+    (getAccessToken as jest.Mock).mockReturnValue('real-access-token');
+    (updateUserCharacter as jest.Mock).mockResolvedValue({ success: true });
+
+    const { getByPlaceholderText, getByText, getByTestId } = render(
+      <ChooseCharacterScreen />
+    );
+
+    fireEvent.changeText(getByPlaceholderText('e.g. Rowan'), 'Arthur');
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    fireEvent.press(getByText('Continue'));
+
+    const flatList = getByTestId('character-carousel');
+    fireEvent(flatList, 'onMomentumScrollEnd', {
+      nativeEvent: { contentOffset: { x: snapInterval } },
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText('Create character'));
+      await Promise.resolve();
+      jest.runAllTimers();
+    });
+
+    expect(updateUserCharacter).toHaveBeenCalledWith({
+      type: 'knight',
+      name: 'Arthur',
+    });
+    expect(createProvisionalUser).not.toHaveBeenCalled();
     expect(mockCharacterStore.createCharacter).toHaveBeenCalledWith(
       'knight',
       'Arthur'

--- a/src/app/onboarding/choose-character.tsx
+++ b/src/app/onboarding/choose-character.tsx
@@ -18,10 +18,14 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
+import { getAccessToken } from '@/api/token';
 import { Button, EyebrowLabel, Input } from '@/components/emberglow';
 import { EmberProgress } from '@/components/onboarding/ember-progress';
 import { FocusAwareStatusBar, Image } from '@/components/ui';
-import { createProvisionalUser } from '@/lib/services/user';
+import {
+  createProvisionalUser,
+  updateUserCharacter,
+} from '@/lib/services/user';
 import { useCharacterStore } from '@/store/character-store';
 import { OnboardingStep, useOnboardingStore } from '@/store/onboarding-store';
 import { type Character, type CharacterType } from '@/store/types';
@@ -450,9 +454,18 @@ export default function ChooseCharacterScreen() {
       createCharacter(selected.id as CharacterType, debouncedName.trim());
       posthog.capture('onboarding_update_character_local_store_success');
 
-      // 2. Create a provisional user on the server
-      await createProvisionalUser(newCharacter as Character);
-      posthog.capture('onboarding_create_provisional_user_success');
+      // 2. Persist the hero server-side. A live real session (Google-first
+      // signup routed here via /no-hero) must PATCH its own account —
+      // minting a provisional user here would create a second identity and
+      // silently split quest data across the two (empty journal bug).
+      // createProvisionalUser enforces the same invariant with a throw.
+      if (getAccessToken()) {
+        await updateUserCharacter(newCharacter as Character);
+        posthog.capture('onboarding_update_character_server_success');
+      } else {
+        await createProvisionalUser(newCharacter as Character);
+        posthog.capture('onboarding_create_provisional_user_success');
+      }
 
       // Only proceed if both operations succeeded
       useOnboardingStore

--- a/src/app/quest-completed-signup.tsx
+++ b/src/app/quest-completed-signup.tsx
@@ -117,12 +117,9 @@ export default function QuestCompletedSignupScreen() {
       // this device, and their social identity already resolves to an
       // existing full account) — outcomes `login`, `existing-account-login`,
       // and `linked` all mean "signed into an account that already
-      // existed," not a new signup, so only `created`/`converted` (a
-      // genuinely new full account) should count toward the funnel.
-      if (
-        outcome === SOCIAL_SIGNIN_OUTCOMES.CREATED ||
-        outcome === SOCIAL_SIGNIN_OUTCOMES.CONVERTED
-      ) {
+      // existed," not a new signup, so only `converted` (a genuinely new
+      // full account) should count toward the funnel.
+      if (outcome === SOCIAL_SIGNIN_OUTCOMES.CONVERTED) {
         posthog.capture('signup_completed', { method: provider });
       }
     },

--- a/src/app/quest-completed-signup.tsx
+++ b/src/app/quest-completed-signup.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/login/social-sign-in-buttons';
 import { FocusAwareStatusBar } from '@/components/ui';
 import {
+  type NoAccountForIdentity,
   SOCIAL_SIGNIN_OUTCOMES,
   type SocialSignInOutcome,
 } from '@/lib/auth/social';
@@ -129,14 +130,16 @@ export default function QuestCompletedSignupScreen() {
   );
 
   const handleSocialSignInError = useCallback(
-    (kind: 'email-in-use' | 'generic') => {
+    // A `NoAccountForIdentity` here is out of scope for this screen (it has
+    // no no-account step of its own) and is treated the same as any other
+    // failure — falls through with everything but the 409 case.
+    (kind: 'email-in-use' | 'generic' | NoAccountForIdentity) => {
+      const isEmailInUse = kind === 'email-in-use';
       showMessage({
-        message:
-          kind === 'email-in-use' ? 'Email already in use' : 'Sign-in failed',
-        description:
-          kind === 'email-in-use'
-            ? 'This email is already tied to another account.'
-            : 'Please try again.',
+        message: isEmailInUse ? 'Email already in use' : 'Sign-in failed',
+        description: isEmailInUse
+          ? 'This email is already tied to another account.'
+          : 'Please try again.',
         type: 'danger',
         duration: 3000,
       });

--- a/src/components/login-form.test.tsx
+++ b/src/components/login-form.test.tsx
@@ -98,13 +98,19 @@ jest.mock('expo-router', () => ({
 // onSuccess/onError scenario LoginForm needs to route or map.
 jest.mock('./login/social-sign-in-buttons', () => {
   const { Pressable } = jest.requireActual('react-native');
+  // Required inside the factory, not via the top-level import: jest.mock is
+  // hoisted above imports, so a reference to an outer `const` here would hit
+  // the temporal-dead-zone rather than the real class.
+  const {
+    NoAccountForIdentity: MockNoAccountForIdentity,
+  } = require('@/lib/auth/social');
   return {
     SocialSignInButtons: ({
       onSuccess,
       onError,
     }: {
       onSuccess: (target: string, outcome: string, provider: string) => void;
-      onError: (kind: 'email-in-use' | 'generic') => void;
+      onError: (kind: 'email-in-use' | 'generic' | Error) => void;
     }) => (
       <>
         <Pressable
@@ -126,6 +132,12 @@ jest.mock('./login/social-sign-in-buttons', () => {
         <Pressable
           testID="mock-social-error-generic"
           onPress={() => onError('generic')}
+        />
+        <Pressable
+          testID="mock-social-error-no-account"
+          onPress={() =>
+            onError(new MockNoAccountForIdentity('tommy@gmail.com'))
+          }
         />
       </>
     ),
@@ -796,48 +808,6 @@ describe('LoginForm Form ', () => {
       });
     });
 
-    it('routes brand-new social signups (outcome "created") to onboarding, not the app shell with no character', async () => {
-      setup(<LoginForm />);
-
-      // `completeSignIn` always resolves target 'app' — routing this by
-      // target alone would drop a brand-new, character-less user into the
-      // app shell. This pins the `created`-outcome override instead.
-      fireEvent.press(screen.getByTestId('mock-social-success-app-created'));
-
-      await waitFor(() => {
-        expect(mockRouterReplace).toHaveBeenCalledWith('/onboarding');
-      });
-    });
-
-    it('fires signup_completed with the provider when a brand-new social account is created', async () => {
-      setup(<LoginForm />);
-
-      fireEvent.press(screen.getByTestId('mock-social-success-app-created'));
-
-      await waitFor(() => {
-        expect(mockRouterReplace).toHaveBeenCalledWith('/onboarding');
-      });
-
-      expect(mockPosthogCapture).toHaveBeenCalledWith('signup_completed', {
-        method: 'google',
-      });
-    });
-
-    it('does NOT fire signup_completed for an ordinary login outcome', async () => {
-      setup(<LoginForm />);
-
-      fireEvent.press(screen.getByTestId('mock-social-success-app-login'));
-
-      await waitFor(() => {
-        expect(mockRouterReplace).toHaveBeenCalledWith('/(app)/');
-      });
-
-      expect(mockPosthogCapture).not.toHaveBeenCalledWith(
-        'signup_completed',
-        expect.anything()
-      );
-    });
-
     it('maps a social sign-in email-in-use error to the same copy as the magic-link 409 path', async () => {
       setup(<LoginForm />);
 
@@ -862,6 +832,33 @@ describe('LoginForm Form ', () => {
           screen.getByText(/Login link failed to send. Please try again./i)
         ).toBeOnTheScreen();
       });
+    });
+
+    it('shows the no-account step when the server reports no account', async () => {
+      setup(<LoginForm intent="signin" />);
+
+      fireEvent.press(screen.getByTestId('mock-social-error-no-account'));
+
+      expect(
+        await screen.findByTestId('no-account-begin-button')
+      ).toBeOnTheScreen();
+      expect(screen.getByText(/tommy@gmail\.com/)).toBeOnTheScreen();
+    });
+
+    it('sends the user to onboarding from the no-account step', async () => {
+      setup(<LoginForm intent="signin" />);
+
+      fireEvent.press(screen.getByTestId('mock-social-error-no-account'));
+      fireEvent.press(await screen.findByTestId('no-account-begin-button'));
+
+      // Assert the resulting STEP, not that a setter was called: setCurrentStep
+      // is forward-only and silently discards a backward move, which is
+      // exactly how a shipped fix passed its test while doing nothing on
+      // device (f90a968).
+      expect(useOnboardingStore.getState().currentStep).toBe(
+        OnboardingStep.NOT_STARTED
+      );
+      expect(mockRouterReplace).toHaveBeenCalledWith('/onboarding/welcome');
     });
   });
 

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -1,7 +1,6 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import * as Linking from 'expo-linking';
 import { router } from 'expo-router';
-import { usePostHog } from 'posthog-react-native';
 import React, { useEffect, useState } from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
@@ -9,7 +8,7 @@ import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import type { SocialProvider } from '@/components/login';
 import { useAuth } from '@/lib/auth';
 import {
-  SOCIAL_SIGNIN_OUTCOMES,
+  NoAccountForIdentity,
   type SocialSignInOutcome,
 } from '@/lib/auth/social';
 import { removeItem } from '@/lib/storage';
@@ -29,6 +28,7 @@ import { DEFAULT_LOGIN_INTENT, LOGIN_COPY } from './login/copy';
 import { EmailInputView } from './login/email-input-view';
 import { EmailSentView } from './login/email-sent-view';
 import { useMagicLink } from './login/hooks/use-magic-link';
+import { NoAccountView } from './login/no-account-view';
 import { StartOverSheet } from './login/start-over-sheet';
 import { cardMeta } from './login/text-styles';
 import type { LoginFormProps } from './login/types';
@@ -70,7 +70,6 @@ export const LoginForm = ({
   intent = DEFAULT_LOGIN_INTENT,
 }: LoginFormProps) => {
   const copy = LOGIN_COPY[intent];
-  const posthog = usePostHog();
   const resetOnboarding = useOnboardingStore((state) => state.resetOnboarding);
   const signOut = useAuth((state) => state.signOut);
   // Read here rather than inside `ChooserView` so that view stays a pure
@@ -105,6 +104,12 @@ export const LoginForm = ({
   // sheet takes a controlled `visible` prop (see its JSDoc).
   const [isConfirmingStartOver, setIsConfirmingStartOver] = useState(false);
 
+  // The address from a no-account failure. `null` means "not in that state" —
+  // an empty STRING is a real value here (the server always sends an address,
+  // but api/auth.ts falls back to '' rather than failing the sign-in over a
+  // display string), so presence cannot be tested by truthiness.
+  const [noAccountEmail, setNoAccountEmail] = useState<string | null>(null);
+
   const {
     isLoading,
     error,
@@ -133,7 +138,8 @@ export const LoginForm = ({
   // `isLoading` below): the transition out of `email` is blocked for exactly the
   // window in which `emailSent` can flip, so `mode === 'email'` is guaranteed
   // whenever that happens and the two can never disagree.
-  const step: 'chooser' | 'email' | 'sent' = emailSent ? 'sent' : mode;
+  const step: 'chooser' | 'email' | 'sent' | 'no-account' =
+    noAccountEmail !== null ? 'no-account' : emailSent ? 'sent' : mode;
 
   const handleEmailSubmit = async (email: string) => {
     await sendMagicLink(email, (submittedEmail) => {
@@ -154,33 +160,40 @@ export const LoginForm = ({
 
   const handleSocialSignInSuccess = (
     target: 'onboarding' | 'app',
-    outcome: SocialSignInOutcome | (string & {}),
-    provider: SocialProvider
+    _outcome: SocialSignInOutcome | (string & {}),
+    _provider: SocialProvider
   ) => {
-    // `completeSignIn` (src/api/auth.ts) always resolves target 'app' today
-    // — 'onboarding' is unreachable (see its JSDoc) — so mirroring
-    // verify.tsx's target-only routing would send a brand-new social
-    // signup (`outcome === 'created'`: a full user created directly from
-    // THIS screen, with no character — a state the app never had before
-    // social sign-in) straight into the app shell. Nothing under
-    // `(app)/` checks for a missing character, and the verified-user-on-
-    // fresh-install sync effect in navigation-state-resolver.ts actively
-    // marks onboarding COMPLETED for exactly this signed-in/no-provisional-
-    // data shape — it would never send them to onboarding on its own
-    // either. So `created` is routed to onboarding explicitly here; every
-    // other outcome follows `target`, same as verify.tsx.
-    if (outcome === SOCIAL_SIGNIN_OUTCOMES.CREATED) {
-      // This is a genuinely new full account created directly from the
-      // login screen (as opposed to `login`/`existing-account-login`/
-      // `linked`, all of which sign the user into an account that already
-      // existed) — capture before navigating, same funnel event the
-      // magic-link (verify.tsx) and quest-completed-signup paths fire.
-      posthog.capture('signup_completed', { method: provider });
-      router.replace('/onboarding');
+    router.replace(target === 'app' ? '/(app)/' : '/onboarding');
+  };
+
+  /**
+   * The server reported that the verified identity owns no account —
+   * `/auth/social` no longer creates one. Names the address and hands the
+   * user into onboarding instead of the generic-error path.
+   */
+  const handleSocialSignInError = (error: unknown) => {
+    if (error instanceof NoAccountForIdentity) {
+      setNoAccountEmail(error.email);
       return;
     }
+    // Everything else keeps the existing generic/email-in-use mapping.
+    setError(mapError(error === 'email-in-use' ? 'email-in-use' : 'generic'));
+  };
 
-    router.replace(target === 'app' ? '/(app)/' : '/onboarding');
+  const handleBeginJourney = () => {
+    setNoAccountEmail(null);
+    // resetOnboarding, NOT setCurrentStep: the latter is forward-only and
+    // silently discards a backward move (see f90a968). Only resetOnboarding
+    // set()s the step directly, and NOT_STARTED is what runs the whole funnel.
+    resetOnboarding();
+    router.replace('/onboarding/welcome');
+  };
+
+  const handleTryAnotherAccount = () => {
+    // Clearing this returns the user to the chooser; getGoogleCredential now
+    // signs out of the SDK first, so the next attempt shows the account picker
+    // rather than silently reusing the one that just failed.
+    setNoAccountEmail(null);
   };
 
   /**
@@ -318,7 +331,14 @@ export const LoginForm = ({
                 error={error}
                 onContinueWithEmail={() => goToMode('email')}
                 onSocialSuccess={handleSocialSignInSuccess}
-                onSocialError={(kind) => setError(mapError(kind))}
+                onSocialError={handleSocialSignInError}
+              />
+            ) : step === 'no-account' ? (
+              <NoAccountView
+                intent={intent}
+                email={noAccountEmail ?? ''}
+                onBeginJourney={handleBeginJourney}
+                onTryAnotherAccount={handleTryAnotherAccount}
               />
             ) : (
               <EmailInputView

--- a/src/components/login/copy.test.ts
+++ b/src/components/login/copy.test.ts
@@ -101,6 +101,32 @@ describe('LOGIN_COPY', () => {
   });
 });
 
+describe('no-account framing', () => {
+  it('names the address on the signin framing and offers a retry', () => {
+    const copy = LOGIN_COPY.signin;
+    expect(copy.noAccountBody('tommy@gmail.com')).toContain('tommy@gmail.com');
+    expect(copy.noAccountPrimaryLabel).toBe('Begin new journey');
+    expect(copy.noAccountShowsRetry).toBe(true);
+  });
+
+  it('omits the address clause when there is no address', () => {
+    // The server always sends one, but api/auth.ts falls back to '' rather than
+    // failing the sign-in over a display string — so the sentence has to read
+    // correctly without it. A fixture of 'unknown@x.com' would assert nothing.
+    expect(LOGIN_COPY.signin.noAccountBody('')).not.toContain('for ');
+    expect(LOGIN_COPY.signin.noAccountBody('')).toMatch(/\S/);
+  });
+
+  it('frames convert as lost progress and offers no retry', () => {
+    const copy = LOGIN_COPY.convert;
+    expect(copy.noAccountTitle).not.toBe(LOGIN_COPY.signin.noAccountTitle);
+    // Retrying cannot succeed here: the account is missing because the
+    // provisional record is gone, not because the wrong provider account was
+    // picked.
+    expect(copy.noAccountShowsRetry).toBe(false);
+  });
+});
+
 describe('parseLoginIntent', () => {
   it('accepts the intents the copy table knows', () => {
     expect(parseLoginIntent('signin')).toBe('signin');

--- a/src/components/login/copy.ts
+++ b/src/components/login/copy.ts
@@ -74,6 +74,24 @@ type LoginFraming = {
   startNewLead: string;
   /** Accent-coloured second half, naming what onboarding asks for next. */
   startNewAction: string;
+  /** Heading of the no-account step. */
+  noAccountTitle: string;
+  /**
+   * Body of the no-account step. A function, like `chooserSubtitle`, so the
+   * empty-address fallback lives with the string that needs it — `api/auth.ts`
+   * resolves a missing `details.email` to `''` rather than failing the sign-in,
+   * so every entry must read correctly with no address.
+   */
+  noAccountBody: (email: string) => string;
+  /** Label of the primary action, which always leads into onboarding. */
+  noAccountPrimaryLabel: string;
+  /**
+   * Whether "Try another account" belongs on this framing. Required and read as
+   * a flag for the same reason as `showStartNewLink`: a third intent must fail
+   * to compile until someone decides, rather than silently inheriting a retry
+   * that cannot succeed.
+   */
+  noAccountShowsRetry: boolean;
 };
 
 export const LOGIN_COPY: Record<LoginIntent, LoginFraming> = {
@@ -89,6 +107,13 @@ export const LOGIN_COPY: Record<LoginIntent, LoginFraming> = {
     showStartNewLink: true,
     startNewLead: START_NEW_LEAD,
     startNewAction: START_NEW_ACTION,
+    noAccountTitle: 'No account yet',
+    noAccountBody: (email) =>
+      email
+        ? `We couldn't find an Emberglow account for ${email}. Every hero starts with a journey — ready to begin?`
+        : "We couldn't find an Emberglow account to sign into. Every hero starts with a journey — ready to begin?",
+    noAccountPrimaryLabel: 'Begin new journey',
+    noAccountShowsRetry: true,
   },
   convert: {
     chooserTitle: 'Save your progress',
@@ -115,6 +140,14 @@ export const LOGIN_COPY: Record<LoginIntent, LoginFraming> = {
     // flag on can never surface stale or drifted copy.
     startNewLead: START_NEW_LEAD,
     startNewAction: START_NEW_ACTION,
+    noAccountTitle: "We couldn't find your progress",
+    // This user HAS a hero locally; what is missing is the provisional record
+    // the server converts. Retrying the same provider cannot produce it, so the
+    // only honest offer is to start the journey again.
+    noAccountBody: () =>
+      "Your quest progress couldn't be linked to an account. Let's start your journey again — it only takes a moment.",
+    noAccountPrimaryLabel: 'Start over',
+    noAccountShowsRetry: false,
   },
 };
 

--- a/src/components/login/no-account-view.test.tsx
+++ b/src/components/login/no-account-view.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import React from 'react';
+
+import { NoAccountView } from './no-account-view';
+
+const props = {
+  intent: 'signin' as const,
+  email: 'tommy@gmail.com',
+  onBeginJourney: jest.fn(),
+  onTryAnotherAccount: jest.fn(),
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+it('names the address the user just authorized', () => {
+  render(<NoAccountView {...props} />);
+  // getByText, not queryByText — RNTL matches hidden elements, so a presence
+  // check on an unrendered subtree can still pass.
+  expect(screen.getByText(/tommy@gmail\.com/)).toBeOnTheScreen();
+});
+
+it('runs the primary action', () => {
+  render(<NoAccountView {...props} />);
+  fireEvent.press(screen.getByTestId('no-account-begin-button'));
+  expect(props.onBeginJourney).toHaveBeenCalledTimes(1);
+});
+
+it('offers a retry on the signin framing', () => {
+  render(<NoAccountView {...props} />);
+  fireEvent.press(screen.getByTestId('no-account-retry-button'));
+  expect(props.onTryAnotherAccount).toHaveBeenCalledTimes(1);
+});
+
+it('withholds the retry on the convert framing', () => {
+  render(<NoAccountView {...props} intent="convert" />);
+  expect(screen.queryByTestId('no-account-retry-button')).toBeNull();
+});

--- a/src/components/login/no-account-view.tsx
+++ b/src/components/login/no-account-view.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { Button } from '@/components/emberglow';
+import { spacing } from '@/theme';
+
+import { LOGIN_COPY } from './copy';
+import { cardBody, cardTitle } from './text-styles';
+import type { LoginIntent } from './types';
+
+export type NoAccountViewProps = {
+  /** How the user arrived, which picks the framing (see `copy.ts`). */
+  intent: LoginIntent;
+  /**
+   * The address the user just authorized with the provider. May be `''` —
+   * `api/auth.ts` falls back to that rather than failing the sign-in over a
+   * display string, and the copy table drops the clause when it is empty.
+   */
+  email: string;
+  /** Into onboarding. This view owns no navigation. */
+  onBeginJourney: () => void;
+  /** Re-runs the provider with a fresh chooser. Only rendered when the
+   * framing says a retry can succeed. */
+  onTryAnotherAccount: () => void;
+};
+
+/**
+ * Shown when the server reports that a verified identity owns no account.
+ *
+ * The dead end this replaces was the point: account creation now belongs to
+ * onboarding, so this screen's job is to name what happened and hand the user
+ * the way forward, not to apologise.
+ */
+export function NoAccountView({
+  intent,
+  email,
+  onBeginJourney,
+  onTryAnotherAccount,
+}: NoAccountViewProps) {
+  const copy = LOGIN_COPY[intent];
+
+  return (
+    <View>
+      <Text style={styles.title}>{copy.noAccountTitle}</Text>
+      <Text style={styles.body}>{copy.noAccountBody(email)}</Text>
+
+      <Button
+        testID="no-account-begin-button"
+        label={copy.noAccountPrimaryLabel}
+        variant="primary"
+        size="lg"
+        fullWidth
+        onPress={onBeginJourney}
+      />
+
+      {copy.noAccountShowsRetry ? (
+        <Button
+          testID="no-account-retry-button"
+          label="Try another account"
+          variant="ghost"
+          fullWidth
+          onPress={onTryAnotherAccount}
+          containerStyle={styles.retry}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    ...cardTitle,
+    marginBottom: spacing[1],
+  },
+  body: {
+    ...cardBody,
+    marginTop: spacing[2],
+    marginBottom: spacing[6],
+  },
+  retry: {
+    marginTop: spacing[2],
+  },
+});

--- a/src/components/login/social-sign-in-buttons.test.tsx
+++ b/src/components/login/social-sign-in-buttons.test.tsx
@@ -8,6 +8,7 @@ import {
   ExistingAccountConfirmationRequired,
   getAppleCredential,
   getGoogleCredential,
+  NoAccountForIdentity,
   SocialSignInCancelled,
 } from '@/lib/auth/social';
 import {
@@ -42,6 +43,10 @@ jest.mock('@/lib/auth/social', () => ({
   ExistingAccountConfirmationRequired: jest.requireActual(
     '@/lib/auth/social/errors'
   ).ExistingAccountConfirmationRequired,
+  // Same reasoning as `ExistingAccountConfirmationRequired` above: the
+  // component branches on `instanceof NoAccountForIdentity`.
+  NoAccountForIdentity: jest.requireActual('@/lib/auth/social/errors')
+    .NoAccountForIdentity,
   SOCIAL_SIGNIN_OUTCOMES: {
     LOGIN: 'login',
     EXISTING_ACCOUNT_LOGIN: 'existing-account-login',
@@ -255,6 +260,29 @@ describe('SocialSignInButtons', () => {
       await waitFor(() => {
         expect(onError).toHaveBeenCalledWith('generic');
       });
+    });
+
+    it('passes a NoAccountForIdentity error through to onError untranslated, and does not log it as a failure', async () => {
+      mockGetGoogleCredential.mockResolvedValue({
+        provider: 'google',
+        idToken: 'google-id-token',
+      });
+      const noAccountError = new NoAccountForIdentity('tommy@gmail.com');
+      mockSocialSignIn.mockRejectedValue(noAccountError);
+      const onError = jest.fn();
+
+      render(<SocialSignInButtons onSuccess={noop} onError={onError} />);
+      fireEvent.press(screen.getByTestId('google-sign-in-button'));
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith(noAccountError);
+      });
+      // Distinct from every other failure: nothing here is a fault to log,
+      // so it must not fire the same event a real failure does.
+      expect(mockCapture).not.toHaveBeenCalledWith(
+        'social_signin_failure',
+        expect.anything()
+      );
     });
 
     it('records the native error code on social_signin_failure, so a DEVELOPER_ERROR is distinguishable from a network failure', async () => {

--- a/src/components/login/social-sign-in-buttons.tsx
+++ b/src/components/login/social-sign-in-buttons.tsx
@@ -19,6 +19,7 @@ import {
   type ExistingAccountSummary,
   getAppleCredential,
   getGoogleCredential,
+  NoAccountForIdentity,
   SOCIAL_SIGNIN_OUTCOMES,
   SocialSignInCancelled,
   type SocialSignInOutcome,
@@ -57,8 +58,11 @@ export type SocialSignInButtonsProps = {
     provider: SocialProvider
   ) => void;
   /** `'email-in-use'` maps to the existing 409 copy already used by the
-   * magic-link flow; `'generic'` covers every other failure. */
-  onError: (kind: 'email-in-use' | 'generic') => void;
+   * magic-link flow; `'generic'` covers every other failure. A
+   * `NoAccountForIdentity` instance is passed through raw instead of
+   * collapsed to a kind string — unlike the other two, the caller needs the
+   * carried `email` to render the no-account step, not just a copy lookup. */
+  onError: (kind: 'email-in-use' | 'generic' | NoAccountForIdentity) => void;
   /** Promotes the Google button to the screen's single primary (ember)
    * action — solid Cinnabar with a warm glow instead of the default
    * `outline`. Off by default because the login screen's magic-link submit
@@ -268,12 +272,24 @@ export function SocialSignInButtons({
           return;
         }
 
+        // Distinguished from every other failure the same way the collision
+        // above is: the server told us something specific, and collapsing it
+        // to 'generic' would lose the address the no-account screen names.
+        // Deliberately has no `reportFailure` call — nothing here is a fault
+        // to log, and firing `social_signin_failure` for it would flag an
+        // expected, server-driven branch as an error.
+        if (error instanceof NoAccountForIdentity) {
+          posthog.capture('social_signin_no_account', { provider });
+          onError(error);
+          return;
+        }
+
         reportFailure(error, provider);
       } finally {
         if (!awaitingConfirmation) setSigningInProvider(null);
       }
     },
-    [isSigningIn, finishSignIn, reportFailure, posthog]
+    [isSigningIn, finishSignIn, reportFailure, posthog, onError]
   );
 
   const handleConfirmExistingAccount = React.useCallback(async () => {

--- a/src/lib/auth/social/errors.ts
+++ b/src/lib/auth/social/errors.ts
@@ -50,3 +50,28 @@ export class ExistingAccountConfirmationRequired extends Error {
     this.account = account;
   }
 }
+
+/**
+ * The verified social identity owns no account. Nothing was created — the
+ * server refuses to create accounts outside onboarding, mirroring magic-link's
+ * "User not found. Please create an account through the app."
+ *
+ * Distinguished by `details.reason` being exactly 'no-account-for-identity',
+ * NOT by status code: 404 is not reserved to this path, and a route-level 404
+ * carries no `details` at all. Any other reason is re-thrown untranslated so it
+ * still reaches the caller's generic error copy.
+ *
+ * `email` is the address the user just authorized with the provider, carried so
+ * the no-account screen can name it. Always present — the server sets it from
+ * the verified identity, which cannot reach this branch without one (an
+ * email-less identity is rejected earlier with 400).
+ */
+export class NoAccountForIdentity extends Error {
+  readonly email: string;
+
+  constructor(email: string) {
+    super('No account found for this sign-in');
+    this.name = 'NoAccountForIdentity';
+    this.email = email;
+  }
+}

--- a/src/lib/auth/social/google.test.ts
+++ b/src/lib/auth/social/google.test.ts
@@ -1,0 +1,34 @@
+import { GoogleSignin } from '@react-native-google-signin/google-signin';
+
+import { getGoogleCredential } from './google';
+
+jest.mock('@react-native-google-signin/google-signin', () => ({
+  GoogleSignin: {
+    configure: jest.fn(),
+    hasPlayServices: jest.fn().mockResolvedValue(true),
+    signOut: jest.fn().mockResolvedValue(undefined),
+    signIn: jest.fn(),
+  },
+  statusCodes: { SIGN_IN_CANCELLED: 'SIGN_IN_CANCELLED' },
+}));
+
+describe('getGoogleCredential', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('clears the cached account BEFORE opening the chooser', async () => {
+    const order: string[] = [];
+    (GoogleSignin.signOut as jest.Mock).mockImplementation(async () => {
+      order.push('signOut');
+    });
+    (GoogleSignin.signIn as jest.Mock).mockImplementation(async () => {
+      order.push('signIn');
+      return { type: 'success', data: { idToken: 'tok' } };
+    });
+
+    await getGoogleCredential();
+
+    // Order, not mere presence: signOut AFTER signIn would still record both
+    // calls while leaving the cached account in place for the chooser.
+    expect(order).toEqual(['signOut', 'signIn']);
+  });
+});

--- a/src/lib/auth/social/google.ts
+++ b/src/lib/auth/social/google.ts
@@ -39,6 +39,14 @@ export async function getGoogleCredential() {
   ensureConfigured();
   await GoogleSignin.hasPlayServices();
 
+  // The SDK caches the last signed-in account and `signIn()` resolves straight
+  // to it, so without this the chooser never appears again and the user cannot
+  // pick a different account without clearing app storage. Clears LOCAL cached
+  // state only — not the OAuth grant (that is `revokeAccess()`) and not any
+  // server session. Nothing depends on the cached state: this app trades the
+  // idToken for its own JWTs immediately and never calls `signInSilently`.
+  await GoogleSignin.signOut();
+
   let result;
   try {
     result = await GoogleSignin.signIn();

--- a/src/lib/auth/social/index.ts
+++ b/src/lib/auth/social/index.ts
@@ -1,6 +1,7 @@
 export { getAppleCredential } from './apple';
 export type { ExistingAccountSummary } from './errors';
 export { ExistingAccountConfirmationRequired } from './errors';
+export { NoAccountForIdentity } from './errors';
 export { SocialSignInCancelled } from './errors';
 export { getGoogleCredential } from './google';
 export type { SocialSignInOutcome } from './outcomes';

--- a/src/lib/navigation/is-already-at-target.test.ts
+++ b/src/lib/navigation/is-already-at-target.test.ts
@@ -163,6 +163,40 @@ describe('isAlreadyAtTarget', () => {
     });
   });
 
+  describe('the /no-hero eviction loop regression', () => {
+    // Tapping "Choose your hero" on /no-hero calls resetOnboarding() and
+    // router.replace('/onboarding/welcome'), but neither action changes any
+    // resolver input (serverUser is untouched), so the resolver still answers
+    // 'no-hero' on the very next render. A strict segments[0] === 'no-hero'
+    // match read the user's new location (onboarding) as "not there yet" and
+    // replaced them straight back onto /no-hero — the button never worked.
+    it('accepts the onboarding funnel as good enough for target no-hero', () => {
+      expect(
+        isAlreadyAtTarget(
+          { type: 'no-hero' },
+          ['onboarding', 'welcome'],
+          '/onboarding/welcome'
+        )
+      ).toBe(true);
+    });
+
+    // The permissiveness must not swallow the case the screen exists for: a
+    // hero-less account sitting inside the app group still has to be evicted.
+    // This is the guard against over-applying the fix above (an
+    // always-true no-hero case would pass the test above too).
+    it('still evicts a hero-less account sitting in the app group', () => {
+      expect(isAlreadyAtTarget({ type: 'no-hero' }, ['(app)'], '/')).toBe(
+        false
+      );
+    });
+
+    it('reports we are already at no-hero when sitting on /no-hero', () => {
+      expect(
+        isAlreadyAtTarget({ type: 'no-hero' }, ['no-hero'], '/no-hero')
+      ).toBe(true);
+    });
+  });
+
   describe('the failed-quest redirect loop regression', () => {
     // Captured from a real Android SDK 53 session (2026-07-16): with
     // failedQuest armed, usePathname() read bare '/quest' while segments read

--- a/src/lib/navigation/is-already-at-target.ts
+++ b/src/lib/navigation/is-already-at-target.ts
@@ -164,8 +164,20 @@ export function isAlreadyAtTarget(
       return segments[0] === 'streak-celebration';
     case 'first-quest-result':
       return segments[0] === 'first-quest-result';
+
+    // A hero-less account sitting in the app group must still be evicted to
+    // /no-hero. But tapping the screen's "Choose your hero" button resets
+    // onboarding and navigates to /onboarding/welcome WITHOUT changing any
+    // resolver input — serverUser is unchanged, so the resolver still answers
+    // 'no-hero' on the next render. A strict segments[0] === 'no-hero' match
+    // read that as "not there yet" and replaced the user straight back onto
+    // /no-hero, making the button inert (same dead-link shape as
+    // PRE_ACCOUNT_ZONE above, just not initiated from inside that zone).
     case 'no-hero':
-      return segments[0] === 'no-hero';
+      return (
+        segments[0] === 'no-hero' ||
+        Object.hasOwn(PRE_ACCOUNT_ZONE, segments[0])
+      );
 
     default: {
       const _exhaustive: never = target;

--- a/src/lib/navigation/is-already-at-target.ts
+++ b/src/lib/navigation/is-already-at-target.ts
@@ -25,6 +25,7 @@ const RESOLVER_OWNED_SEGMENTS: Record<ResolverOwnedSegment, true> = {
   'quest-completed-signup': true,
   'streak-celebration': true,
   'first-quest-result': true,
+  'no-hero': true,
 };
 
 /**
@@ -163,6 +164,8 @@ export function isAlreadyAtTarget(
       return segments[0] === 'streak-celebration';
     case 'first-quest-result':
       return segments[0] === 'first-quest-result';
+    case 'no-hero':
+      return segments[0] === 'no-hero';
 
     default: {
       const _exhaustive: never = target;

--- a/src/lib/navigation/navigation-state-resolver.test.ts
+++ b/src/lib/navigation/navigation-state-resolver.test.ts
@@ -493,9 +493,11 @@ describe('Navigation State Resolver', () => {
   // A social signup (resolveSocialUser branch 4) creates a full, verified
   // account with NO character, so the user never passes through onboarding.
   // The step below is already COMPLETED because a previous run of the
-  // sync effect force-completed it and MMKV persisted that — so declining to
-  // force-complete is not enough on its own; the step has to be walked back.
-  it('sends a verified user whose server account has no character back to character creation', () => {
+  // sync effect force-completed it and MMKV persisted that. Routing here is
+  // synchronous (part of the render's return value, not a useEffect side
+  // effect) so the caller never sees an intermediate '/(app)' target — the
+  // silent bounce is the defect this replaces.
+  it('routes a hero-less signed-in account to the explanation, not silently home', () => {
     mockAuthState.status = 'signIn';
     mockOnboardingState.isOnboardingComplete.mockReturnValue(true);
     mockOnboardingState.currentStep = OnboardingStep.COMPLETED;
@@ -505,12 +507,10 @@ describe('Navigation State Resolver', () => {
     mockUserState.user = { id: 'u1', type: '', name: '', email: 'a@b.com' };
     mockGetItem.mockReturnValue(null); // no provisional data
 
-    renderHook(() => useNavigationTarget());
+    const { result } = renderHook(() => useNavigationTarget());
 
-    // Assert the step MOVED, not that a setter was called. setCurrentStep is
-    // forward-only, so "called with SELECTING_CHARACTER" is satisfied by a
-    // request the store silently discards.
-    expect(mockOnboardingState.currentStep).toBe(OnboardingStep.NOT_STARTED);
+    expect(result.current).toEqual({ type: 'no-hero' });
+    expect(result.current).not.toEqual({ type: 'app' });
   });
 
   // The over-application guard for the test above. A returning user on a fresh

--- a/src/lib/navigation/navigation-state-resolver.test.ts
+++ b/src/lib/navigation/navigation-state-resolver.test.ts
@@ -39,10 +39,36 @@ const mockAuthState = {
   status: 'idle' as 'idle' | 'signOut' | 'signIn' | 'hydrating',
 };
 
+// Step order, mirrored from the real store so the double below can enforce the
+// same rule. Kept local rather than exported from the store: the point is for
+// this file to encode what the store PROMISES, so a change there fails here.
+const STEP_ORDER: Record<OnboardingStep, number> = {
+  [OnboardingStep.NOT_STARTED]: 0,
+  [OnboardingStep.SELECTING_CHARACTER]: 1,
+  [OnboardingStep.VIEWING_INTRO]: 2,
+  [OnboardingStep.REQUESTING_NOTIFICATIONS]: 3,
+  [OnboardingStep.STARTING_FIRST_QUEST]: 4,
+  [OnboardingStep.VIEWING_SIGNUP_PROMPT]: 5,
+  [OnboardingStep.COMPLETED]: 6,
+};
+
 const mockOnboardingState = {
   isOnboardingComplete: jest.fn(() => false),
   currentStep: OnboardingStep.NOT_STARTED,
-  setCurrentStep: jest.fn(),
+  // NOT a bare jest.fn(). The real setCurrentStep is FORWARD-ONLY: it silently
+  // refuses to move backwards and only logs a warning. A bare spy records the
+  // call and reports success, so a test asserting "we asked for step X" passes
+  // while the app does nothing — which is exactly how a broken fix for the
+  // character-less social account shipped and had to be caught on a device.
+  // Move backwards through resetOnboarding, which set()s directly.
+  setCurrentStep: jest.fn((step: OnboardingStep) => {
+    if (STEP_ORDER[step] >= STEP_ORDER[mockOnboardingState.currentStep]) {
+      mockOnboardingState.currentStep = step;
+    }
+  }),
+  resetOnboarding: jest.fn(() => {
+    mockOnboardingState.currentStep = OnboardingStep.NOT_STARTED;
+  }),
 };
 
 const mockCharacterState = {
@@ -107,6 +133,7 @@ beforeEach(() => {
   mockOnboardingState.isOnboardingComplete.mockReturnValue(false);
   mockOnboardingState.currentStep = OnboardingStep.NOT_STARTED;
   mockOnboardingState.setCurrentStep.mockClear();
+  mockOnboardingState.resetOnboarding.mockClear();
   mockCharacterState.character = null;
   mockUserState.user = null;
   mockQuestState.pendingQuest = null;
@@ -480,9 +507,10 @@ describe('Navigation State Resolver', () => {
 
     renderHook(() => useNavigationTarget());
 
-    expect(mockOnboardingState.setCurrentStep).toHaveBeenCalledWith(
-      OnboardingStep.SELECTING_CHARACTER
-    );
+    // Assert the step MOVED, not that a setter was called. setCurrentStep is
+    // forward-only, so "called with SELECTING_CHARACTER" is satisfied by a
+    // request the store silently discards.
+    expect(mockOnboardingState.currentStep).toBe(OnboardingStep.NOT_STARTED);
   });
 
   // The over-application guard for the test above. A returning user on a fresh

--- a/src/lib/navigation/navigation-state-resolver.test.ts
+++ b/src/lib/navigation/navigation-state-resolver.test.ts
@@ -8,6 +8,7 @@ import { useCharacterStore } from '@/store/character-store';
 import { OnboardingStep } from '@/store/onboarding-store';
 import { useOnboardingStore } from '@/store/onboarding-store';
 import { useQuestStore } from '@/store/quest-store';
+import { useUserStore } from '@/store/user-store';
 
 // Mock modules
 jest.mock('@/lib/storage');
@@ -15,6 +16,7 @@ jest.mock('@/lib/auth');
 jest.mock('@/store/onboarding-store');
 jest.mock('@/store/character-store');
 jest.mock('@/store/quest-store');
+jest.mock('@/store/user-store');
 
 // Setup mock implementations
 const mockGetItem = getItem as jest.MockedFunction<typeof getItem>;
@@ -45,6 +47,18 @@ const mockOnboardingState = {
 
 const mockCharacterState = {
   character: null as any,
+};
+
+const mockUseUserStore = useUserStore as jest.MockedFunction<
+  typeof useUserStore
+>;
+
+// The server's view of the account. `type`/`name` are '' (not undefined) when
+// the account has no character — see the server's transformUserResponse, whose
+// fallbacks are `character?.type || ''`. `user: null` means the post-sign-in
+// fetch has not landed yet, which is a DIFFERENT state from "has no character".
+const mockUserState = {
+  user: null as any,
 };
 
 const mockQuestState = {
@@ -79,6 +93,8 @@ beforeEach(() => {
     selector(mockCharacterState)
   );
 
+  mockUseUserStore.mockImplementation((selector) => selector(mockUserState));
+
   mockUseQuestStore.mockImplementation((selector) => {
     if (typeof selector === 'function') {
       return selector(mockQuestState);
@@ -92,6 +108,7 @@ beforeEach(() => {
   mockOnboardingState.currentStep = OnboardingStep.NOT_STARTED;
   mockOnboardingState.setCurrentStep.mockClear();
   mockCharacterState.character = null;
+  mockUserState.user = null;
   mockQuestState.pendingQuest = null;
   mockQuestState.recentCompletedQuest = null;
   mockQuestState.failedQuest = null;
@@ -442,6 +459,85 @@ describe('Navigation State Resolver', () => {
 
     // Should have called setCurrentStep to mark onboarding as complete
     expect(mockOnboardingState.setCurrentStep).toHaveBeenCalledWith(
+      OnboardingStep.COMPLETED
+    );
+  });
+
+  // A social signup (resolveSocialUser branch 4) creates a full, verified
+  // account with NO character, so the user never passes through onboarding.
+  // The step below is already COMPLETED because a previous run of the
+  // sync effect force-completed it and MMKV persisted that — so declining to
+  // force-complete is not enough on its own; the step has to be walked back.
+  it('sends a verified user whose server account has no character back to character creation', () => {
+    mockAuthState.status = 'signIn';
+    mockOnboardingState.isOnboardingComplete.mockReturnValue(true);
+    mockOnboardingState.currentStep = OnboardingStep.COMPLETED;
+    mockCharacterState.character = null;
+    mockQuestState.completedQuests = [];
+    // Empty strings, exactly as the server sends them for a null character.
+    mockUserState.user = { id: 'u1', type: '', name: '', email: 'a@b.com' };
+    mockGetItem.mockReturnValue(null); // no provisional data
+
+    renderHook(() => useNavigationTarget());
+
+    expect(mockOnboardingState.setCurrentStep).toHaveBeenCalledWith(
+      OnboardingStep.SELECTING_CHARACTER
+    );
+  });
+
+  // The over-application guard for the test above. A returning user on a fresh
+  // install ALSO has `character === null` at this moment — the post-sign-in
+  // fetch has not hydrated the store yet — so keying on the local character
+  // alone would drag them into character creation and overwrite the hero they
+  // already own. Only the server's empty type/name may trigger that.
+  it('still completes onboarding for a returning user whose server account has a character', () => {
+    mockAuthState.status = 'signIn';
+    mockOnboardingState.isOnboardingComplete.mockReturnValue(false);
+    mockOnboardingState.currentStep = OnboardingStep.NOT_STARTED;
+    mockCharacterState.character = null;
+    mockQuestState.completedQuests = [];
+    mockUserState.user = {
+      id: 'u1',
+      type: 'bard',
+      name: 'Tommy',
+      email: 'a@b.com',
+    };
+    mockGetItem.mockReturnValue(null);
+
+    renderHook(() => useNavigationTarget());
+
+    expect(mockOnboardingState.setCurrentStep).toHaveBeenCalledWith(
+      OnboardingStep.COMPLETED
+    );
+    expect(mockOnboardingState.setCurrentStep).not.toHaveBeenCalledWith(
+      OnboardingStep.SELECTING_CHARACTER
+    );
+  });
+
+  // Once the fix above routes a character-less social user into onboarding,
+  // they walk it while ALREADY signed in and non-provisional — the two
+  // conditions the force-complete branch keys on. Without a step check it
+  // fires the moment they pick a hero and skips the intro and first quest,
+  // which is the whole experience they were sent back for.
+  it('does not force-complete onboarding while a verified user is partway through it', () => {
+    mockAuthState.status = 'signIn';
+    mockOnboardingState.isOnboardingComplete.mockReturnValue(false);
+    mockOnboardingState.currentStep = OnboardingStep.VIEWING_INTRO;
+    // They have just chosen a hero locally; the server has not been told yet.
+    mockCharacterState.character = {
+      name: 'Tommy',
+      type: 'bard',
+      level: 1,
+      currentXP: 0,
+      xpToNextLevel: 100,
+    };
+    mockQuestState.completedQuests = [];
+    mockUserState.user = { id: 'u1', type: '', name: '', email: 'a@b.com' };
+    mockGetItem.mockReturnValue(null);
+
+    renderHook(() => useNavigationTarget());
+
+    expect(mockOnboardingState.setCurrentStep).not.toHaveBeenCalledWith(
       OnboardingStep.COMPLETED
     );
   });

--- a/src/lib/navigation/navigation-state-resolver.test.ts
+++ b/src/lib/navigation/navigation-state-resolver.test.ts
@@ -263,6 +263,68 @@ describe('Navigation State Resolver', () => {
     });
   });
 
+  it('redirects to first-quest-result for completed first quest during AUTHENTICATED onboarding (no provisional session)', () => {
+    // Named bug: a Google-first signup runs onboarding fully authenticated —
+    // no provisional session ever exists. The onboarding-flow predicate only
+    // recognized signOut/provisional, so completion routed to the regular
+    // quest-result screen, which cleared the quest WITHOUT advancing the
+    // onboarding step: the user was sent back to the wake-up CTA forever.
+    mockAuthState.status = 'signIn';
+    mockOnboardingState.isOnboardingComplete.mockReturnValue(false);
+    mockOnboardingState.currentStep = OnboardingStep.STARTING_FIRST_QUEST;
+    mockCharacterState.character = { type: 'alchemist', name: 'jeremy' };
+    mockUserState.user = { type: 'alchemist', name: 'jeremy' };
+    mockQuestState.recentCompletedQuest = { id: 'quest-1' };
+    mockGetItem.mockReturnValue(null); // no provisional anything
+
+    const { result } = renderHook(() => useNavigationTarget());
+
+    expect(result.current).toEqual({
+      type: 'first-quest-result',
+      outcome: 'completed',
+    });
+  });
+
+  it('redirects to first-quest-result for failed first quest during AUTHENTICATED onboarding (no provisional session)', () => {
+    mockAuthState.status = 'signIn';
+    mockOnboardingState.isOnboardingComplete.mockReturnValue(false);
+    mockOnboardingState.currentStep = OnboardingStep.STARTING_FIRST_QUEST;
+    mockCharacterState.character = { type: 'alchemist', name: 'jeremy' };
+    mockUserState.user = { type: 'alchemist', name: 'jeremy' };
+    mockQuestState.failedQuest = { id: 'quest-1' };
+    mockGetItem.mockReturnValue(null);
+
+    const { result } = renderHook(() => useNavigationTarget());
+
+    expect(result.current).toEqual({
+      type: 'first-quest-result',
+      outcome: 'failed',
+    });
+  });
+
+  it('keeps the regular quest-result for a verified user whose onboarding store was reset (NOT_STARTED is not "mid-onboarding")', () => {
+    // Counterpart to the two tests above: the flow predicate must not
+    // over-apply. A verified user with a wiped/reset onboarding store
+    // (legacy migration) is NOT mid-onboarding — their completed quest keeps
+    // the regular result screen, and the sync effect force-completes the
+    // store from NOT_STARTED.
+    mockAuthState.status = 'signIn';
+    mockOnboardingState.isOnboardingComplete.mockReturnValue(false);
+    mockOnboardingState.currentStep = OnboardingStep.NOT_STARTED;
+    mockCharacterState.character = { type: 'alchemist', name: 'jeremy' };
+    mockUserState.user = { type: 'alchemist', name: 'jeremy' };
+    mockQuestState.recentCompletedQuest = { id: 'quest-5' };
+    mockGetItem.mockReturnValue(null);
+
+    const { result } = renderHook(() => useNavigationTarget());
+
+    expect(result.current).toEqual({
+      type: 'quest-result',
+      questId: 'quest-5',
+      outcome: 'completed',
+    });
+  });
+
   it('redirects to quest-result for regular completed quest', () => {
     mockAuthState.status = 'signIn';
     mockOnboardingState.isOnboardingComplete.mockReturnValue(true);
@@ -605,6 +667,29 @@ describe('Navigation State Resolver', () => {
     expect(mockOnboardingState.setCurrentStep).toHaveBeenCalledWith(
       OnboardingStep.COMPLETED
     );
+  });
+
+  it('completes onboarding after a successful signup from the signup prompt (provisional conversion)', () => {
+    // Named bug: tapping "Continue with Google" on the claim-your-legend
+    // screen succeeded server-side, socialSignIn cleared the provisional
+    // keys, but the step stayed VIEWING_SIGNUP_PROMPT — the sync effect only
+    // fired from NOT_STARTED, and the VIEWING_SIGNUP_PROMPT special case
+    // routed the user straight back to the signup screen. Both social and
+    // magic-link conversions rely on this effect (see quest-completed-signup
+    // handleSocialSignInSuccess). VIEWING_SIGNUP_PROMPT is the LAST step, so
+    // completing from it skips nothing.
+    mockAuthState.status = 'signIn';
+    mockOnboardingState.isOnboardingComplete.mockReturnValue(false);
+    mockOnboardingState.currentStep = OnboardingStep.VIEWING_SIGNUP_PROMPT;
+    mockCharacterState.character = { type: 'alchemist', name: 'James' };
+    mockUserState.user = { type: 'alchemist', name: 'James' };
+    mockGetItem.mockReturnValue(null); // provisional keys cleared by socialSignIn
+
+    renderHook(() => useNavigationTarget());
+
+    // Assert the resulting STEP, not merely that a setter was called — the
+    // double enforces the store's forward-only rule.
+    expect(mockOnboardingState.currentStep).toBe(OnboardingStep.COMPLETED);
   });
 
   it('does not synchronize onboarding state for users with provisional data', () => {

--- a/src/lib/navigation/navigation-state-resolver.ts
+++ b/src/lib/navigation/navigation-state-resolver.ts
@@ -17,6 +17,7 @@ export type NavigationTarget =
   | { type: 'onboarding' }
   | { type: 'login' }
   | { type: 'app' }
+  | { type: 'no-hero' }
   | { type: 'loading' };
 
 export function useNavigationTarget(): NavigationTarget {
@@ -27,7 +28,6 @@ export function useNavigationTarget(): NavigationTarget {
   );
   const currentStep = useOnboardingStore((s) => s.currentStep);
   const setCurrentStep = useOnboardingStore((s) => s.setCurrentStep);
-  const resetOnboarding = useOnboardingStore((s) => s.resetOnboarding);
   const character = useCharacterStore((s) => s.character);
   const serverUser = useUserStore((s) => s.user);
 
@@ -81,6 +81,17 @@ export function useNavigationTarget(): NavigationTarget {
     shouldShowStreakCelebration,
   } = questState;
 
+  // A social signup (resolveSocialUser branch 4) mints a full, verified
+  // account with no character, so its owner never passes through onboarding.
+  // The server is the authority on that: transformUserResponse reports a null
+  // character as `type: ''` / `name: ''`, so an EMPTY string here means "this
+  // account has no hero", while `serverUser === null` means the post-sign-in
+  // fetch simply hasn't landed yet — a different state, and the one the
+  // force-complete branch below is for. Computed here (not just inside the
+  // effect) so the render's return value below can act on it synchronously.
+  const serverAccountHasNoCharacter =
+    !!serverUser && !(serverUser.type && serverUser.name);
+
   // Synchronize onboarding state when user is signed in but onboarding appears incomplete
   useEffect(() => {
     if (authStatus !== 'signIn') return;
@@ -93,30 +104,11 @@ export function useNavigationTarget(): NavigationTarget {
     );
     if (hasProvisionalData) return;
 
-    // A social signup (resolveSocialUser branch 4) mints a full, verified
-    // account with no character, so its owner never passes through onboarding.
-    // The server is the authority on that: transformUserResponse reports a null
-    // character as `type: ''` / `name: ''`, so an EMPTY string here means "this
-    // account has no hero", while `serverUser === null` means the post-sign-in
-    // fetch simply hasn't landed yet — a different state, and the one the
-    // force-complete below is for.
-    //
-    // Walk the step back rather than merely declining to complete it: an
-    // earlier run of this effect already force-completed these users and MMKV
-    // persisted that, so they stay stuck across relaunches otherwise.
-    //
-    // resetOnboarding, NOT setCurrentStep: the latter is forward-only and
-    // silently discards a backward move with only a console warning, so asking
-    // it for an earlier step leaves the user exactly where they were. Only
-    // resetOnboarding set()s the step directly. NOT_STARTED then runs the whole
-    // funnel from the welcome screen, which is what these users never saw.
-    const serverAccountHasNoCharacter =
-      !!serverUser && !(serverUser.type && serverUser.name);
+    // The hero-less case is handled synchronously below (type: 'no-hero') so
+    // it can't flash the app before this effect runs. resetOnboarding is no
+    // longer called here: it belongs to the '/no-hero' screen's button, which
+    // fires it when the user acts rather than as a side effect of a render.
     if (serverAccountHasNoCharacter && !character) {
-      console.log(
-        '🧭 Signed-in account has no character on the server - restarting onboarding'
-      );
-      resetOnboarding();
       return;
     }
 
@@ -144,7 +136,7 @@ export function useNavigationTarget(): NavigationTarget {
     serverUser,
     completedQuests,
     setCurrentStep,
-    resetOnboarding,
+    serverAccountHasNoCharacter,
   ]);
 
   // Debug current state
@@ -255,6 +247,17 @@ export function useNavigationTarget(): NavigationTarget {
       questId: recentCompletedQuest.id,
       outcome: 'completed',
     };
+  }
+
+  // Priority 2.5: Hero-less signed-in account. Checked synchronously here
+  // (not only inside the sync effect above) so a signed-in account with no
+  // server-side character never renders '/(app)' for a frame before this
+  // fires — that flash-then-correct was the original defect.
+  if (authStatus === 'signIn' && serverAccountHasNoCharacter && !character) {
+    console.log(
+      '🧭 Signed-in account has no character on the server - explaining before onboarding'
+    );
+    return { type: 'no-hero' };
   }
 
   // Priority 3: Onboarding

--- a/src/lib/navigation/navigation-state-resolver.ts
+++ b/src/lib/navigation/navigation-state-resolver.ts
@@ -89,6 +89,17 @@ export function useNavigationTarget(): NavigationTarget {
   // fetch simply hasn't landed yet — a different state, and the one the
   // force-complete branch below is for. Computed here (not just inside the
   // effect) so the render's return value below can act on it synchronously.
+  //
+  // Checks both `type` and `name`, not just `type`: every user-reachable write
+  // path (createProvisionalUser, PATCH /users/me — user.validation.js) marks
+  // both fields required on the same request, so in ordinary onboarding they
+  // are never set independently. The one exception is the admin-only
+  // PATCH /users/:userId route (`manageUsers` scope), whose validation allows
+  // a partial character object and whose Mongoose update only validates the
+  // paths being $set — so a type-without-name (or vice versa) row isn't
+  // reachable from the app, but isn't impossible in the database either. This
+  // check is this account's last-line safety net, so covering that DB-only
+  // edge case costs nothing.
   const serverAccountHasNoCharacter =
     !!serverUser && !(serverUser.type && serverUser.name);
 

--- a/src/lib/navigation/navigation-state-resolver.ts
+++ b/src/lib/navigation/navigation-state-resolver.ts
@@ -5,6 +5,7 @@ import { getItem } from '@/lib/storage';
 import { useCharacterStore } from '@/store/character-store';
 import { OnboardingStep, useOnboardingStore } from '@/store/onboarding-store';
 import { useQuestStore } from '@/store/quest-store';
+import { useUserStore } from '@/store/user-store';
 
 export type NavigationTarget =
   | { type: 'pending-quest'; questId: string }
@@ -27,6 +28,7 @@ export function useNavigationTarget(): NavigationTarget {
   const currentStep = useOnboardingStore((s) => s.currentStep);
   const setCurrentStep = useOnboardingStore((s) => s.setCurrentStep);
   const character = useCharacterStore((s) => s.character);
+  const serverUser = useUserStore((s) => s.user);
 
   // Use direct subscription for quest state including completed quests
   const [questState, setQuestState] = useState(() => {
@@ -80,36 +82,56 @@ export function useNavigationTarget(): NavigationTarget {
 
   // Synchronize onboarding state when user is signed in but onboarding appears incomplete
   useEffect(() => {
-    if (authStatus === 'signIn' && !isOnboardingComplete) {
-      // Check if user has provisional data (indicating they're a new user going through onboarding)
-      const hasProvisionalData = !!(
-        getItem('provisionalUserId') ||
-        getItem('provisionalAccessToken') ||
-        getItem('provisionalEmail')
+    if (authStatus !== 'signIn') return;
+
+    // Check if user has provisional data (indicating they're a new user going through onboarding)
+    const hasProvisionalData = !!(
+      getItem('provisionalUserId') ||
+      getItem('provisionalAccessToken') ||
+      getItem('provisionalEmail')
+    );
+    if (hasProvisionalData) return;
+
+    // A social signup (resolveSocialUser branch 4) mints a full, verified
+    // account with no character, so its owner never passes through onboarding.
+    // The server is the authority on that: transformUserResponse reports a null
+    // character as `type: ''` / `name: ''`, so an EMPTY string here means "this
+    // account has no hero", while `serverUser === null` means the post-sign-in
+    // fetch simply hasn't landed yet — a different state, and the one the
+    // force-complete below is for.
+    //
+    // Walk the step back rather than merely declining to complete it: an
+    // earlier run of this effect already force-completed these users and MMKV
+    // persisted that, so they stay stuck across relaunches otherwise.
+    const serverAccountHasNoCharacter =
+      !!serverUser && !(serverUser.type && serverUser.name);
+    if (serverAccountHasNoCharacter && !character) {
+      setCurrentStep(OnboardingStep.SELECTING_CHARACTER);
+      return;
+    }
+
+    // Only from a standing start. This branch exists for a verified user
+    // opening a fresh install, whose persisted step is therefore NOT_STARTED.
+    // Any other step means onboarding is actively in progress — which now
+    // happens to signed-in, non-provisional users too, since the branch above
+    // sends character-less accounts back into it. Completing them mid-flow
+    // would skip the intro and first quest they were sent back for.
+    if (!isOnboardingComplete && currentStep === OnboardingStep.NOT_STARTED) {
+      // User is signed in with no provisional data and no local data
+      // This indicates they're a verified user logging in on a fresh install
+      console.log(
+        '🧭 Detected verified user with no local data - marking onboarding as complete'
       );
 
-      if (!hasProvisionalData) {
-        // User is signed in with no provisional data and no local data
-        // This indicates they're a verified user logging in on a fresh install
-        console.log(
-          '🧭 Detected verified user with no local data - marking onboarding as complete'
-        );
-        console.log(
-          '🧭 Synchronizing onboarding state to COMPLETED for verified user'
-        );
-
-        // Mark onboarding as complete for verified users
-        setCurrentStep(OnboardingStep.COMPLETED);
-
-        console.log(
-          '🧭 Onboarding state synchronized successfully for verified user'
-        );
-      }
+      // Mark onboarding as complete for verified users
+      setCurrentStep(OnboardingStep.COMPLETED);
     }
   }, [
     authStatus,
     isOnboardingComplete,
+    currentStep,
     character,
+    serverUser,
     completedQuests,
     setCurrentStep,
   ]);

--- a/src/lib/navigation/navigation-state-resolver.ts
+++ b/src/lib/navigation/navigation-state-resolver.ts
@@ -27,6 +27,7 @@ export function useNavigationTarget(): NavigationTarget {
   );
   const currentStep = useOnboardingStore((s) => s.currentStep);
   const setCurrentStep = useOnboardingStore((s) => s.setCurrentStep);
+  const resetOnboarding = useOnboardingStore((s) => s.resetOnboarding);
   const character = useCharacterStore((s) => s.character);
   const serverUser = useUserStore((s) => s.user);
 
@@ -103,10 +104,19 @@ export function useNavigationTarget(): NavigationTarget {
     // Walk the step back rather than merely declining to complete it: an
     // earlier run of this effect already force-completed these users and MMKV
     // persisted that, so they stay stuck across relaunches otherwise.
+    //
+    // resetOnboarding, NOT setCurrentStep: the latter is forward-only and
+    // silently discards a backward move with only a console warning, so asking
+    // it for an earlier step leaves the user exactly where they were. Only
+    // resetOnboarding set()s the step directly. NOT_STARTED then runs the whole
+    // funnel from the welcome screen, which is what these users never saw.
     const serverAccountHasNoCharacter =
       !!serverUser && !(serverUser.type && serverUser.name);
     if (serverAccountHasNoCharacter && !character) {
-      setCurrentStep(OnboardingStep.SELECTING_CHARACTER);
+      console.log(
+        '🧭 Signed-in account has no character on the server - restarting onboarding'
+      );
+      resetOnboarding();
       return;
     }
 
@@ -134,6 +144,7 @@ export function useNavigationTarget(): NavigationTarget {
     serverUser,
     completedQuests,
     setCurrentStep,
+    resetOnboarding,
   ]);
 
   // Debug current state

--- a/src/lib/navigation/navigation-state-resolver.ts
+++ b/src/lib/navigation/navigation-state-resolver.ts
@@ -123,13 +123,21 @@ export function useNavigationTarget(): NavigationTarget {
       return;
     }
 
-    // Only from a standing start. This branch exists for a verified user
-    // opening a fresh install, whose persisted step is therefore NOT_STARTED.
-    // Any other step means onboarding is actively in progress — which now
-    // happens to signed-in, non-provisional users too, since the branch above
-    // sends character-less accounts back into it. Completing them mid-flow
-    // would skip the intro and first quest they were sent back for.
-    if (!isOnboardingComplete && currentStep === OnboardingStep.NOT_STARTED) {
+    // Only from a standing start — or from the very last step. NOT_STARTED
+    // is a verified user opening a fresh install. VIEWING_SIGNUP_PROMPT is a
+    // provisional user whose signup on the claim-your-legend screen just
+    // succeeded: socialSignIn/verifyMagicLink cleared the provisional keys
+    // (so the hasProvisionalData guard above no longer returns early), and
+    // both conversion paths rely on THIS effect to finish onboarding — it is
+    // the last step, so completing from it skips nothing. Every step in
+    // between means onboarding is actively in progress (the no-hero flow runs
+    // it fully authenticated); completing those mid-flow would skip the intro
+    // and first quest the user was sent back for.
+    if (
+      !isOnboardingComplete &&
+      (currentStep === OnboardingStep.NOT_STARTED ||
+        currentStep === OnboardingStep.VIEWING_SIGNUP_PROMPT)
+    ) {
       // User is signed in with no provisional data and no local data
       // This indicates they're a verified user logging in on a fresh install
       console.log(
@@ -186,9 +194,16 @@ export function useNavigationTarget(): NavigationTarget {
   const hasProvisionalSession = !!(
     getItem('provisionalUserId') || getItem('provisionalAccessToken')
   );
+  // A signed-in, non-provisional user can ALSO be mid-onboarding: a social
+  // signup with no hero is routed back through it fully authenticated, and no
+  // provisional session ever exists on that path. Any started-but-unfinished
+  // step therefore counts; NOT_STARTED stays excluded so a verified user on a
+  // fresh install (force-completed by the sync effect above) isn't captured.
   const isInOnboardingFlow =
     !isOnboardingComplete &&
-    (authStatus === 'signOut' || hasProvisionalSession);
+    (authStatus === 'signOut' ||
+      hasProvisionalSession ||
+      currentStep !== OnboardingStep.NOT_STARTED);
 
   // Priority 1: Streak celebration (highest priority to show before quest complete)
   if (shouldShowStreakCelebration) {

--- a/src/lib/services/user.test.ts
+++ b/src/lib/services/user.test.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import { apiClient } from '@/api/common/client';
+import { getAccessToken } from '@/api/token';
 import { posthogClient } from '@/lib/posthog';
 import { setItem } from '@/lib/storage';
 
@@ -21,6 +22,7 @@ import {
 
 // Mock dependencies
 jest.mock('@/api/common/client');
+jest.mock('@/api/token', () => ({ getAccessToken: jest.fn(() => null) }));
 jest.mock('@/lib/storage');
 jest.mock('uuid');
 
@@ -115,6 +117,18 @@ describe('User Service', () => {
   });
 
   describe('createProvisionalUser', () => {
+    it('refuses to mint a provisional account over an active real session', async () => {
+      // Named bug: Google-first signup → onboarding minted a SECOND server
+      // account, silently splitting quest runs across two identities.
+      (getAccessToken as jest.Mock).mockReturnValueOnce('real-access-token');
+
+      await expect(
+        createProvisionalUser({ type: 'alchemist', name: 'Tester' } as any)
+      ).rejects.toThrow('PROVISIONAL_WITH_ACTIVE_SESSION');
+
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
     it('identifies the user in PostHog with the server user id', async () => {
       mockUuidv4.mockReturnValue('test-uuid' as any);
       mockApiClient.post.mockResolvedValue({

--- a/src/lib/services/user.ts
+++ b/src/lib/services/user.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import { apiClient } from '@/api/common/client';
+import { getAccessToken } from '@/api/token';
 import { posthogClient } from '@/lib/posthog';
 import { setItem } from '@/lib/storage';
 import type { Character } from '@/store/types';
@@ -350,6 +351,14 @@ export async function refreshPremiumStatus(): Promise<{
 export async function createProvisionalUser(
   character: Character
 ): Promise<any> {
+  // Invariant: a device must never hold a real session AND mint a provisional
+  // account — every write path prefers the provisional token when it exists,
+  // so the two identities silently split the user's data (empty journal,
+  // zeroed server stats). Callers with a real session must PATCH the
+  // character onto that account (updateUserCharacter) instead.
+  if (getAccessToken()) {
+    throw new Error('PROVISIONAL_WITH_ACTIVE_SESSION');
+  }
   try {
     // Generate a provisional email using UUID
     const provisionalEmail = `${uuidv4()}@unquestapp.com`;


### PR DESCRIPTION
## Why

`resolveSocialUser` branch 4 was the only user-facing path that could create an account with no character. Anyone whose first action was "Sign in with Google" got a permanently hero-less account and an empty Profile.

Server side (emberglow-server#64, must merge and deploy first) deletes branch 4, so `/auth/social` is login-only — matching magic link, which has never had a create branch.

## What changed

- **No account? A screen, not a dead end.** The 404 renders the address the user authorized and hands them into onboarding. They pick a hero, the provisional account is created *with* it, and the Google tap at the end of onboarding converts it in place — hero intact. No credential is carried.
- **The Google chooser always appears.** `signOut()` before `signIn()`; without it the SDK silently reused the cached account and clearing app storage was the only escape.
- **The silent bounce got a destination.** The hero-less recovery now routes to `/no-hero`, which explains itself, instead of landing in the app and correcting a beat later. The gate treats onboarding as an acceptable place for a `no-hero`-targeted user, so the recovery button actually works instead of looping.
- Deletes two now-unreachable `created`-outcome branches.

## Retained from the original PR

`7383a59` (don't prompt signup for an already-signed-in user) and `9b10964`'s hook hoist (a real "Rendered more hooks" crash) are independent of branch 4 and stay.

## Verification

Full suite exit 0 (173 suites / 1953 passed / 3 skipped); type-check 0 errors; translations clean; every new assertion mutation-tested both ways, with different tests catching never-fires and always-fires. Device walk on the Android emulator still pending (blocked until emberglow-server#64 deploys).

**Apple sign-in is still unverified on a device** — it needs an iOS device before 2.0.0.

## Not in scope

`transformUserResponse` coerces a null character to `type: ''` / `level: 1`, fabricating a plausible value. Ticketed separately — it is a breaking wire-contract change and nothing here depends on it.