### PR TITLE
fix(nav): stop the gate evicting user-initiated streak navigation

### DIFF
--- a/src/app/streak-celebration.test.tsx
+++ b/src/app/streak-celebration.test.tsx
@@ -10,16 +10,25 @@ import StreakCelebrationScreen from './streak-celebration';
 // Create a shared router mock
 const mockRouterBack = jest.fn();
 const mockRouterPush = jest.fn();
+const mockRouterReplace = jest.fn();
+// Defaults to true — the common case is a user who PUSHED here from the play
+// header, journal or profile stats card, so there is somewhere to go back to.
+// Tests covering the auto-shown celebration set this false explicitly.
+const mockRouterCanGoBack = jest.fn(() => true);
 
 // Mock dependencies
 jest.mock('expo-router', () => ({
   router: {
     back: mockRouterBack,
     push: mockRouterPush,
+    replace: mockRouterReplace,
+    canGoBack: mockRouterCanGoBack,
   },
   useRouter: jest.fn(() => ({
     back: mockRouterBack,
     push: mockRouterPush,
+    replace: mockRouterReplace,
+    canGoBack: mockRouterCanGoBack,
   })),
   useFocusEffect: jest.fn((callback) => {
     // Immediately call the callback to simulate screen focus
@@ -230,6 +239,11 @@ describe('StreakCelebrationScreen', () => {
     mockCharacterStore.markStreakCelebrationShown.mockClear();
     mockRouterBack.mockClear();
     mockRouterPush.mockClear();
+    mockRouterReplace.mockClear();
+    // jest.clearAllMocks() resets recorded calls but NOT return values, so a
+    // mockReturnValue set inside one test would leak into every test after it.
+    // Restating the default here scopes that override to the test making it.
+    mockRouterCanGoBack.mockReturnValue(true);
     mockCharacterStore.dailyQuestStreak = 1;
 
     mockUseCharacterStore.mockImplementation((selector) =>
@@ -300,6 +314,26 @@ describe('StreakCelebrationScreen', () => {
       fireEvent.press(getByTestId('streak-continue-button'));
 
       expect(mockRouterBack).toHaveBeenCalled();
+    });
+
+    // This screen's exit stopped being NavigationGate's job when
+    // /streak-celebration became user-reachable (is-already-at-target.ts,
+    // USER_REACHABLE_SEGMENTS): the gate could not tell a deliberate tap from
+    // a stale auto-show, so it bounced the tappers back to Play.
+    //
+    // Nothing else moves the user now. The auto-shown celebration arrives via
+    // router.replace, so on a cold start there is no back entry and back() is
+    // a silent no-op — which would strand the user on this screen with the
+    // Continue button visibly doing nothing.
+    it('lands the user on the play screen when there is no back stack', () => {
+      mockRouterCanGoBack.mockReturnValue(false);
+
+      const { getByTestId } = render(<StreakCelebrationScreen />);
+
+      fireEvent.press(getByTestId('streak-continue-button'));
+
+      expect(mockRouterReplace).toHaveBeenCalledWith('/(app)');
+      expect(mockRouterBack).not.toHaveBeenCalled();
     });
 
     it('should call setShouldShowStreakCelebration(false) when Continue is pressed', () => {

--- a/src/app/streak-celebration.tsx
+++ b/src/app/streak-celebration.tsx
@@ -202,11 +202,43 @@ export default function StreakCelebrationScreen() {
     }
   };
 
+  /**
+   * This screen's exit is now its OWN responsibility.
+   *
+   * It used to lean on NavigationGate: clearing the flag made the resolver
+   * answer 'app', and the gate evicted whoever was still sitting here. That
+   * eviction is gone (is-already-at-target.ts, USER_REACHABLE_SEGMENTS) —
+   * it could not tell a user who tapped the flame from a stale auto-show, so
+   * it bounced the tappers straight back to Play. Nothing else will move the
+   * user now, so a `back()` that no-ops strands them.
+   *
+   * Two ways in, and they want different exits:
+   *  - Auto-shown after a streak-extending quest, via router.replace. The back
+   *    stack may be EMPTY (cold start), so back() can be a silent no-op.
+   *  - Tapped in via router.push from the play header, journal, or the profile
+   *    stats card. Back returns them where they were — journal or profile,
+   *    not Play.
+   *
+   * So: go back when there is somewhere to go back to, and fall back to Play
+   * when there is not. Returning a tapper to the journal or profile they came
+   * from beats relocating them to Play, and the accepted trade is that an
+   * auto-show with a non-empty stack returns to whatever preceded it.
+   *
+   * That last case is not left to chance either: the resolver ranks streak
+   * celebration ABOVE quest results (navigation-state-resolver.ts:209 vs 253),
+   * so clearing the flag with a recent completion still armed makes the gate
+   * navigate on to the quest result regardless of where this lands first.
+   */
   const handleContinue = () => {
     // Clear the flag when user clicks continue.
     setShouldShowStreakCelebration(false);
-    // Navigate back to the main app screen.
-    router.back();
+
+    if (router.canGoBack()) {
+      router.back();
+      return;
+    }
+
+    router.replace('/(app)');
   };
 
   return (

--- a/src/lib/navigation/is-already-at-target.test.ts
+++ b/src/lib/navigation/is-already-at-target.test.ts
@@ -65,17 +65,72 @@ describe('isAlreadyAtTarget', () => {
     });
   });
 
+  describe('the dead streak indicator regression', () => {
+    // Reported from a device on 2026-07-28: tapping the flame in the play
+    // screen header flashed the streak screen and bounced straight back to
+    // Play. The logs showed the whole chain — "Default to app", immediately
+    // followed by "navigating to app from /streak-celebration".
+    //
+    // The resolver only names 'streak-celebration' while
+    // shouldShowStreakCelebration is true, so a user who taps in when it is
+    // false gets the Priority 5 fall-through 'app', and a strict
+    // resolver-owns-this match read their deliberate arrival as a stale one.
+    it('leaves the user on the streak screen they tapped into', () => {
+      expect(
+        isAlreadyAtTarget(
+          { type: 'app' },
+          ['streak-celebration'],
+          '/streak-celebration'
+        )
+      ).toBe(true);
+    });
+
+    // The carve-out is scoped to target 'app' — the resolver's "nothing is
+    // happening" answer — and nothing else. This is the guard against
+    // over-applying the fix: a version that always reported a match would pass
+    // the test above too, and would strand a user on their streak screen while
+    // a quest was counting down behind it.
+    // 'quest-result' is the load-bearing one: the resolver deliberately ranks
+    // streak celebration ABOVE quest results (navigation-state-resolver.ts:208
+    // — "highest priority to show before quest complete"), so the auto-shown
+    // celebration hands off to the quest result the moment the flag clears.
+    // That handoff is the gate's, and it runs through this function.
+    it.each([
+      'pending-quest',
+      'cooperative-pending-quest',
+      'quest-result',
+      'first-quest-result',
+      'login',
+      'onboarding',
+      'no-hero',
+    ])('target %s still evicts a user reading their streak', (type) => {
+      expect(
+        isAlreadyAtTarget(
+          { type, questId: 'q1', outcome: 'completed' } as any,
+          ['streak-celebration'],
+          '/streak-celebration'
+        )
+      ).toBe(false);
+    });
+  });
+
   describe('screens the resolver owns are still evacuated on target app', () => {
     // Load-bearing: nothing else moves the user off these. login-form hands off
     // to /onboarding/welcome, and the end of onboarding has no self-navigation
     // at all — the gate is what puts a freshly-onboarded user into the app.
+    //
+    // 'streak-celebration' was in this list and is deliberately not any more.
+    // It was the one entry the rationale above never applied to: that screen
+    // has three user-facing entry points, so membership could not be read as
+    // "the resolver put you here". Its exit is now the screen's own
+    // responsibility rather than the gate's — see the dead streak indicator
+    // regression above, and streak-celebration.test.tsx.
     it.each([
       'login',
       'onboarding',
       'pending-quest',
       'cooperative-pending-quest',
       'quest-completed-signup',
-      'streak-celebration',
       'first-quest-result',
     ])('evacuates /%s', (segment) => {
       expect(isAlreadyAtTarget({ type: 'app' }, [segment], `/${segment}`)).toBe(

--- a/src/lib/navigation/is-already-at-target.ts
+++ b/src/lib/navigation/is-already-at-target.ts
@@ -68,6 +68,40 @@ const PRE_ACCOUNT_ZONE: Partial<Record<ResolverOwnedSegment, true>> = {
 };
 
 /**
+ * Resolver-owned screens that ALSO have their own entry points, and so must
+ * survive the Priority 5 'app' fall-through.
+ *
+ * `RESOLVER_OWNED_SEGMENTS` encodes "only the resolver puts you here", which
+ * lets target 'app' read any membership as a stale state-driven arrival and
+ * evict. That inference is sound for screens with no other way in. It is false
+ * for `/streak-celebration`: three affordances push it on purpose — the play
+ * screen header and journal (`StreakCounter`) and the profile stats card — and
+ * the resolver only names it while `shouldShowStreakCelebration` is true. Tap
+ * the flame on any other day and the resolver answers 'app', so the gate
+ * replaced the user back onto Play before the screen could be read
+ * (emberglow#365, captured on device 2026-07-28).
+ *
+ * Same defect shape as PRE_ACCOUNT_ZONE above — store state cannot express
+ * "the user just tapped" — but a distinct carve-out, because that zone answers
+ * "which screens satisfy each other" while this one answers "which screens the
+ * absence of a destination is no reason to leave".
+ *
+ * The safety this gives up is real and is paid for elsewhere: the gate used to
+ * be the fallback that landed an auto-shown celebration back home when
+ * `handleContinue` cleared the flag and `router.back()` had nowhere to go. That
+ * screen now guarantees its own exit rather than leaning on eviction, which is
+ * where the guarantee belonged — the gate cannot tell the two arrivals apart,
+ * and the screen does not need to.
+ *
+ * Scoped to target 'app' only. Every higher-priority target still evicts from
+ * here (see the strict cases below): a pending quest outranks reading your
+ * streak, and those are consequences of state the user cannot opt out of.
+ */
+const USER_REACHABLE_SEGMENTS: Partial<Record<ResolverOwnedSegment, true>> = {
+  'streak-celebration': true,
+};
+
+/**
  * Answers "is where we are good enough for `target`?" so NavigationGate can skip
  * a redirect.
  *
@@ -118,6 +152,13 @@ export function isAlreadyAtTarget(
       // a dependency of the gate's effect, so the real decision is only
       // deferred until they populate a tick later.
       if (root === undefined) {
+        return true;
+      }
+
+      // Screens the user can reach on purpose (see USER_REACHABLE_SEGMENTS)
+      // are resolver-owned but not resolver-exclusive: 'app' is the absence of
+      // a destination, which is no reason to take one away from them.
+      if (Object.hasOwn(USER_REACHABLE_SEGMENTS, root)) {
         return true;
       }
 


### PR DESCRIPTION
## The bug

Tapping the streak indicator flashed `/streak-celebration` and bounced straight back to Play. Reported on `main` from the simulator, with the whole chain visible in the logs:

```
🧭 Default to app
🧭 [NavigationGate] navigating to app from /streak-celebration ["streak-celebration"]
```

**Three affordances were dead, not one** — the play screen header and journal (both via `StreakCounter`) and the profile stats card. All three push `/streak-celebration`.

## Root cause

`isAlreadyAtTarget`'s `'app'` case treated membership in `RESOLVER_OWNED_SEGMENTS` as proof the resolver put you there:

```ts
return !Object.hasOwn(RESOLVER_OWNED_SEGMENTS, root);
```

That inference is sound only for screens with no other way in. The resolver names `streak-celebration` **solely** while `shouldShowStreakCelebration` is true, so a tap on any other day falls through to Priority 5 `'app'`, and the gate read the user's deliberate arrival as a stale state-driven one.

**This is the third instance of the same defect class**, after the pre-account links (`PRE_ACCOUNT_ZONE`) and the `/no-hero` button. The gate derives one destination from store state, and store state cannot express "the user just tapped."

## The fix

**`is-already-at-target.ts`** — `USER_REACHABLE_SEGMENTS`, a carve-out scoped to target `'app'` only, so every higher-priority target still evicts (a pending quest outranks reading your streak). `RESOLVER_OWNED_SEGMENTS` stays complete so its compiler enforcement still catches a future unowned screen.

**`streak-celebration.tsx`** — `handleContinue` now guarantees its own exit (`canGoBack() ? back() : replace('/(app)')`). This was mandatory, not cleanup: the eviction being removed *was* the fallback that landed an auto-shown celebration home when the flag cleared and `back()` had nowhere to go on a cold start.

## Verification

| Gate | Result |
|---|---|
| Full suite | 173 suites / 1967 passed / 3 skipped / **0 failed** |
| `type-check` | 0 errors |
| eslint (changed files) | 0 errors |
| translations | clean |
| Device (simulator) | ✅ confirmed working |

Green alone proves nothing here, so every new assertion was mutation-tested — and both directions are caught by **different** tests:

**Carve-out**
- deleted (never fires) → 1 test fails (the regression test)
- hoisted above the switch (always fires) → 6 *different* tests fail

**Exit guard**
- always `replace` → the back test fails
- always `back` → the no-stack test fails
- calls **both** → the no-stack test fails

That last one matters: a carve-out returning `true` unconditionally makes the tap work perfectly in the simulator *and* strands users on the streak screen while a quest counts down behind it. The happy-path fix and the broken fix are indistinguishable by hand.

## Not included

`invitation-waiting.tsx:117` pushes `/cooperative-pending-quest`. **Not the same bug** — it's a state-driven `useEffect`, and if `pendingQuest` is already set the resolver names that screen and nothing evicts. It is only a defect if the store lags the push, which is unproven. Flagged, not fixed, not filed.

The celebration/detail split is also out of scope: `/streak-celebration` is still one route doing two jobs (state-driven interstitial *and* user destination). This fix makes that survivable, not clean.
