### PR TITLE
feat: announcement bottom sheet for the female narrator voice launch

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -270,13 +270,27 @@ jest.mock('@gorhom/bottom-sheet', () => {
   const React = jest.requireActual('react');
   const RN = jest.requireActual('react-native');
 
-  // Mocked BottomSheetModal that supports refs with dismiss method
-  const MockedBottomSheetModal = React.forwardRef(({ children }: any, ref: any) => {
+  // Mocked BottomSheetModal that supports BOTH:
+  // 1. ref forwarding with dismiss/present methods (for emberglow BottomSheet)
+  // 2. .mock.calls introspection (for existing tests in bottom-sheet.test.tsx and unlock-celebration-modal.test.tsx)
+  //
+  // Keep jest.fn() for mock tracking, wrap in React.forwardRef for ref support,
+  // expose .mock property via live getter so jest.clearAllMocks() refreshes it.
+  const bottomSheetModalRender = jest.fn((props: any, ref: any) => {
     React.useImperativeHandle(ref, () => ({
       dismiss: jest.fn(),
       present: jest.fn(),
     }));
-    return React.createElement(RN.View, { testID: 'bottom-sheet-modal' }, children);
+    return React.createElement(
+      RN.View,
+      { testID: 'bottom-sheet-modal' },
+      props.children
+    );
+  });
+
+  const MockedBottomSheetModal = React.forwardRef(bottomSheetModalRender);
+  Object.defineProperty(MockedBottomSheetModal, 'mock', {
+    get: () => bottomSheetModalRender.mock,
   });
 
   return {

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -270,8 +270,17 @@ jest.mock('@gorhom/bottom-sheet', () => {
   const React = jest.requireActual('react');
   const RN = jest.requireActual('react-native');
 
+  // Mocked BottomSheetModal that supports refs with dismiss method
+  const MockedBottomSheetModal = React.forwardRef(({ children }: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({
+      dismiss: jest.fn(),
+      present: jest.fn(),
+    }));
+    return React.createElement(RN.View, { testID: 'bottom-sheet-modal' }, children);
+  });
+
   return {
-    BottomSheetModal: jest.fn(({ children }) => children),
+    BottomSheetModal: MockedBottomSheetModal,
     BottomSheetModalProvider: jest.fn(({ children }) => children),
     BottomSheetBackdrop: jest.fn(() => null),
     BottomSheetScrollView: jest.fn(({ children }) => children),

--- a/src/app/(app)/index.test.tsx
+++ b/src/app/(app)/index.test.tsx
@@ -86,10 +86,12 @@ const mockAnnouncementState = {
   hasSeenBranchingAnnouncement: false,
   hasSeenSkillTreeAnnouncement: false,
   hasSeenGuildsAnnouncement: false,
+  hasSeenNarratorVoiceAnnouncement: false,
   lastAnnouncementShownAt: null,
   setHasSeenBranchingAnnouncement: jest.fn(),
   setHasSeenSkillTreeAnnouncement: jest.fn(),
   setHasSeenGuildsAnnouncement: jest.fn(),
+  setHasSeenNarratorVoiceAnnouncement: jest.fn(),
   markAnnouncementShown: jest.fn(),
   getAnnouncementToShow: mockGetAnnouncementToShow,
 };
@@ -405,6 +407,22 @@ describe('Home Component - Integration Tests', () => {
       // The branching sheet content is mounted (bottom-sheet pattern).
       expect(screen.getByText('Your Story Just Got Deadlier')).toBeTruthy();
       expect(screen.getByText('Restart at Branching Point')).toBeTruthy();
+
+      unmount();
+    });
+
+    it('presents the narrator voice announcement and stamps the throttle when due', () => {
+      mockGetAnnouncementToShow.mockReturnValue('narratorVoice');
+
+      const { unmount } = render(<Home />);
+      jest.advanceTimersByTime(1500);
+
+      expect(mockAnnouncementState.markAnnouncementShown).toHaveBeenCalledTimes(
+        1
+      );
+      // The narrator sheet content is mounted (bottom-sheet pattern).
+      expect(screen.getByText('Choose Who Tells Your Story')).toBeTruthy();
+      expect(screen.getByText('Choose My Narrator')).toBeTruthy();
 
       unmount();
     });

--- a/src/app/(app)/index.tsx
+++ b/src/app/(app)/index.tsx
@@ -55,6 +55,7 @@ import {
 import { useOnboardingStore } from '@/store/onboarding-store';
 import { useQuestStore } from '@/store/quest-store';
 import { useSkillTreeStore } from '@/store/skill-tree-store';
+import type { User } from '@/store/types';
 import { useUserStore } from '@/store/user-store';
 import { shadows } from '@/theme';
 
@@ -86,33 +87,29 @@ function usePremiumRefreshOnMount(refreshPremiumStatus: () => void) {
   }, []);
 }
 
-export default function Home() {
-  const activeQuest = useQuestStore((state) => state.activeQuest);
-  const pendingQuest = useQuestStore((state) => state.pendingQuest);
-  const refreshAvailableQuests = useQuestStore(
-    (state) => state.refreshAvailableQuests
-  );
-  const availableQuests = useQuestStore((state) => state.availableQuests);
-
-  // Premium access state
-  const [showPaywallModal, setShowPaywallModal] = useState(false);
-  const { handlePaywallSuccess } = usePremiumAccess();
-
-  // Deck state with paywall reset. Item count is tied to QUEST_MODES
-  // (always the 3 fixed modes), not carouselData.length, so this hook can
-  // be called before useHomeData computes carouselData below.
-  const { activeIndex, progress, advance } = useCarouselState({
-    itemCount: QUEST_MODES.length,
-    onPaywallReset: () => {
-      if (showPaywallModal) {
-        setShowPaywallModal(false);
-      }
-    },
-  });
-
-  // Home-screen feature announcements. Gating + the once-per-day throttle live
-  // in the announcement store (see getAnnouncementToShow); these three refs are
-  // the sheets this screen presents.
+/**
+ * Feature-announcement modal refs plus the once-per-day gating effect that
+ * decides which (if any) to present.
+ *
+ * Extracted from `Home` for the same reason as `usePremiumRefreshOnMount`
+ * above: the component crept past the 500-line `max-lines-per-function`
+ * limit again once the narrator-voice announcement wiring landed. This block
+ * is self-contained — it reads only what its caller passes in and returns
+ * only the four modal refs `Home` renders. Gating and the once-per-day
+ * throttle itself still live in the announcement store (see
+ * `getAnnouncementToShow`).
+ */
+function useFeatureAnnouncementSheets({
+  hasCompletedFirstBranch,
+  user,
+  completedQuestsLength,
+  availablePerksLength,
+}: {
+  hasCompletedFirstBranch: boolean;
+  user: User | null;
+  completedQuestsLength: number;
+  availablePerksLength: number;
+}) {
   const branchingModal = useModal();
   const skillTreeModal = useModal();
   const guildsModal = useModal();
@@ -137,6 +134,87 @@ export default function Home() {
     (state) => state.markAnnouncementShown
   );
 
+  // Decide which feature announcement (if any) to surface, honoring the
+  // once-per-day cap. Previously three independent effects that could stack all
+  // three sheets in one session; now a single selector-driven effect.
+  useEffect(() => {
+    const which = getAnnouncementToShow(
+      {
+        hasSeenBranchingAnnouncement,
+        hasSeenSkillTreeAnnouncement,
+        hasSeenGuildsAnnouncement,
+        hasSeenNarratorVoiceAnnouncement,
+        lastAnnouncementShownAt,
+      },
+      {
+        hasCompletedFirstBranch,
+        isRegistered: !!user && !user.isProvisional,
+        completedQuestCount: completedQuestsLength,
+        availablePerksCount: availablePerksLength,
+      }
+    );
+
+    if (!which) return;
+
+    const modalByKey = {
+      branching: branchingModal,
+      skillTree: skillTreeModal,
+      guilds: guildsModal,
+      narratorVoice: narratorVoiceModal,
+    };
+
+    // Delay slightly to let the screen settle, then present and stamp the
+    // throttle so nothing else shows today.
+    const timer = setTimeout(() => {
+      modalByKey[which].present();
+      markAnnouncementShown();
+    }, 1500);
+
+    return () => clearTimeout(timer);
+  }, [
+    hasSeenBranchingAnnouncement,
+    hasSeenSkillTreeAnnouncement,
+    hasSeenGuildsAnnouncement,
+    hasSeenNarratorVoiceAnnouncement,
+    lastAnnouncementShownAt,
+    hasCompletedFirstBranch,
+    user,
+    completedQuestsLength,
+    availablePerksLength,
+    branchingModal,
+    skillTreeModal,
+    guildsModal,
+    narratorVoiceModal,
+    markAnnouncementShown,
+  ]);
+
+  return { branchingModal, skillTreeModal, guildsModal, narratorVoiceModal };
+}
+
+export default function Home() {
+  const activeQuest = useQuestStore((state) => state.activeQuest);
+  const pendingQuest = useQuestStore((state) => state.pendingQuest);
+  const refreshAvailableQuests = useQuestStore(
+    (state) => state.refreshAvailableQuests
+  );
+  const availableQuests = useQuestStore((state) => state.availableQuests);
+
+  // Premium access state
+  const [showPaywallModal, setShowPaywallModal] = useState(false);
+  const { handlePaywallSuccess } = usePremiumAccess();
+
+  // Deck state with paywall reset. Item count is tied to QUEST_MODES
+  // (always the 3 fixed modes), not carouselData.length, so this hook can
+  // be called before useHomeData computes carouselData below.
+  const { activeIndex, progress, advance } = useCarouselState({
+    itemCount: QUEST_MODES.length,
+    onPaywallReset: () => {
+      if (showPaywallModal) {
+        setShowPaywallModal(false);
+      }
+    },
+  });
+
   const completedQuests = useQuestStore((state) => state.completedQuests);
   // First branching quest (quest-1a or quest-1b) unlocks the restart offer.
   const hasCompletedFirstBranch = completedQuests.some(
@@ -146,6 +224,18 @@ export default function Home() {
   const availablePerks = useSkillTreeStore((state) =>
     state.getAvailablePerksToUnlock()
   );
+
+  // Home-screen feature announcements. Gating + the once-per-day throttle live
+  // in the announcement store (see getAnnouncementToShow); useFeatureAnnouncementSheets
+  // owns the modal refs and the selection effect, and returns the refs this
+  // screen presents.
+  const { branchingModal, skillTreeModal, guildsModal, narratorVoiceModal } =
+    useFeatureAnnouncementSheets({
+      hasCompletedFirstBranch,
+      user,
+      completedQuestsLength: completedQuests.length,
+      availablePerksLength: availablePerks.length,
+    });
 
   // Use server-driven quests
   const {
@@ -275,60 +365,6 @@ export default function Home() {
       }
     }
   }, [activeQuest]);
-
-  // Decide which feature announcement (if any) to surface, honoring the
-  // once-per-day cap. Previously three independent effects that could stack all
-  // three sheets in one session; now a single selector-driven effect.
-  useEffect(() => {
-    const which = getAnnouncementToShow(
-      {
-        hasSeenBranchingAnnouncement,
-        hasSeenSkillTreeAnnouncement,
-        hasSeenGuildsAnnouncement,
-        hasSeenNarratorVoiceAnnouncement,
-        lastAnnouncementShownAt,
-      },
-      {
-        hasCompletedFirstBranch,
-        isRegistered: !!user && !user.isProvisional,
-        completedQuestCount: completedQuests.length,
-        availablePerksCount: availablePerks.length,
-      }
-    );
-
-    if (!which) return;
-
-    const modalByKey = {
-      branching: branchingModal,
-      skillTree: skillTreeModal,
-      guilds: guildsModal,
-      narratorVoice: narratorVoiceModal,
-    };
-
-    // Delay slightly to let the screen settle, then present and stamp the
-    // throttle so nothing else shows today.
-    const timer = setTimeout(() => {
-      modalByKey[which].present();
-      markAnnouncementShown();
-    }, 1500);
-
-    return () => clearTimeout(timer);
-  }, [
-    hasSeenBranchingAnnouncement,
-    hasSeenSkillTreeAnnouncement,
-    hasSeenGuildsAnnouncement,
-    hasSeenNarratorVoiceAnnouncement,
-    lastAnnouncementShownAt,
-    hasCompletedFirstBranch,
-    user,
-    completedQuests.length,
-    availablePerks.length,
-    branchingModal,
-    skillTreeModal,
-    guildsModal,
-    narratorVoiceModal,
-    markAnnouncementShown,
-  ]);
 
   // Refresh available quests when there's no active quest
   // Only use local refresh if server quests aren't being used

--- a/src/app/(app)/index.tsx
+++ b/src/app/(app)/index.tsx
@@ -17,6 +17,7 @@ import { AVAILABLE_QUESTS } from '@/app/data/quests';
 import { Badge, Button } from '@/components/emberglow';
 import { BranchingStoryAnnouncementModal } from '@/components/modals/branching-story-announcement-modal';
 import { GuildsAnnouncementModal } from '@/components/modals/guilds-announcement-modal';
+import { NarratorVoiceAnnouncementModal } from '@/components/modals/narrator-voice-announcement-modal';
 import { SkillTreeAnnouncementModal } from '@/components/modals/skill-tree-announcement-modal';
 import { PremiumPaywall } from '@/components/paywall';
 import { StreakCounter } from '@/components/StreakCounter';
@@ -115,6 +116,7 @@ export default function Home() {
   const branchingModal = useModal();
   const skillTreeModal = useModal();
   const guildsModal = useModal();
+  const narratorVoiceModal = useModal();
 
   const hasSeenBranchingAnnouncement = useAnnouncementStore(
     (state) => state.hasSeenBranchingAnnouncement
@@ -124,6 +126,9 @@ export default function Home() {
   );
   const hasSeenGuildsAnnouncement = useAnnouncementStore(
     (state) => state.hasSeenGuildsAnnouncement
+  );
+  const hasSeenNarratorVoiceAnnouncement = useAnnouncementStore(
+    (state) => state.hasSeenNarratorVoiceAnnouncement
   );
   const lastAnnouncementShownAt = useAnnouncementStore(
     (state) => state.lastAnnouncementShownAt
@@ -280,6 +285,7 @@ export default function Home() {
         hasSeenBranchingAnnouncement,
         hasSeenSkillTreeAnnouncement,
         hasSeenGuildsAnnouncement,
+        hasSeenNarratorVoiceAnnouncement,
         lastAnnouncementShownAt,
       },
       {
@@ -296,6 +302,7 @@ export default function Home() {
       branching: branchingModal,
       skillTree: skillTreeModal,
       guilds: guildsModal,
+      narratorVoice: narratorVoiceModal,
     };
 
     // Delay slightly to let the screen settle, then present and stamp the
@@ -310,6 +317,7 @@ export default function Home() {
     hasSeenBranchingAnnouncement,
     hasSeenSkillTreeAnnouncement,
     hasSeenGuildsAnnouncement,
+    hasSeenNarratorVoiceAnnouncement,
     lastAnnouncementShownAt,
     hasCompletedFirstBranch,
     user,
@@ -318,6 +326,7 @@ export default function Home() {
     branchingModal,
     skillTreeModal,
     guildsModal,
+    narratorVoiceModal,
     markAnnouncementShown,
   ]);
 
@@ -573,6 +582,9 @@ export default function Home() {
 
       {/* Guilds Announcement Modal */}
       <GuildsAnnouncementModal ref={guildsModal.ref} />
+
+      {/* Narrator Voice Announcement Modal */}
+      <NarratorVoiceAnnouncementModal ref={narratorVoiceModal.ref} />
     </View>
   );
 }

--- a/src/components/modals/narrator-voice-announcement-modal.test.tsx
+++ b/src/components/modals/narrator-voice-announcement-modal.test.tsx
@@ -20,32 +20,6 @@ jest.mock('posthog-react-native', () => ({
   }),
 }));
 
-// Mock emberglow BottomSheet to properly forward refs in tests
-jest.mock('@/components/emberglow', () => {
-  const React = require('react');
-  const RN = require('react-native');
-
-  return {
-    BottomSheet: React.forwardRef(({ children, title }: any, ref: any) => {
-      // Ensure the ref passed in is properly exposed
-      if (ref && ref.current) {
-        // The ref.current already has dismiss, just ensure it's accessible
-      }
-      return (
-        <RN.View>
-          {title && <RN.Text>{title}</RN.Text>}
-          {children}
-        </RN.View>
-      );
-    }),
-    Button: ({ label, onPress, variant }: any) => (
-      <RN.TouchableOpacity onPress={onPress} testID={`button-${label}`}>
-        <RN.Text>{label}</RN.Text>
-      </RN.TouchableOpacity>
-    ),
-  };
-});
-
 describe('NarratorVoiceAnnouncementModal', () => {
   let mockRef: any;
 

--- a/src/components/modals/narrator-voice-announcement-modal.test.tsx
+++ b/src/components/modals/narrator-voice-announcement-modal.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, screen } from '@testing-library/react-native';
+import React from 'react';
+
+import { render } from '@/lib/test-utils';
+import { useAnnouncementStore } from '@/store/announcement-store';
+
+import { NarratorVoiceAnnouncementModal } from './narrator-voice-announcement-modal';
+
+const mockRouterPush = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
+
+const mockPosthogCapture = jest.fn();
+jest.mock('posthog-react-native', () => ({
+  usePostHog: () => ({
+    capture: mockPosthogCapture,
+  }),
+}));
+
+// Mock emberglow BottomSheet to properly forward refs in tests
+jest.mock('@/components/emberglow', () => {
+  const React = require('react');
+  const RN = require('react-native');
+
+  return {
+    BottomSheet: React.forwardRef(({ children, title }: any, ref: any) => {
+      // Ensure the ref passed in is properly exposed
+      if (ref && ref.current) {
+        // The ref.current already has dismiss, just ensure it's accessible
+      }
+      return (
+        <RN.View>
+          {title && <RN.Text>{title}</RN.Text>}
+          {children}
+        </RN.View>
+      );
+    }),
+    Button: ({ label, onPress, variant }: any) => (
+      <RN.TouchableOpacity onPress={onPress} testID={`button-${label}`}>
+        <RN.Text>{label}</RN.Text>
+      </RN.TouchableOpacity>
+    ),
+  };
+});
+
+describe('NarratorVoiceAnnouncementModal', () => {
+  let mockRef: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRef = { current: { dismiss: jest.fn() } };
+    // Real store, reset per test — assertions below check resulting state,
+    // not setter calls, per the repo's silent-pass trap list.
+    useAnnouncementStore.setState({ hasSeenNarratorVoiceAnnouncement: false });
+  });
+
+  describe('Rendering', () => {
+    it('renders the modal title', () => {
+      render(<NarratorVoiceAnnouncementModal ref={mockRef} />);
+      expect(screen.getByText('New: Narrator Voices')).toBeTruthy();
+    });
+
+    it('renders the main heading', () => {
+      render(<NarratorVoiceAnnouncementModal ref={mockRef} />);
+      expect(screen.getByText('Choose Who Tells Your Story')).toBeTruthy();
+    });
+
+    it('renders the description text', () => {
+      render(<NarratorVoiceAnnouncementModal ref={mockRef} />);
+      expect(
+        screen.getByText(/quest in Vaedros can now be narrated/i)
+      ).toBeTruthy();
+    });
+
+    it('renders both voices in the preview card with the new-voice badge', () => {
+      render(<NarratorVoiceAnnouncementModal ref={mockRef} />);
+      expect(screen.getByText('The Original Narrator')).toBeTruthy();
+      expect(screen.getByText('The New Narrator')).toBeTruthy();
+      expect(screen.getByText('NEW')).toBeTruthy();
+    });
+
+    it('renders the primary CTA and the maybe later option', () => {
+      render(<NarratorVoiceAnnouncementModal ref={mockRef} />);
+      expect(screen.getByText('Choose My Narrator')).toBeTruthy();
+      expect(screen.getByText('Maybe Later')).toBeTruthy();
+    });
+  });
+
+  describe('Interactions', () => {
+    it('accepted: marks seen in the store, captures the event, dismisses, and opens Settings', () => {
+      render(<NarratorVoiceAnnouncementModal ref={mockRef} />);
+
+      fireEvent.press(screen.getByText('Choose My Narrator'));
+
+      expect(
+        useAnnouncementStore.getState().hasSeenNarratorVoiceAnnouncement
+      ).toBe(true);
+      expect(mockPosthogCapture).toHaveBeenCalledWith(
+        'narrator_voice_announcement_accepted'
+      );
+      expect(mockRef.current.dismiss).toHaveBeenCalled();
+      expect(mockRouterPush).toHaveBeenCalledWith('/settings');
+    });
+
+    it('declined: marks seen in the store, captures the event, dismisses, does NOT navigate', () => {
+      render(<NarratorVoiceAnnouncementModal ref={mockRef} />);
+
+      fireEvent.press(screen.getByText('Maybe Later'));
+
+      expect(
+        useAnnouncementStore.getState().hasSeenNarratorVoiceAnnouncement
+      ).toBe(true);
+      expect(mockPosthogCapture).toHaveBeenCalledWith(
+        'narrator_voice_announcement_declined'
+      );
+      expect(mockRef.current.dismiss).toHaveBeenCalled();
+      expect(mockRouterPush).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/modals/narrator-voice-announcement-modal.tsx
+++ b/src/components/modals/narrator-voice-announcement-modal.tsx
@@ -1,0 +1,200 @@
+import type { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { useRouter } from 'expo-router';
+import { usePostHog } from 'posthog-react-native';
+import React, { forwardRef } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { BottomSheet, Button } from '@/components/emberglow';
+import { useAnnouncementStore } from '@/store/announcement-store';
+import { colors, fontFamily, palette, radii, spacing } from '@/theme';
+
+const VOICES = [
+  {
+    initial: 'M',
+    name: 'The Original Narrator',
+    tagline: 'The voice of Vaedros since day one',
+    background: colors.accent.primary,
+    color: colors.text.onAccent,
+    isNew: false,
+  },
+  {
+    initial: 'F',
+    name: 'The New Narrator',
+    tagline: 'A new voice joins the tale',
+    background: palette.sandy,
+    color: palette.richBlack,
+    isNew: true,
+  },
+];
+
+/** Two-voice preview in the same bordered fill.faint card style as guilds. */
+function VoicePreviewCard() {
+  return (
+    <View style={styles.previewCard}>
+      {VOICES.map((voice, index) => (
+        <View
+          key={voice.initial}
+          style={[styles.voiceRow, index > 0 && styles.voiceRowSpacing]}
+        >
+          <View
+            style={[styles.voiceAvatar, { backgroundColor: voice.background }]}
+          >
+            <Text style={[styles.voiceInitial, { color: voice.color }]}>
+              {voice.initial}
+            </Text>
+          </View>
+          <View style={styles.voiceInfo}>
+            <Text style={styles.voiceName}>{voice.name}</Text>
+            <Text style={styles.voiceTagline}>{voice.tagline}</Text>
+          </View>
+          {voice.isNew && (
+            <View style={styles.newBadge}>
+              <Text style={styles.newBadgeText}>NEW</Text>
+            </View>
+          )}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+export const NarratorVoiceAnnouncementModal = forwardRef<BottomSheetModal>(
+  (_, ref) => {
+    const router = useRouter();
+    const posthog = usePostHog();
+    const setHasSeenNarratorVoiceAnnouncement = useAnnouncementStore(
+      (state) => state.setHasSeenNarratorVoiceAnnouncement
+    );
+
+    const handleModalChange = (index: number) => {
+      if (index >= 0) {
+        posthog.capture('narrator_voice_announcement_viewed');
+      }
+    };
+
+    // Deep-link rather than switching immediately: character defaults already
+    // make the effective voice female for half the roster (see
+    // DEFAULT_VOICE_BY_CHARACTER), so "switch to female now" could be a no-op.
+    const handleChooseVoice = () => {
+      posthog.capture('narrator_voice_announcement_accepted');
+      setHasSeenNarratorVoiceAnnouncement(true);
+      // @ts-ignore - ref might be null but we check before calling
+      ref?.current?.dismiss();
+      router.push('/settings');
+    };
+
+    const handleDismiss = () => {
+      posthog.capture('narrator_voice_announcement_declined');
+      setHasSeenNarratorVoiceAnnouncement(true);
+      // @ts-ignore - ref might be null but we check before calling
+      ref?.current?.dismiss();
+    };
+
+    return (
+      <BottomSheet
+        ref={ref}
+        title="New: Narrator Voices"
+        onChange={handleModalChange}
+      >
+        <View style={styles.previewWrapper}>
+          <VoicePreviewCard />
+        </View>
+
+        <Text style={styles.heading}>Choose Who Tells Your Story</Text>
+
+        <Text style={styles.body}>
+          Every quest in Vaedros can now be narrated by a new female voice.
+          Switch anytime in Settings — your story, your storyteller.
+        </Text>
+
+        <View style={styles.actions}>
+          <Button
+            label="Choose My Narrator"
+            onPress={handleChooseVoice}
+            fullWidth
+          />
+          <Button
+            label="Maybe Later"
+            variant="ghost"
+            onPress={handleDismiss}
+            fullWidth
+          />
+        </View>
+      </BottomSheet>
+    );
+  }
+);
+
+const styles = StyleSheet.create({
+  previewWrapper: {
+    marginBottom: spacing[5],
+  },
+  previewCard: {
+    borderWidth: 1,
+    borderColor: colors.border.subtle,
+    backgroundColor: colors.fill.faint,
+    borderRadius: radii.lg,
+    padding: spacing[4],
+  },
+  voiceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+  },
+  voiceRowSpacing: {
+    marginTop: spacing[3],
+  },
+  voiceAvatar: {
+    width: 40,
+    height: 40,
+    borderRadius: radii.pill,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  voiceInitial: {
+    fontFamily: fontFamily.bold,
+    fontSize: 16,
+  },
+  voiceInfo: {
+    flex: 1,
+  },
+  voiceName: {
+    fontFamily: fontFamily.semibold,
+    fontSize: 16,
+    color: colors.text.primary,
+  },
+  voiceTagline: {
+    fontFamily: fontFamily.regular,
+    fontStyle: 'italic',
+    fontSize: 13,
+    color: colors.text.secondary,
+    marginTop: spacing[1] / 2,
+  },
+  newBadge: {
+    backgroundColor: colors.accent.primary,
+    borderRadius: radii.pill,
+    paddingHorizontal: spacing[2],
+    paddingVertical: spacing[1] / 2,
+  },
+  newBadgeText: {
+    fontFamily: fontFamily.bold,
+    fontSize: 10,
+    color: colors.text.onAccent,
+  },
+  heading: {
+    fontFamily: fontFamily.display,
+    fontSize: 20,
+    color: colors.text.primary,
+    marginBottom: spacing[2],
+  },
+  body: {
+    fontFamily: fontFamily.regular,
+    fontSize: 16,
+    lineHeight: 24,
+    color: colors.text.secondary,
+    marginBottom: spacing[6],
+  },
+  actions: {
+    gap: spacing[3],
+  },
+});

--- a/src/store/announcement-store.test.ts
+++ b/src/store/announcement-store.test.ts
@@ -16,7 +16,15 @@ const baseSeen = {
   hasSeenBranchingAnnouncement: false,
   hasSeenSkillTreeAnnouncement: false,
   hasSeenGuildsAnnouncement: false,
+  hasSeenNarratorVoiceAnnouncement: false,
   lastAnnouncementShownAt: null,
+};
+
+// narratorVoice has no engagement precondition, so tests that isolate OTHER
+// branches' gating must mark it seen or it wins by default.
+const narratorSeen = {
+  ...baseSeen,
+  hasSeenNarratorVoiceAnnouncement: true,
 };
 
 describe('parseLegacyAnnouncementFlags', () => {
@@ -79,6 +87,7 @@ describe('useAnnouncementStore', () => {
     expect(state.hasSeenBranchingAnnouncement).toBe(false);
     expect(state.hasSeenSkillTreeAnnouncement).toBe(false);
     expect(state.hasSeenGuildsAnnouncement).toBe(false);
+    expect(state.hasSeenNarratorVoiceAnnouncement).toBe(false);
     expect(state.lastAnnouncementShownAt).toBeNull();
   });
 
@@ -102,6 +111,14 @@ describe('useAnnouncementStore', () => {
     expect(useAnnouncementStore.getState().hasSeenGuildsAnnouncement).toBe(
       true
     );
+  });
+
+  it('setHasSeenNarratorVoiceAnnouncement flips only the narrator flag', () => {
+    useAnnouncementStore.getState().setHasSeenNarratorVoiceAnnouncement(true);
+    const state = useAnnouncementStore.getState();
+    expect(state.hasSeenNarratorVoiceAnnouncement).toBe(true);
+    expect(state.hasSeenBranchingAnnouncement).toBe(false);
+    expect(state.hasSeenGuildsAnnouncement).toBe(false);
   });
 
   it('markAnnouncementShown stamps a numeric timestamp', () => {
@@ -136,8 +153,8 @@ describe('getAnnouncementToShow (pure selector)', () => {
     availablePerksCount: 3,
   };
 
-  it('returns null when nothing is eligible', () => {
-    expect(getAnnouncementToShow(baseSeen, baseCtx, TODAY)).toBeNull();
+  it('returns null when nothing is eligible and narratorVoice was already seen', () => {
+    expect(getAnnouncementToShow(narratorSeen, baseCtx, TODAY)).toBeNull();
   });
 
   it('returns branching when it is unseen and its precondition is met', () => {
@@ -153,7 +170,7 @@ describe('getAnnouncementToShow (pure selector)', () => {
   it('gates skillTree behind registration', () => {
     expect(
       getAnnouncementToShow(
-        baseSeen,
+        narratorSeen,
         { ...baseCtx, availablePerksCount: 2 },
         TODAY
       )
@@ -170,7 +187,7 @@ describe('getAnnouncementToShow (pure selector)', () => {
   it('gates guilds behind registration and >= 3 completed quests', () => {
     expect(
       getAnnouncementToShow(
-        baseSeen,
+        narratorSeen,
         { ...baseCtx, isRegistered: true, completedQuestCount: 2 },
         TODAY
       )
@@ -211,7 +228,7 @@ describe('getAnnouncementToShow (pure selector)', () => {
   it('never returns an announcement the user has already seen', () => {
     expect(
       getAnnouncementToShow(
-        { ...baseSeen, hasSeenBranchingAnnouncement: true },
+        { ...narratorSeen, hasSeenBranchingAnnouncement: true },
         { ...baseCtx, hasCompletedFirstBranch: true },
         TODAY
       )
@@ -236,6 +253,41 @@ describe('getAnnouncementToShow (pure selector)', () => {
         TODAY
       )
     ).toBe('branching');
+  });
+
+  it('returns narratorVoice for any unseen user — no engagement precondition', () => {
+    // baseCtx is all-false/zero: not registered, no quests, no perks.
+    expect(getAnnouncementToShow(baseSeen, baseCtx, TODAY)).toBe(
+      'narratorVoice'
+    );
+  });
+
+  it('checks narratorVoice LAST: a user eligible for guilds AND narratorVoice gets guilds today', () => {
+    expect(
+      getAnnouncementToShow(
+        {
+          ...baseSeen,
+          hasSeenBranchingAnnouncement: true,
+          hasSeenSkillTreeAnnouncement: true,
+        },
+        allEligibleCtx,
+        TODAY
+      )
+    ).toBe('guilds');
+  });
+
+  it('narratorVoice respects the once-per-day cap', () => {
+    expect(
+      getAnnouncementToShow(
+        { ...baseSeen, lastAnnouncementShownAt: EARLIER_TODAY },
+        baseCtx,
+        TODAY
+      )
+    ).toBeNull();
+  });
+
+  it('never re-shows narratorVoice once seen', () => {
+    expect(getAnnouncementToShow(narratorSeen, baseCtx, TODAY)).toBeNull();
   });
 });
 

--- a/src/store/announcement-store.ts
+++ b/src/store/announcement-store.ts
@@ -18,7 +18,11 @@ import { getItem, removeItem, setItem } from '@/lib/storage';
  * user from getting all three stacked in one session.
  */
 
-export type AnnouncementKey = 'branching' | 'skillTree' | 'guilds';
+export type AnnouncementKey =
+  | 'branching'
+  | 'skillTree'
+  | 'guilds'
+  | 'narratorVoice';
 
 /**
  * Preconditions the store cannot read itself — supplied by the home screen from
@@ -36,6 +40,7 @@ export type AnnouncementSeenState = {
   hasSeenBranchingAnnouncement: boolean;
   hasSeenSkillTreeAnnouncement: boolean;
   hasSeenGuildsAnnouncement: boolean;
+  hasSeenNarratorVoiceAnnouncement: boolean;
   lastAnnouncementShownAt: number | null;
 };
 
@@ -102,12 +107,13 @@ export function parseLegacyAnnouncementFlags(
  *      shows today.
  *   2. Priority order — because of the day-cap, whichever is checked first is
  *      the one that shows *today*; the rest wait for a later day. Order is
- *      branching → skillTree → guilds (story progression first, social last).
+ *      branching → skillTree → guilds → narratorVoice (story progression first, social/narrator last).
  *
- * Preconditions (from `ctx`) match the three effects this replaced verbatim:
+ * Preconditions (from `ctx`) match the effects this replaced verbatim:
  *   - branching : ctx.hasCompletedFirstBranch
  *   - skillTree : ctx.isRegistered && ctx.availablePerksCount > 0
  *   - guilds    : ctx.isRegistered && ctx.completedQuestCount >= 3
+ *   - narratorVoice: none (always eligible if unseen)
  */
 export function getAnnouncementToShow(
   state: AnnouncementSeenState,
@@ -142,6 +148,14 @@ export function getAnnouncementToShow(
     return 'guilds';
   }
 
+  // narratorVoice: no engagement precondition — any user who hasn't seen it.
+  // Deliberately LAST so it never preempts the engagement announcements above;
+  // with the day-cap, users with several pending announcements see this one
+  // only after the others have had their day.
+  if (!state.hasSeenNarratorVoiceAnnouncement) {
+    return 'narratorVoice';
+  }
+
   return null;
 }
 
@@ -149,6 +163,7 @@ type AnnouncementStore = AnnouncementSeenState & {
   setHasSeenBranchingAnnouncement: (value: boolean) => void;
   setHasSeenSkillTreeAnnouncement: (value: boolean) => void;
   setHasSeenGuildsAnnouncement: (value: boolean) => void;
+  setHasSeenNarratorVoiceAnnouncement: (value: boolean) => void;
   /**
    * Stamp the once-per-day throttle. Fires when a sheet is *presented*, not when
    * it is dismissed — a user who force-quits without dismissing has still used
@@ -177,6 +192,7 @@ export const useAnnouncementStore = create<AnnouncementStore>()(
       hasSeenBranchingAnnouncement: legacySeed.hasSeenBranchingAnnouncement,
       hasSeenSkillTreeAnnouncement: legacySeed.hasSeenSkillTreeAnnouncement,
       hasSeenGuildsAnnouncement: legacySeed.hasSeenGuildsAnnouncement,
+      hasSeenNarratorVoiceAnnouncement: false,
       lastAnnouncementShownAt: null,
       setHasSeenBranchingAnnouncement: (value) =>
         set({ hasSeenBranchingAnnouncement: value }),
@@ -184,6 +200,8 @@ export const useAnnouncementStore = create<AnnouncementStore>()(
         set({ hasSeenSkillTreeAnnouncement: value }),
       setHasSeenGuildsAnnouncement: (value) =>
         set({ hasSeenGuildsAnnouncement: value }),
+      setHasSeenNarratorVoiceAnnouncement: (value) =>
+        set({ hasSeenNarratorVoiceAnnouncement: value }),
       markAnnouncementShown: () => set({ lastAnnouncementShownAt: Date.now() }),
       getAnnouncementToShow: (ctx) => getAnnouncementToShow(get(), ctx),
     }),


### PR DESCRIPTION
Closes #375

## What
- `narratorVoice` announcement key: LAST priority (branching → skillTree → guilds → narratorVoice), NO engagement precondition, participates in the once-per-day cap. Flag persists in `unquest-announcements`; no legacy-blob migration (flag never existed in `unquest-settings`).
- `NarratorVoiceAnnouncementModal`: Emberglow BottomSheet with a two-voice preview card, primary CTA deep-links to Settings, ghost "Maybe Later". Both paths mark seen permanently.
- Home screen wiring identical to the three existing announcement modals — with the whole announcement block (4 subscriptions, 4 modal refs, selection effect) extracted into a `useFeatureAnnouncementSheets` hook, because the added wiring pushed `Home` past the 500-line eslint `max-lines-per-function` cap. Behavior-preserving, byte-equivalent effect body.
- `jest-setup.ts`: the global `BottomSheetModal` mock is now `jest.fn` + `forwardRef` with a live `.mock` getter, so it supports BOTH ref forwarding (needed by the new modal test, which uses the real Emberglow components) and the `.mock.calls` introspection two existing suites rely on.
- PostHog: `narrator_voice_announcement_viewed` / `_accepted` / `_declined`.

## Design note
Primary CTA deep-links to Settings instead of calling `setNarratorVoice('female')` directly: `DEFAULT_VOICE_BY_CHARACTER` already defaults alchemist/bard/druid to female, so an unconditional switch would be a no-op with wrong confirmation copy for half the characters.

## Tests
- Store: no-precondition branch, LAST-priority ordering (mutation-verified by reordering branches), day-cap participation, never-reshow.
- Modal: real announcement store (state assertions, not setter-call assertions), accepted/declined paths, real BottomSheet/Button components.
- Home: presents the sheet and stamps the throttle; mutation-verified both ways (also re-verified after the hook extraction).
- Full suite: 182/182 suites, 2068 passed / 3 skipped; type-check 0; translations clean; touched-files eslint clean.

## Known minor (sibling-parity) behaviors
- Swipe/backdrop dismissal fires neither CTA, so the flag stays unseen and the sheet returns on a later day (day-cap still stamped for today). Same as the other three announcements — flagging in case "no answer ≠ declined" wasn't intentional.

## Device QA checklist
- [ ] Fresh user sees the sheet on home (after any higher-priority pending announcement has had its day)
- [ ] `viewed` event fires on present (onChange is not exercised in Jest)
- [ ] CTA lands on Settings with the Narrator voice row visible
- [ ] Sheet never reappears after either CTA; day-cap holds