### PR TITLE
fix(ci): complete the jest env stub so app.config.test.ts runs in CI

### DIFF
--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -1,4 +1,12 @@
-// Set environment variables for testing
+// Set environment variables for testing.
+// Must cover EVERY required var in the root env.js client schema: this file is
+// what lets suites that require app.config.ts (e.g. app.config.test.ts) run
+// hermetically — in CI there is no .env.* file, and dotenv never overrides
+// values set here. A var added to env.js but not here fails only in CI.
 process.env.API_URL = 'http://test-api.example.com';
 process.env.ONESIGNAL_APP_ID = 'test-onesignal-id';
 process.env.POSTHOG_API_KEY = 'test-posthog-key';
+process.env.REVENUECAT_APPLE_API_KEY = 'test-revenuecat-apple-key';
+process.env.REVENUECAT_GOOGLE_API_KEY = 'test-revenuecat-google-key';
+process.env.GOOGLE_WEB_CLIENT_ID = 'test-google-web-client-id';
+process.env.GOOGLE_IOS_CLIENT_ID = 'test-google-ios-client-id';


### PR DESCRIPTION
## Problem
The **Tests (jest)** check has been red on every push/PR since `073ad4e` (2026-07-28) — the commit that added `app.config.test.ts` (OTA-updates guard). That suite requires `app.config.ts` → `env.js`, whose zod schema now demands `REVENUECAT_APPLE_API_KEY`, `REVENUECAT_GOOGLE_API_KEY`, `GOOGLE_WEB_CLIENT_ID`, `GOOGLE_IOS_CLIENT_ID`. Locally dotenv fills those from `.env.development`; CI has no `.env` files, so `env.js` throws at require time and the suite fails to run. (Verified: main was green through `e27d10c`, first failure is the push that landed the suite; simulating CI locally — dotenv disabled, only the old stub vars set — reproduces the exact four `Required` field errors.)

## Fix
`.jest/setEnvVars.js` (jest `setupFiles`) already existed to make env-dependent code hermetic under jest, but was never updated when the four newer vars joined the schema. This adds them with dummy values and a comment explaining the invariant (every required var in `env.js`'s client schema must appear here, because CI has no `.env` file and dotenv never overrides pre-set values).

No workflow/secrets changes needed. Other suites are unaffected: `@env` resolves to `src/lib/env.js` (expo-constants, mocked), and the two suites referencing these var names mock `@env` themselves (re-ran both: 44/44).

## Verification
- Repro before fix: `APP_ENV=preview pnpm test app.config.test.ts` → suite fails to run with the same four field errors as CI. After fix: 4/4 pass.
- Plain `pnpm test app.config.test.ts`: 4/4 pass.
- The genuine red phase is CI itself — this PR's own Tests check going green is the proof.

Once merged, re-running the Tests check on open PRs (e.g. #381) picks up the fix via the merge ref and goes green.