### PR TITLE
fix: don't sign users out when token refresh fails for network reasons

### DIFF
--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -721,22 +721,52 @@ describe('auth.ts', () => {
       expect(result).toBeNull();
     });
 
-    it('should clear tokens and return null on refresh error', async () => {
-      const error = new Error('Refresh failed');
+    it('clears tokens and returns null when the server rejects the refresh token (401)', async () => {
       (tokenService.getRefreshToken as jest.Mock).mockReturnValue(
         'old-refresh-token'
       );
-      (tokenService.removeTokens as jest.Mock).mockImplementation(() => {}); // Reset to not throw
-      (authClient.post as jest.Mock).mockRejectedValue(error);
+      (tokenService.removeTokens as jest.Mock).mockImplementation(() => {});
+      (authClient.post as jest.Mock).mockRejectedValue({
+        response: { status: 401 },
+      });
 
       const result = await refreshAccessToken();
 
-      expect(console.error).toHaveBeenCalledWith(
-        'Error refreshing token:',
-        error
-      );
       expect(tokenService.removeTokens).toHaveBeenCalled();
       expect(result).toBeNull();
+    });
+
+    it('keeps tokens and rethrows on a network error', async () => {
+      // A refresh that dies in transit says NOTHING about the refresh
+      // token's validity. Destroying the tokens here signed real users out
+      // for a tunnel or a Render cold-start timeout (emberglow-server#70).
+      const error = new Error('timeout of 10000ms exceeded');
+      (tokenService.getRefreshToken as jest.Mock).mockReturnValue(
+        'old-refresh-token'
+      );
+      (tokenService.removeTokens as jest.Mock).mockImplementation(() => {});
+      (authClient.post as jest.Mock).mockRejectedValue(error);
+
+      await expect(refreshAccessToken()).rejects.toThrow(
+        'timeout of 10000ms exceeded'
+      );
+      expect(tokenService.removeTokens).not.toHaveBeenCalled();
+    });
+
+    it('keeps tokens and rethrows on a server error (5xx)', async () => {
+      (tokenService.getRefreshToken as jest.Mock).mockReturnValue(
+        'old-refresh-token'
+      );
+      (tokenService.removeTokens as jest.Mock).mockImplementation(() => {});
+      (authClient.post as jest.Mock).mockRejectedValue({
+        response: { status: 503 },
+        message: 'Service Unavailable',
+      });
+
+      await expect(refreshAccessToken()).rejects.toMatchObject({
+        response: { status: 503 },
+      });
+      expect(tokenService.removeTokens).not.toHaveBeenCalled();
     });
   });
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -416,9 +416,20 @@ export const refreshAccessToken =
       return newTokens;
     } catch (error) {
       console.error('Error refreshing token:', error);
-      // If refresh fails, clear tokens
-      tokenService.removeTokens();
-      return null;
+      // Only a 401 from /auth/refresh-tokens proves the refresh token itself
+      // is dead — that's the one case where clearing is correct. A network
+      // failure or 5xx says nothing about the token; clearing there signed
+      // real users out for a tunnel or a Render cold-start timeout
+      // (emberglow-server#70). Same discrimination refreshProvisionalTokens
+      // makes below. Rethrow so the caller can tell the two apart: null means
+      // "definitively dead, tokens cleared", a throw means "try again later".
+      const status = (error as { response?: { status?: number } })?.response
+        ?.status;
+      if (status === 401) {
+        tokenService.removeTokens();
+        return null;
+      }
+      throw error;
     }
   };
 

--- a/src/api/common/client.test.tsx
+++ b/src/api/common/client.test.tsx
@@ -262,7 +262,12 @@ describe('apiClient', () => {
         expect(refreshAccessToken).not.toHaveBeenCalled();
       });
 
-      it('should sign out when refresh fails', async () => {
+      it('does NOT sign out when the refresh throws (network/5xx) — the session may be fine', async () => {
+        // refreshAccessToken's contract (emberglow-server#70): it THROWS for
+        // indeterminate failures (network, 5xx) and only returns null after
+        // itself clearing tokens on a definitive 401. A throw here must not
+        // sign the user out — the TOKEN_REFRESH_EXHAUSTED escalation is the
+        // backstop if it keeps happening.
         (refreshAccessToken as jest.Mock).mockRejectedValue(
           new Error('Refresh failed')
         );
@@ -280,11 +285,7 @@ describe('apiClient', () => {
         await expect(responseInterceptor.onRejected(error)).rejects.toThrow(
           'Refresh failed'
         );
-        expect(signOut).toHaveBeenCalled();
-        expect(console.error).toHaveBeenCalledWith(
-          'Token refresh failed catastrophically:',
-          expect.any(Error)
-        );
+        expect(signOut).not.toHaveBeenCalled();
       });
 
       it('should sign out when refresh returns no token', async () => {
@@ -404,7 +405,9 @@ describe('apiClient', () => {
         refreshReject!(refreshError);
 
         await expect(promise1).rejects.toThrow('Refresh failed');
-        expect(signOut).toHaveBeenCalled();
+        // Queued requests fail, but an indeterminate refresh error must not
+        // end the session (see the network/5xx test above).
+        expect(signOut).not.toHaveBeenCalled();
       });
 
       describe('provisional users', () => {

--- a/src/api/common/client.tsx
+++ b/src/api/common/client.tsx
@@ -271,17 +271,17 @@ apiClient.interceptors.response.use(
           return Promise.reject(refreshError);
         }
       } catch (refreshError) {
-        console.error('Token refresh failed catastrophically:', refreshError);
+        console.error('Token refresh failed:', refreshError);
         processQueue(refreshError as Error);
 
-        // Check if this is a provisional user before signing out
-        if (!hasProvisionalCredentials()) {
-          signOut();
-        } else if (__DEV__) {
-          console.log(
-            '[API Client] Not signing out provisional user on catastrophic token refresh failure'
-          );
-        }
+        // A THROW from refreshAccessToken means the failure was
+        // indeterminate — network, 5xx, timeout — and says nothing about the
+        // refresh token's validity (a definitive 401 comes back as `null`
+        // AFTER the tokens were cleared, via the branch above). Signing out
+        // here logged real users out for a tunnel or a Render cold start
+        // (emberglow-server#70). The retry budget and the
+        // TOKEN_REFRESH_EXHAUSTED escalation remain the backstop if the
+        // failure persists.
         return Promise.reject(refreshError);
       } finally {
         isRefreshing = false;


### PR DESCRIPTION
Fixes emberglow-server#70. **Stacked on #373** (same 401-handler region) — merge #373 first; this then retargets to main automatically.

`refreshAccessToken` cleared the stored tokens in its catch-all, and the 401 interceptor signed the user out on any thrown refresh error — so a refresh that died in transit (tunnel, airplane mode, Render cold-start timeout, 5xx) destroyed a valid refresh token and logged a real user out.

Now mirrors the provisional path's discrimination from #373: only a definitive 401 from `/auth/refresh-tokens` clears tokens (returns null → interceptor signs out); indeterminate failures rethrow with tokens intact — the triggering request fails, the session survives, and the retry budget + `TOKEN_REFRESH_EXHAUSTED` escalation remain the backstop for persistent failure.

**Verification:** full suite 1988 passed / 3 skipped / 0 failed; type-check 0. Mutations, each killed by the intended test: always-clear (old behavior) fails the network + 5xx tests; never-clear fails the 401 test — different tests per direction; restoring `signOut()` in the interceptor catch fails the no-sign-out and queue-rejection tests.