### PR TITLE
fix: Back on a journal quest detail returns to the Journal, not Play

### DIFF
--- a/src/app/(app)/quest/[id].test.tsx
+++ b/src/app/(app)/quest/[id].test.tsx
@@ -30,6 +30,8 @@ jest.mock('expo-router', () => ({
   router: {
     replace: jest.fn(),
     push: jest.fn(),
+    back: jest.fn(),
+    canGoBack: jest.fn(() => true),
   },
 }));
 
@@ -843,6 +845,45 @@ describe('AppQuestDetailsScreen', () => {
 
       // Verify quest renders (animations are disabled in props)
       expect(screen.getByText('Morning Meditation')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Back Navigation', () => {
+    it('pops back to the journal (router.back) when opened from the journal', async () => {
+      mockUseLocalSearchParams.mockReturnValue({
+        id: 'quest-123',
+        from: 'journal',
+        questData: JSON.stringify(mockCompletedQuest),
+      });
+
+      const user = userEvent.setup();
+      await renderAsync(<AppQuestDetailsScreen />);
+
+      await user.press(screen.getByLabelText('Go back'));
+
+      // The journal pushed this screen, so the journal is still on the
+      // stack — replacing to home instead is the "Back lands on Play" bug.
+      expect(router.back).toHaveBeenCalled();
+      expect(router.replace).not.toHaveBeenCalled();
+    });
+
+    it('falls back to home when there is no stack to pop (deep link)', async () => {
+      mockUseLocalSearchParams.mockReturnValue({
+        id: 'quest-123',
+        from: 'journal',
+        questData: JSON.stringify(mockCompletedQuest),
+      });
+      // Once, not persistently: afterEach only clearAllMocks()es, which
+      // keeps mockReturnValue and would leak `false` into later tests.
+      (router.canGoBack as jest.Mock).mockReturnValueOnce(false);
+
+      const user = userEvent.setup();
+      await renderAsync(<AppQuestDetailsScreen />);
+
+      await user.press(screen.getByLabelText('Go back'));
+
+      expect(router.back).not.toHaveBeenCalled();
+      expect(router.replace).toHaveBeenCalledWith('/(app)');
     });
   });
 

--- a/src/app/(app)/quest/[id].tsx
+++ b/src/app/(app)/quest/[id].tsx
@@ -75,7 +75,15 @@ export default function AppQuestDetailsScreen() {
       }
     }
 
-    router.replace(APP_HOME_ROUTE);
+    // From the journal this screen was pushed, so pop back to it. In the
+    // post-quest result flow the stack behind us is stale (pending-quest),
+    // so replacing to home stays correct there. canGoBack guards the
+    // deep-link case where this screen is the first one on the stack.
+    if (from === 'journal' && router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace(APP_HOME_ROUTE);
+    }
   };
 
   const quest = useMemo(() => {


### PR DESCRIPTION
## Problem
Journal → tap a completed quest → tap Back landed on the home (Play) tab instead of returning to the Journal.

## Root cause
`src/app/(app)/quest/[id].tsx` doubles as the post-quest **result** screen, where `handleBackNavigation` deliberately does `router.replace('/(app)')` because the stack behind it is stale (pending-quest). The journal path reused that handler even though the journal `push`es this screen with `from: 'journal'`, leaving a valid history entry that was being thrown away.

## Fix
When `from === 'journal'` and `router.canGoBack()`, use `router.back()`. The replace-to-home behavior is preserved for the result flow and for deep links where the detail screen is the first screen on the stack. Quest-state clearing (recent-completed / failed) is unchanged.

## Verification
- New journal-back test written RED first (failed with `router.back` never called), green after the fix.
- Mutation tested both ways, each caught by a **different** test:
  - revert to always-`replace` → journal-back test fails
  - always-`back()` → not-found screen test + deep-link fallback test fail
  - drop only the `canGoBack()` guard → deep-link fallback test fails
- `pnpm type-check` 0 errors; full suite 181 suites / 2055 passed / 3 skipped; ESLint clean on the changed source file.