### PR TITLE
fix(sentry): Android replay deadlock bump + quota/PII audit

### DIFF
--- a/docs/superpowers/specs/2026-08-02-invite-link-design.md
+++ b/docs/superpowers/specs/2026-08-02-invite-link-design.md
@@ -1,0 +1,109 @@
+# Invite a Friend with a Link — Design
+
+**Date:** 2026-08-02
+**Status:** Approved direction (validated section-by-section in brainstorming)
+**Issue:** tommyshellberg/emberglow#290
+**Supersedes:** `2026-07-21-social-invites-design.md` (its manual-code-entry UX is explicitly rejected here; its codebase audit remains accurate)
+
+## Goal
+
+A user shares one permanent link (`https://emberglowapp.com/i/{code}`). Anyone who taps it gets to the right app store, and after installing and opening the app they are attributed to the inviter **with no code entry and no contact picking**. The invitee gets a one-tap confirm ("X invited you — connect?"); confirming creates a pending friend request that the **link owner** approves or rejects. The same infrastructure tracks marketing/creator campaign installs (`/c/{code}`) without any friendship semantics.
+
+## Decisions (made during brainstorming)
+
+1. **DIY probabilistic attribution** — no third-party SDK. Branch's free tier caps at ~10K MAU with an enterprise-pricing cliff; AppsFlyer has no meaningful free tier. Branch is the documented fallback if match rates disappoint.
+2. **One permanent invite link per user** — no per-share minting. Per-share source analytics come from a `?src=` param appended at share time.
+3. **Universal links + Android App Links are set up as part of this feature** (neither exists today). Requires new native builds — this feature cannot ship OTA.
+4. **Invitee quick-confirm before anything is created** — absorbs fingerprint false positives and avoids leaking the invitee's profile to a wrong inviter.
+5. **Campaign links: schema + tracking now, no admin UI** — `/c/{code}` works end-to-end; campaign codes are created by script; payout reporting is a PostHog/Mongo query.
+
+## Architecture
+
+```
+Share sheet ──> emberglowapp.com/i/{code}?src=...
+                      │  (Vercel rewrite /i/* and /c/* → API server)
+                      ▼
+        GET /i/:code on API server (public, strictLimiter)
+        • record InviteClick {kind, code, ipHash, platform, src}
+        • PostHog invite_link_clicked
+        • interstitial page → store redirect
+          (Play URL carries &referrer=emberglow_invite%3D{code})
+                      │
+         install ──> first app open ──> POST /v1/invites/match
+                      │   (referrer wins; else ipHash+platform ≤48h)
+                      ▼
+        friend match: confirm prompt ──> POST /v1/invites/claim
+                      │
+                      ▼
+        plain existing Invitation (sender=invitee, recipientUser=owner)
+        → owner's existing pending-invite UI → accept/reject → mutual friends
+```
+
+Already-installed users tapping `/i/{code}` skip everything probabilistic: the universal link opens the app route directly with the exact code (deterministic). Brand-new users who re-tap the link after installing also land on the deterministic path.
+
+### Why the invite direction inverts
+
+The claim creates a standard `Invitation` document with `sender = invitee` and `recipientUser = owner`, and adds the invitee to the owner's `pendingFriends`. From that point the owner's existing invite list, `PATCH /v1/users/invites/:id/accept|reject`, and mutual-friending logic run **unchanged**. No new approval lifecycle is built.
+
+### match vs claim separation
+
+`POST /v1/invites/match` is read-only ("who invited me?") and creates nothing; `POST /v1/invites/claim` is the only mutation. A false fingerprint match therefore costs nothing — the human confirm sits between them. Deterministic entries (universal link, Play referrer) skip `match` entirely.
+
+## Server changes (`unquest-server`)
+
+### Data
+
+- **`User.inviteCode`** — short unique sparse-indexed code, lazily generated with `crypto.randomBytes` (same recipe as guild invite codes, `guild.service.js`).
+- **`User.inviteAttribution`** — `{ kind: 'friend'|'campaign', code, matchedAt, declined?: boolean }`, written once at match time. Serves as match idempotency guard and campaign-payout dedupe source.
+- **`InviteClick`** (new model) — `{ kind, code, ipHash, platform: 'ios'|'android'|'other', src, createdAt }` with a **72h TTL index**. `ipHash` is an HMAC of the client IP with a server secret — raw IPs are never stored.
+- **`Campaign`** (new model) — `{ code (unique), name, source, active }`. Created via script; no CRUD endpoints in this build.
+
+### Endpoints (route → Joi validate → catchAsync controller → service, house style)
+
+| Endpoint | Auth | Behavior |
+|---|---|---|
+| `GET /v1/users/me/invite-link` | auth (provisional OK) | Returns `{ code, url }`, lazily minting `inviteCode`. |
+| `GET /i/:code`, `GET /c/:code` | public, `strictLimiter` | Validate code (User.inviteCode / Campaign.code), record `InviteClick`, PostHog `invite_link_clicked`, render interstitial (pattern: `magic-link-page.js`; `Cache-Control: no-store`) that auto-redirects to the store by user-agent with both store buttons as fallback. Unknown code → generic "invite link isn't valid" page **with store buttons**, identical shape for both kinds (no enumeration signal). |
+| `POST /v1/invites/match` | auth (provisional OK) | Body: `{ platform, installReferrer? }`. Android referrer wins (deterministic). Else newest `InviteClick` matching `ipHash` + platform within 48h, excluding the caller's own code. Friend match → return `{ code, inviter: { characterName } }`, create nothing. Campaign match → record attribution server-side (`inviteAttribution` + PostHog `campaign_install_attributed`), return nothing actionable. Stamps `inviteAttribution` on any successful match (friend or campaign) so a match never fires twice per user; a no-match leaves it unset, allowing a retry on a later cold start. No-match → null. |
+| `POST /v1/invites/claim` | auth (provisional OK) | Body: `{ code }`. Guards: code exists (else 404), not self (400), not already friends / no existing pending pair (200 with `status: 'already_friends'|'already_pending'` — never an error for a fine state). Creates `Invitation { sender: invitee, recipient: owner.email, recipientUser: owner, status: 'pending' }` + `$addToSet` invitee into owner's `pendingFriends`. |
+
+Vercel (`unquest-landing-page`): rewrites for `/i/*` and `/c/*` → API server; static `/.well-known/apple-app-site-association` and `/.well-known/assetlinks.json` in `public/`. Only `/i/*` appears in AASA/App Links paths — campaign links must always reach the web page and bounce to the store.
+
+## Mobile app changes (`unquest`)
+
+- **Share flow:** "Invite a friend" action on the profile screen (contact-import entry points remain). `useInviteLink` react-query hook fetches the link; native `Share.share` (guild-screen pattern) sends message + link with `?src=` context param. PostHog `invite_link_shared`.
+- **First-launch match:** after provisional user creation succeeds (`choose-character.tsx` flow), call `POST /invites/match` once — reading the Play Install Referrer first on Android (small native lib, e.g. `react-native-play-install-referrer`). Friend match → store in a small MMKV-persisted Zustand slice (the prompt survives an app restart, since the server has already stamped the attribution and will not re-match) → confirm modal ("**{characterName} invited you to Emberglow — connect with them?**") shown at the next natural pause after onboarding, never interrupting character creation. Confirm → `claim` → toast. Dismiss → server stamps `declined`, never re-prompted. Match failure is swallowed and logged — attribution must never block onboarding; retried on next cold start only while `inviteAttribution` is unset.
+- **Universal link route:** new `src/app/i/[code].tsx`. Existing/provisional session → same confirm prompt with the URL's code (no fingerprint). No session yet → stash code in MMKV (`pendingInviteCode`), run normal onboarding, then skip `match` and go straight to confirm → claim with the stashed code.
+- **Native config (bare workflow — edit native dirs directly, `app.config.ts` plugins are inert):** iOS `applinks:emberglowapp.com` entitlement; Android `autoVerify` https intent filter for `emberglowapp.com` path prefix `/i/`; `assetlinks.json` carries the release signing cert fingerprint. New native builds required on both platforms.
+- **Owner side: no new UI.** The claim appears in the existing pending-invitations list with accept/reject. Optional copy tweak ("joined via your invite link") only if cheaply distinguishable; skip if fiddly.
+
+## Analytics (PostHog, both SDKs already integrated)
+
+Funnel: `invite_link_shared` (app) → `invite_link_clicked` (server; src/UTM/platform/country) → `invite_match_found` | `campaign_install_attributed` (server) → `invite_claimed` (server) → `invite_accepted_by_owner` (server, added to existing accept path).
+
+Campaign installs are countable as distinct users where `inviteAttribution.code = X`. Android campaign counts are deterministic (Play referrer); iOS counts are good-faith probabilistic estimates — state the methodology in creator deals. The `clicked` − `match_found` gap quantifies probabilistic loss.
+
+## Edge cases
+
+- **Self-claim:** claim → 400 `ApiError`; match never returns the caller's own code.
+- **Ambiguous fingerprint** (two codes, same ipHash+platform in window): newest wins; the named-inviter confirm lets a human decline a wrong guess.
+- **Expired window / VPN / no click record:** match → null; app silent. Accepted loss, measured by the funnel.
+- **Owner account deleted before claim:** claim 404; app drops the flow with a neutral toast.
+- **Double-tap / re-tapped link:** claim returns 200 with `already_pending` / `already_friends`, no user-facing error.
+- **No email is sent anywhere in this flow** — the existing invite path's email-failure/rescind logic does not apply.
+
+## Security & privacy
+
+- Public routes behind `strictLimiter`; identical generic pages for valid-shape-but-unknown codes.
+- IPs stored only as HMAC hashes; click records self-purge after 72h.
+- Fingerprint match reveals nothing without the invitee's confirm; owner approval is the second human gate.
+
+## Testing
+
+- **Server (Vitest, precedents: `friend-invite-email.test.js`, `magiclink-open.test.js`):** click recording + TTL field; interstitial (per-UA store redirect, referrer param, `no-store`); match (referrer beats fingerprint, window, newest-wins, own-code exclusion, idempotency stamp, campaign vs friend branch); claim guards (self / already-friends / duplicate-pending / dead code); full happy path click → match → claim → existing accept → mutual friends. After green, mutate guards both ways (e.g. remove own-code exclusion) and confirm the specific tests go red.
+- **App (Jest + RNTL):** `useInviteLink`; match-on-first-launch effect (mocked API, failure-swallowing); confirm modal render/confirm/dismiss; MMKV stash path for link-before-onboarding.
+- **Manual/device:** iOS universal link on a real device (AASA validation), `adb shell pm get-app-links` verification, one real Play referrer round-trip via the internal-testing track.
+
+## Out of scope
+
+Invite rewards/incentives; campaign CRUD or admin UI; payout reports beyond PostHog queries; Branch migration (documented fallback only); removing the contact-import flow.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2521,7 +2521,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNSentry (7.2.0):
+  - RNSentry (7.13.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2543,7 +2543,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - Sentry/HybridSDK (= 8.56.1)
+    - Sentry/HybridSDK (= 8.58.0)
     - Yoga
   - RNSVG (15.12.1):
     - hermes-engine
@@ -2672,7 +2672,7 @@ PODS:
   - SDWebImageWebPCoder (0.14.6):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
-  - Sentry/HybridSDK (8.56.1)
+  - Sentry/HybridSDK (8.58.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -3225,14 +3225,14 @@ SPEC CHECKSUMS:
   RNPurchases: 8760b3ac640aeb516104796f58c340362eeb043e
   RNReanimated: 4c22534d66ec0c382187cbeaa155d3154eff3c92
   RNScreens: d8d6f1792f6e7ac12b0190d33d8d390efc0c1845
-  RNSentry: 41979b419908128847ef662cc130a400b7576fa9
+  RNSentry: e01b22e35a8898557d54a09945975792e4fa6c65
   RNSVG: 31d6639663c249b7d5abc9728dde2041eb2a3c34
   RNWorklets: e31a7cd9e9b3d3cf8cb79a1c5f01e6573b5476f9
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  Sentry: b3ec44d01708fce73f99b544beb57e890eca4406
+  Sentry: d587a8fe91ca13503ecd69a1905f3e8a0fcf61be
   Yoga: 5934998fbeaef7845dbf698f698518695ab4cd1a
 
 PODFILE CHECKSUM: 4cc12bb7f70f1876ce1ae1381513b7639ac465b9

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@react-native-google-signin/google-signin": "^16.1.2",
     "@react-native-masked-view/masked-view": "0.3.2",
     "@react-native-picker/picker": "2.11.1",
-    "@sentry/react-native": "^7.2.0",
+    "@sentry/react-native": "^7.13.0",
     "@shopify/flash-list": "2.0.2",
     "@tanstack/react-query": "^5.52.1",
     "axios": "^1.7.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: 2.11.1
         version: 2.11.1(react-native@0.81.5(@babel/core@7.28.5)(@react-native/metro-config@0.86.0(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@sentry/react-native':
-        specifier: ^7.2.0
-        version: 7.2.0(expo@54.0.36)(react-native@0.81.5(@babel/core@7.28.5)(@react-native/metro-config@0.86.0(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        specifier: ^7.13.0
+        version: 7.13.0(expo@54.0.36)(react-native@0.81.5(@babel/core@7.28.5)(@react-native/metro-config@0.86.0(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@shopify/flash-list':
         specifier: 2.0.2
         version: 2.0.2(@babel/runtime@7.28.4)(react-native@0.81.5(@babel/core@7.28.5)(@react-native/metro-config@0.86.0(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -2143,88 +2143,88 @@ packages:
       zen-observable:
         optional: true
 
-  '@sentry-internal/browser-utils@10.12.0':
-    resolution: {integrity: sha512-dozbx389jhKynj0d657FsgbBVOar7pX3mb6GjqCxslXF0VKpZH2Xks0U32RgDY/nK27O+o095IWz7YvjVmPkDw==}
+  '@sentry-internal/browser-utils@10.38.0':
+    resolution: {integrity: sha512-UOJtYmdcxHCcV0NPfXFff/a95iXl/E0EhuQ1y0uE0BuZDMupWSF5t2BgC4HaE5Aw3RTjDF3XkSHWoIF6ohy7eA==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/feedback@10.12.0':
-    resolution: {integrity: sha512-0+7ceO6yQPPqfxRc9ue/xoPHKcnB917ezPaehGQNfAFNQB9PNTG1y55+8mRu0Fw+ANbZeCt/HyoCmXuRdxmkpg==}
+  '@sentry-internal/feedback@10.38.0':
+    resolution: {integrity: sha512-JXneg9zRftyfy1Fyfc39bBlF/Qd8g4UDublFFkVvdc1S6JQPlK+P6q22DKz3Pc8w3ySby+xlIq/eTu9Pzqi4KA==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay-canvas@10.12.0':
-    resolution: {integrity: sha512-W/z1/+69i3INNfPjD1KuinSNaRQaApjzwb37IFmiyF440F93hxmEYgXHk3poOlYYaigl2JMYbysGPWOiXnqUXA==}
+  '@sentry-internal/replay-canvas@10.38.0':
+    resolution: {integrity: sha512-OXWM9jEqNYh4VTvrMu7v+z1anz+QKQ/fZXIZdsO7JTT2lGNZe58UUMeoq386M+Saxen8F9SUH7yTORy/8KI5qw==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay@10.12.0':
-    resolution: {integrity: sha512-/1093gSNGN5KlOBsuyAl33JkzGiG38kCnxswQLZWpPpR6LBbR1Ddb18HjhDpoQNNEZybJBgJC3a5NKl43C2TSQ==}
+  '@sentry-internal/replay@10.38.0':
+    resolution: {integrity: sha512-YWIkL6/dnaiQyFiZXJ/nN+NXGv/15z45ia86bE/TMq01CubX/DUOilgsFz0pk2v/pg3tp/U2MskLO9Hz0cnqeg==}
     engines: {node: '>=18'}
 
-  '@sentry/babel-plugin-component-annotate@4.3.0':
-    resolution: {integrity: sha512-OuxqBprXRyhe8Pkfyz/4yHQJc5c3lm+TmYWSSx8u48g5yKewSQDOxkiLU5pAk3WnbLPy8XwU/PN+2BG0YFU9Nw==}
+  '@sentry/babel-plugin-component-annotate@4.9.1':
+    resolution: {integrity: sha512-0gEoi2Lb54MFYPOmdTfxlNKxI7kCOvNV7gP8lxMXJ7nCazF5OqOOZIVshfWjDLrc0QrSV6XdVvwPV9GDn4wBMg==}
     engines: {node: '>= 14'}
 
-  '@sentry/browser@10.12.0':
-    resolution: {integrity: sha512-lKyaB2NFmr7SxPjmMTLLhQ7xfxaY3kdkMhpzuRI5qwOngtKt4+FtvNYHRuz+PTtEFv4OaHhNNbRn6r91gWguQg==}
+  '@sentry/browser@10.38.0':
+    resolution: {integrity: sha512-3phzp1YX4wcQr9mocGWKbjv0jwtuoDBv7+Y6Yfrys/kwyaL84mDLjjQhRf4gL5SX7JdYkhBp4WaiNlR0UC4kTA==}
     engines: {node: '>=18'}
 
-  '@sentry/cli-darwin@2.55.0':
-    resolution: {integrity: sha512-jGHE7SHHzqXUmnsmRLgorVH6nmMmTjQQXdPZbSL5tRtH8d3OIYrVNr5D72DSgD26XAPBDMV0ibqOQ9NKoiSpfA==}
+  '@sentry/cli-darwin@2.58.4':
+    resolution: {integrity: sha512-kbTD+P4X8O+nsNwPxCywtj3q22ecyRHWff98rdcmtRrvwz8CKi/T4Jxn/fnn2i4VEchy08OWBuZAqaA5Kh2hRQ==}
     engines: {node: '>=10'}
     os: [darwin]
 
-  '@sentry/cli-linux-arm64@2.55.0':
-    resolution: {integrity: sha512-jNB/0/gFcOuDCaY/TqeuEpsy/k52dwyk1SOV3s1ku4DUsln6govTppeAGRewY3T1Rj9B2vgIWTrnB8KVh9+Rgg==}
+  '@sentry/cli-linux-arm64@2.58.4':
+    resolution: {integrity: sha512-0g0KwsOozkLtzN8/0+oMZoOuQ0o7W6O+hx+ydVU1bktaMGKEJLMAWxOQNjsh1TcBbNIXVOKM/I8l0ROhaAb8Ig==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-arm@2.55.0':
-    resolution: {integrity: sha512-ATjU0PsiWADSPLF/kZroLZ7FPKd5W9TDWHVkKNwIUNTei702LFgTjNeRwOIzTgSvG3yTmVEqtwFQfFN/7hnVXQ==}
+  '@sentry/cli-linux-arm@2.58.4':
+    resolution: {integrity: sha512-rdQ8beTwnN48hv7iV7e7ZKucPec5NJkRdrrycMJMZlzGBPi56LqnclgsHySJ6Kfq506A2MNuQnKGaf/sBC9REA==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-i686@2.55.0':
-    resolution: {integrity: sha512-8LZjo6PncTM6bWdaggscNOi5r7F/fqRREsCwvd51dcjGj7Kp1plqo9feEzYQ+jq+KUzVCiWfHrUjddFmYyZJrg==}
+  '@sentry/cli-linux-i686@2.58.4':
+    resolution: {integrity: sha512-NseoIQAFtkziHyjZNPTu1Gm1opeQHt7Wm1LbLrGWVIRvUOzlslO9/8i6wETUZ6TjlQxBVRgd3Q0lRBG2A8rFYA==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-x64@2.55.0':
-    resolution: {integrity: sha512-5LUVvq74Yj2cZZy5g5o/54dcWEaX4rf3myTHy73AKhRj1PABtOkfexOLbF9xSrZy95WXWaXyeH+k5n5z/vtHfA==}
+  '@sentry/cli-linux-x64@2.58.4':
+    resolution: {integrity: sha512-d3Arz+OO/wJYTqCYlSN3Ktm+W8rynQ/IMtSZLK8nu0ryh5mJOh+9XlXY6oDXw4YlsM8qCRrNquR8iEI1Y/IH+Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux, freebsd, android]
 
-  '@sentry/cli-win32-arm64@2.55.0':
-    resolution: {integrity: sha512-cWIQdzm1pfLwPARsV6dUb8TVd6Y3V1A2VWxjTons3Ift6GvtVmiAe0OWL8t2Yt95i8v61kTD/6Tq21OAaogqzA==}
+  '@sentry/cli-win32-arm64@2.58.4':
+    resolution: {integrity: sha512-bqYrF43+jXdDBh0f8HIJU3tbvlOFtGyRjHB8AoRuMQv9TEDUfENZyCelhdjA+KwDKYl48R1Yasb4EHNzsoO83w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@sentry/cli-win32-i686@2.55.0':
-    resolution: {integrity: sha512-ldepCn2t9r4I0wvgk7NRaA7coJyy4rTQAzM66u9j5nTEsUldf66xym6esd5ZZRAaJUjffqvHqUIr/lrieTIrVg==}
+  '@sentry/cli-win32-i686@2.58.4':
+    resolution: {integrity: sha512-3triFD6jyvhVcXOmGyttf+deKZcC1tURdhnmDUIBkiDPJKGT/N5xa4qAtHJlAB/h8L9jgYih9bvJnvvFVM7yug==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
     os: [win32]
 
-  '@sentry/cli-win32-x64@2.55.0':
-    resolution: {integrity: sha512-4hPc/I/9tXx+HLTdTGwlagtAfDSIa2AoTUP30tl32NAYQhx9a6niUbPAemK2qfxesiufJ7D2djX83rCw6WnJVA==}
+  '@sentry/cli-win32-x64@2.58.4':
+    resolution: {integrity: sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@sentry/cli@2.55.0':
-    resolution: {integrity: sha512-cynvcIM2xL8ddwELyFRSpZQw4UtFZzoM2rId2l9vg7+wDREPDocMJB9lEQpBIo3eqhp9JswqUT037yjO6iJ5Sw==}
+  '@sentry/cli@2.58.4':
+    resolution: {integrity: sha512-ArDrpuS8JtDYEvwGleVE+FgR+qHaOp77IgdGSacz6SZy6Lv90uX0Nu4UrHCQJz8/xwIcNxSqnN22lq0dH4IqTg==}
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@sentry/core@10.12.0':
-    resolution: {integrity: sha512-Jrf0Yo7DvmI/ZQcvBnA0xKNAFkJlVC/fMlvcin+5IrFNRcqOToZ2vtF+XqTgjRZymXQNE8s1QTD7IomPHk0TAw==}
+  '@sentry/core@10.38.0':
+    resolution: {integrity: sha512-1pubWDZE5y5HZEPMAZERP4fVl2NH3Ihp1A+vMoVkb3Qc66Diqj1WierAnStlZP7tCx0TBa0dK85GTW/ZFYyB9g==}
     engines: {node: '>=18'}
 
-  '@sentry/react-native@7.2.0':
-    resolution: {integrity: sha512-rjqYgEjntPz1sPysud78wi4B9ui7LBVPsG6qr8s/htLMYho9GPGFA5dF+eqsQWqMX8NDReAxNkLTC4+gCNklLQ==}
+  '@sentry/react-native@7.13.0':
+    resolution: {integrity: sha512-pKY+rln3CEnhnG21eUXcl/yeG5fkNruqXXjEikE5FjsyLmJi2POAGwT4tlupyHtG3fQT5mp06QI7bQdpAuH4Xw==}
     hasBin: true
     peerDependencies:
       expo: '>=49.0.0'
@@ -2234,14 +2234,14 @@ packages:
       expo:
         optional: true
 
-  '@sentry/react@10.12.0':
-    resolution: {integrity: sha512-TpqgdoYbkf5JynmmW2oQhHQ/h5w+XPYk0cEb/UrsGlvJvnBSR+5tgh0AqxCSi3gvtp82rAXI5w1TyRPBbhLDBw==}
+  '@sentry/react@10.38.0':
+    resolution: {integrity: sha512-3UiKo6QsqTyPGUt0XWRY9KLaxc/cs6Kz4vlldBSOXEL6qPDL/EfpwNJT61osRo81VFWu8pKu7ZY2bvLPryrnBQ==}
     engines: {node: '>=18'}
     peerDependencies:
       react: 19.1.0
 
-  '@sentry/types@10.12.0':
-    resolution: {integrity: sha512-sKGj3l3V8ZKISh2Tu88bHfnm5ztkRtSLdmpZ6TmCeJdSM9pV+RRd6CMJ0RnSEXmYHselPNUod521t2NQFd4W1w==}
+  '@sentry/types@10.38.0':
+    resolution: {integrity: sha512-DoeyTv/TvnoVDhHgdyv/wehieAKdyjLjEMtPOqqq/AjkP02BxeC0JYUrrWKOjV0wdLq5ZP8jKcCX8GN7awZonQ==}
     engines: {node: '>=18'}
 
   '@shopify/flash-list@2.0.2':
@@ -10230,59 +10230,59 @@ snapshots:
     transitivePeerDependencies:
       - zenObservable
 
-  '@sentry-internal/browser-utils@10.12.0':
+  '@sentry-internal/browser-utils@10.38.0':
     dependencies:
-      '@sentry/core': 10.12.0
+      '@sentry/core': 10.38.0
 
-  '@sentry-internal/feedback@10.12.0':
+  '@sentry-internal/feedback@10.38.0':
     dependencies:
-      '@sentry/core': 10.12.0
+      '@sentry/core': 10.38.0
 
-  '@sentry-internal/replay-canvas@10.12.0':
+  '@sentry-internal/replay-canvas@10.38.0':
     dependencies:
-      '@sentry-internal/replay': 10.12.0
-      '@sentry/core': 10.12.0
+      '@sentry-internal/replay': 10.38.0
+      '@sentry/core': 10.38.0
 
-  '@sentry-internal/replay@10.12.0':
+  '@sentry-internal/replay@10.38.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.12.0
-      '@sentry/core': 10.12.0
+      '@sentry-internal/browser-utils': 10.38.0
+      '@sentry/core': 10.38.0
 
-  '@sentry/babel-plugin-component-annotate@4.3.0': {}
+  '@sentry/babel-plugin-component-annotate@4.9.1': {}
 
-  '@sentry/browser@10.12.0':
+  '@sentry/browser@10.38.0':
     dependencies:
-      '@sentry-internal/browser-utils': 10.12.0
-      '@sentry-internal/feedback': 10.12.0
-      '@sentry-internal/replay': 10.12.0
-      '@sentry-internal/replay-canvas': 10.12.0
-      '@sentry/core': 10.12.0
+      '@sentry-internal/browser-utils': 10.38.0
+      '@sentry-internal/feedback': 10.38.0
+      '@sentry-internal/replay': 10.38.0
+      '@sentry-internal/replay-canvas': 10.38.0
+      '@sentry/core': 10.38.0
 
-  '@sentry/cli-darwin@2.55.0':
+  '@sentry/cli-darwin@2.58.4':
     optional: true
 
-  '@sentry/cli-linux-arm64@2.55.0':
+  '@sentry/cli-linux-arm64@2.58.4':
     optional: true
 
-  '@sentry/cli-linux-arm@2.55.0':
+  '@sentry/cli-linux-arm@2.58.4':
     optional: true
 
-  '@sentry/cli-linux-i686@2.55.0':
+  '@sentry/cli-linux-i686@2.58.4':
     optional: true
 
-  '@sentry/cli-linux-x64@2.55.0':
+  '@sentry/cli-linux-x64@2.58.4':
     optional: true
 
-  '@sentry/cli-win32-arm64@2.55.0':
+  '@sentry/cli-win32-arm64@2.58.4':
     optional: true
 
-  '@sentry/cli-win32-i686@2.55.0':
+  '@sentry/cli-win32-i686@2.58.4':
     optional: true
 
-  '@sentry/cli-win32-x64@2.55.0':
+  '@sentry/cli-win32-x64@2.58.4':
     optional: true
 
-  '@sentry/cli@2.55.0':
+  '@sentry/cli@2.58.4':
     dependencies:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
@@ -10290,28 +10290,28 @@ snapshots:
       proxy-from-env: 1.1.0
       which: 2.0.2
     optionalDependencies:
-      '@sentry/cli-darwin': 2.55.0
-      '@sentry/cli-linux-arm': 2.55.0
-      '@sentry/cli-linux-arm64': 2.55.0
-      '@sentry/cli-linux-i686': 2.55.0
-      '@sentry/cli-linux-x64': 2.55.0
-      '@sentry/cli-win32-arm64': 2.55.0
-      '@sentry/cli-win32-i686': 2.55.0
-      '@sentry/cli-win32-x64': 2.55.0
+      '@sentry/cli-darwin': 2.58.4
+      '@sentry/cli-linux-arm': 2.58.4
+      '@sentry/cli-linux-arm64': 2.58.4
+      '@sentry/cli-linux-i686': 2.58.4
+      '@sentry/cli-linux-x64': 2.58.4
+      '@sentry/cli-win32-arm64': 2.58.4
+      '@sentry/cli-win32-i686': 2.58.4
+      '@sentry/cli-win32-x64': 2.58.4
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@sentry/core@10.12.0': {}
+  '@sentry/core@10.38.0': {}
 
-  '@sentry/react-native@7.2.0(expo@54.0.36)(react-native@0.81.5(@babel/core@7.28.5)(@react-native/metro-config@0.86.0(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@sentry/react-native@7.13.0(expo@54.0.36)(react-native@0.81.5(@babel/core@7.28.5)(@react-native/metro-config@0.86.0(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@sentry/babel-plugin-component-annotate': 4.3.0
-      '@sentry/browser': 10.12.0
-      '@sentry/cli': 2.55.0
-      '@sentry/core': 10.12.0
-      '@sentry/react': 10.12.0(react@19.1.0)
-      '@sentry/types': 10.12.0
+      '@sentry/babel-plugin-component-annotate': 4.9.1
+      '@sentry/browser': 10.38.0
+      '@sentry/cli': 2.58.4
+      '@sentry/core': 10.38.0
+      '@sentry/react': 10.38.0(react@19.1.0)
+      '@sentry/types': 10.38.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.5)(@react-native/metro-config@0.86.0(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
@@ -10320,16 +10320,15 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/react@10.12.0(react@19.1.0)':
+  '@sentry/react@10.38.0(react@19.1.0)':
     dependencies:
-      '@sentry/browser': 10.12.0
-      '@sentry/core': 10.12.0
-      hoist-non-react-statics: 3.3.2
+      '@sentry/browser': 10.38.0
+      '@sentry/core': 10.38.0
       react: 19.1.0
 
-  '@sentry/types@10.12.0':
+  '@sentry/types@10.38.0':
     dependencies:
-      '@sentry/core': 10.12.0
+      '@sentry/core': 10.38.0
 
   '@shopify/flash-list@2.0.2(@babel/runtime@7.28.4)(react-native@0.81.5(@babel/core@7.28.5)(@react-native/metro-config@0.86.0(@babel/core@7.28.5))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -34,6 +34,7 @@ import colors from '@/components/ui/colors';
 import { hydrateAuth, loadSelectedTheme, useAuth } from '@/lib';
 import { useTokenRefreshErrorHandler } from '@/lib/hooks/use-token-refresh-error-handler';
 import useLockStateDetection from '@/lib/hooks/useLockStateDetection';
+import { getSentryConfig } from '@/lib/sentry-config';
 import { scheduleStreakWarningNotification } from '@/lib/services/notifications';
 import { getQuestRunStatus } from '@/lib/services/quest-run-service';
 import { revenueCatService } from '@/lib/services/revenuecat-service';
@@ -50,14 +51,15 @@ const navigationIntegration = Sentry.reactNavigationIntegration({
   enableTimeToInitialDisplay: !isRunningInExpoGo(),
 });
 
+const sentryConfig = getSentryConfig(Env.APP_ENV);
+
 const integrations =
   Env.APP_ENV === 'production'
     ? [
+        // Masking uses SDK defaults (maskAllText/Images/Vectors: true).
+        // Replays previously recorded login emails and journal content in cleartext.
         Sentry.mobileReplayIntegration({
           enableExperimentalViewRenderer: true,
-          maskAllText: false,
-          maskAllImages: false,
-          maskAllVectors: false,
         }),
         Sentry.reactNativeTracingIntegration(),
         navigationIntegration,
@@ -66,10 +68,14 @@ const integrations =
 
 Sentry.init({
   dsn: 'https://6d85dbe3783d343a049b93fa8afaf144@o4508966745997312.ingest.us.sentry.io/4508966747570176',
-  replaysSessionSampleRate: 1.0,
-  replaysOnErrorSampleRate: 1.0,
-  integrations: integrations,
-  tracesSampleRate: 1.0,
+  enabled: sentryConfig.enabled,
+  environment: Env.APP_ENV,
+  replaysSessionSampleRate: sentryConfig.replaysSessionSampleRate,
+  replaysOnErrorSampleRate: sentryConfig.replaysOnErrorSampleRate,
+  tracesSampleRate: sentryConfig.tracesSampleRate,
+  integrations,
+  // Known network-blip noise; extend once prod volume shows what dominates.
+  ignoreErrors: ['Network request failed', 'AbortError'],
 });
 
 // Keep the splash screen visible until we explicitly hide it

--- a/src/lib/auth/index.test.tsx
+++ b/src/lib/auth/index.test.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import Constants from 'expo-constants';
 import { Alert } from 'react-native';
 import { OneSignal } from 'react-native-onesignal';
@@ -9,6 +10,12 @@ import { useUserStore } from '@/store/user-store';
 
 import { endProvisionalSession, useAuth } from './index';
 import { getToken, removeToken, setToken } from './utils';
+
+jest.mock('@sentry/react-native', () => ({
+  addBreadcrumb: jest.fn(),
+  setTag: jest.fn(),
+  setUser: jest.fn(),
+}));
 
 // Mock all dependencies
 jest.mock('expo-constants', () => ({
@@ -173,6 +180,19 @@ describe('Auth Store', () => {
         refresh: 'refresh-token',
       });
     });
+
+    it('tags authState full', () => {
+      const loginResponse = {
+        token: {
+          access: 'access-token',
+          refresh: 'refresh-token',
+        },
+      };
+
+      useAuth.getState().signIn(loginResponse);
+
+      expect(Sentry.setTag).toHaveBeenCalledWith('authState', 'full');
+    });
   });
 
   describe('endProvisionalSession', () => {
@@ -235,6 +255,17 @@ describe('Auth Store', () => {
       const state = useAuth.getState();
       expect(state.status).toBe('signOut');
       expect(state.token).toBeNull();
+    });
+
+    it('tags authState signedOut', async () => {
+      const mockClearUser = jest.fn();
+      (useUserStore.getState as jest.Mock).mockReturnValue({
+        clearUser: mockClearUser,
+      });
+
+      await useAuth.getState().signOut();
+
+      expect(Sentry.setTag).toHaveBeenCalledWith('authState', 'signedOut');
     });
 
     it('should logout from OneSignal when initialized', async () => {
@@ -304,6 +335,22 @@ describe('Auth Store', () => {
       const state = useAuth.getState();
       expect(state.status).toBe('signIn');
       expect(state.token).toEqual(mockToken);
+    });
+
+    it('tags authState full when a stored token is hydrated successfully', async () => {
+      const mockToken = { access: 'stored-token', refresh: 'stored-refresh' };
+      const mockUser = { id: 'user-123', name: 'Test User' };
+
+      (getToken as jest.Mock).mockReturnValue(mockToken);
+      (getUserDetails as jest.Mock).mockResolvedValue(mockUser);
+      (useUserStore.getState as jest.Mock).mockReturnValue({
+        setUser: jest.fn(),
+        clearUser: jest.fn(),
+      });
+
+      await useAuth.getState().hydrate();
+
+      expect(Sentry.setTag).toHaveBeenCalledWith('authState', 'full');
     });
 
     it('should link OneSignal when user has ID and OneSignal is initialized', async () => {
@@ -397,6 +444,18 @@ describe('Auth Store', () => {
       });
     });
 
+    it('tags authState provisional when only a provisional token exists', async () => {
+      (getToken as jest.Mock).mockReturnValue(null);
+      (getItem as jest.Mock).mockReturnValue('provisional-access-token');
+
+      await useAuth.getState().hydrate();
+
+      const state = useAuth.getState();
+      expect(state.status).toBe('signIn');
+      expect(getUserDetails).not.toHaveBeenCalled();
+      expect(Sentry.setTag).toHaveBeenCalledWith('authState', 'provisional');
+    });
+
     it('should set signOut status when no token exists', async () => {
       (getToken as jest.Mock).mockReturnValue(null);
       (getItem as jest.Mock).mockReturnValue(null); // No provisional tokens either
@@ -407,6 +466,15 @@ describe('Auth Store', () => {
       expect(state.status).toBe('signOut');
       expect(state.token).toBeNull();
       expect(getUserDetails).not.toHaveBeenCalled();
+    });
+
+    it('tags authState signedOut when no token exists', async () => {
+      (getToken as jest.Mock).mockReturnValue(null);
+      (getItem as jest.Mock).mockReturnValue(null); // No provisional tokens either
+
+      await useAuth.getState().hydrate();
+
+      expect(Sentry.setTag).toHaveBeenCalledWith('authState', 'signedOut');
     });
 
     it('should keep user signed in when user details fetch fails', async () => {
@@ -431,6 +499,17 @@ describe('Auth Store', () => {
       expect(state.token).toEqual({ access: 'token' });
     });
 
+    it('tags authState full when the stored token is kept despite a fetch failure', async () => {
+      (getToken as jest.Mock).mockReturnValue({ access: 'token' });
+      (getUserDetails as jest.Mock).mockRejectedValue(
+        new Error('Network error')
+      );
+
+      await useAuth.getState().hydrate();
+
+      expect(Sentry.setTag).toHaveBeenCalledWith('authState', 'full');
+    });
+
     it('should handle hydration errors gracefully', async () => {
       (getToken as jest.Mock).mockImplementation(() => {
         throw new Error('Storage error');
@@ -446,6 +525,16 @@ describe('Auth Store', () => {
       // But it should set the status to signOut
       const state = useAuth.getState();
       expect(state.status).toBe('signOut');
+    });
+
+    it('tags authState signedOut when hydration itself throws', async () => {
+      (getToken as jest.Mock).mockImplementation(() => {
+        throw new Error('Storage error');
+      });
+
+      await useAuth.getState().hydrate();
+
+      expect(Sentry.setTag).toHaveBeenCalledWith('authState', 'signedOut');
     });
 
     it('should use maestro tokens in development when available', async () => {

--- a/src/lib/auth/index.tsx
+++ b/src/lib/auth/index.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import Constants from 'expo-constants';
 import { Alert } from 'react-native';
 import { OneSignal } from 'react-native-onesignal';
@@ -41,6 +42,7 @@ const _useAuth = create<AuthState>((set, get) => ({
         refresh: loginResponse.token.refresh,
       },
     });
+    Sentry.setTag('authState', 'full');
 
     // Login to RevenueCat with user ID
     if (loginResponse.user?.id) {
@@ -65,6 +67,7 @@ const _useAuth = create<AuthState>((set, get) => ({
       status: 'signOut',
       token: null,
     });
+    Sentry.setTag('authState', 'signedOut');
 
     // Clear user store
     useUserStore.getState().clearUser();
@@ -249,6 +252,7 @@ const _useAuth = create<AuthState>((set, get) => ({
           }
 
           set({ status: 'signIn', token: userToken });
+          Sentry.setTag('authState', 'full');
         } catch (fetchError) {
           console.error(
             'Failed to fetch user details during hydration:',
@@ -259,6 +263,7 @@ const _useAuth = create<AuthState>((set, get) => ({
           console.log('[Auth] Keeping user signed in despite fetch failure');
           // CRITICAL: Must set status to signIn so app can proceed offline
           set({ status: 'signIn', token: userToken });
+          Sentry.setTag('authState', 'full');
         }
       } else if (provisionalToken) {
         // Handle provisional users
@@ -271,6 +276,7 @@ const _useAuth = create<AuthState>((set, get) => ({
         };
 
         set({ status: 'signIn', token: provisionalTokenData });
+        Sentry.setTag('authState', 'provisional');
 
         // Note: We don't fetch user details for provisional users yet
         // They will be fetched after quest completion when converting to full user
@@ -279,12 +285,14 @@ const _useAuth = create<AuthState>((set, get) => ({
         // No tokens found - set signOut status without calling logout methods
         // since the user was never logged in
         set({ status: 'signOut', token: null });
+        Sentry.setTag('authState', 'signedOut');
       }
     } catch (e) {
       console.error('Error during hydration process:', e);
       // Don't sign out on hydration errors - let the user continue if possible
       // They might just have network issues or other temporary problems
       set({ status: 'signOut' }); // Set to signOut state but don't clear tokens
+      Sentry.setTag('authState', 'signedOut');
     }
   },
 }));

--- a/src/lib/sentry-config.test.ts
+++ b/src/lib/sentry-config.test.ts
@@ -1,0 +1,34 @@
+import { getSentryConfig } from './sentry-config';
+
+describe('getSentryConfig', () => {
+  it('production: enabled, 5% session replays, 100% error replays, 15% traces', () => {
+    expect(getSentryConfig('production')).toEqual({
+      enabled: true,
+      replaysSessionSampleRate: 0.05,
+      replaysOnErrorSampleRate: 1.0,
+      tracesSampleRate: 0.15,
+    });
+  });
+
+  it('staging: enabled, no session replays, full traces', () => {
+    expect(getSentryConfig('staging')).toEqual({
+      enabled: true,
+      replaysSessionSampleRate: 0,
+      replaysOnErrorSampleRate: 1.0,
+      tracesSampleRate: 1.0,
+    });
+  });
+
+  it('development: fully disabled', () => {
+    expect(getSentryConfig('development')).toEqual({
+      enabled: false,
+      replaysSessionSampleRate: 0,
+      replaysOnErrorSampleRate: 0,
+      tracesSampleRate: 0,
+    });
+  });
+
+  it('unknown env falls back to the disabled development config', () => {
+    expect(getSentryConfig('e2e').enabled).toBe(false);
+  });
+});

--- a/src/lib/sentry-config.ts
+++ b/src/lib/sentry-config.ts
@@ -1,0 +1,33 @@
+type AppEnv = 'development' | 'staging' | 'production';
+
+export type SentryEnvConfig = {
+  enabled: boolean;
+  replaysSessionSampleRate: number;
+  replaysOnErrorSampleRate: number;
+  tracesSampleRate: number;
+};
+
+const CONFIGS: Record<AppEnv, SentryEnvConfig> = {
+  production: {
+    enabled: true,
+    replaysSessionSampleRate: 0.05,
+    replaysOnErrorSampleRate: 1.0,
+    tracesSampleRate: 0.15,
+  },
+  staging: {
+    enabled: true,
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: 1.0,
+    tracesSampleRate: 1.0,
+  },
+  development: {
+    enabled: false,
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: 0,
+    tracesSampleRate: 0,
+  },
+};
+
+export function getSentryConfig(appEnv: string): SentryEnvConfig {
+  return CONFIGS[appEnv as AppEnv] ?? CONFIGS.development;
+}

--- a/src/store/quest-store.test.ts
+++ b/src/store/quest-store.test.ts
@@ -1653,6 +1653,26 @@ describe('quest lifecycle breadcrumbs', () => {
     });
   });
 
+  it('cancelQuest leaves a quest.cancel breadcrumb with the pending quest id when there is no active quest', () => {
+    const pendingQuest = {
+      id: 'pending-quest-88',
+      mode: 'story' as const,
+      title: 'Test Quest',
+      durationMinutes: 10,
+      reward: { xp: 100 },
+    };
+    useQuestStore.setState({ activeQuest: null, pendingQuest });
+
+    useQuestStore.getState().cancelQuest();
+
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'quest',
+      message: 'quest.cancel',
+      level: 'info',
+      data: { questId: 'pending-quest-88' },
+    });
+  });
+
   it('cancelQuest with no active or pending quest does not leave a quest.cancel breadcrumb', () => {
     useQuestStore.setState({ activeQuest: null, pendingQuest: null });
 
@@ -1682,6 +1702,26 @@ describe('quest lifecycle breadcrumbs', () => {
       message: 'quest.fail',
       level: 'info',
       data: { questId: 'quest-42' },
+    });
+  });
+
+  it('failQuest leaves a quest.fail breadcrumb with the pending quest id when there is no active quest', () => {
+    const pendingQuest = {
+      id: 'pending-quest-88',
+      mode: 'story' as const,
+      title: 'Test Quest',
+      durationMinutes: 10,
+      reward: { xp: 100 },
+    };
+    useQuestStore.setState({ activeQuest: null, pendingQuest });
+
+    useQuestStore.getState().failQuest();
+
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'quest',
+      message: 'quest.fail',
+      level: 'info',
+      data: { questId: 'pending-quest-88' },
     });
   });
 

--- a/src/store/quest-store.test.ts
+++ b/src/store/quest-store.test.ts
@@ -1653,10 +1653,45 @@ describe('quest lifecycle breadcrumbs', () => {
     });
   });
 
-  it('failQuest leaves a quest.fail breadcrumb', () => {
+  it('cancelQuest with no active or pending quest does not leave a quest.cancel breadcrumb', () => {
+    useQuestStore.setState({ activeQuest: null, pendingQuest: null });
+
+    useQuestStore.getState().cancelQuest();
+
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'quest.cancel' })
+    );
+  });
+
+  it('failQuest leaves a quest.fail breadcrumb with the active quest id', () => {
+    const activeQuest = {
+      id: 'quest-42',
+      mode: 'story' as const,
+      title: 'Test Quest',
+      durationMinutes: 10,
+      reward: { xp: 100 },
+      startTime: Date.now(),
+      status: 'active' as const,
+    };
+    useQuestStore.setState({ activeQuest, pendingQuest: null });
+
     useQuestStore.getState().failQuest();
-    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-      expect.objectContaining({ category: 'quest', message: 'quest.fail' })
+
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'quest',
+      message: 'quest.fail',
+      level: 'info',
+      data: { questId: 'quest-42' },
+    });
+  });
+
+  it('failQuest with no active or pending quest does not leave a quest.fail breadcrumb', () => {
+    useQuestStore.setState({ activeQuest: null, pendingQuest: null });
+
+    useQuestStore.getState().failQuest();
+
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'quest.fail' })
     );
   });
 
@@ -1680,5 +1715,15 @@ describe('quest lifecycle breadcrumbs', () => {
       level: 'info',
       data: { questId: 'quest-55', mode: 'story' },
     });
+  });
+
+  it('completeQuest with no active quest does not leave a quest.complete breadcrumb', () => {
+    useQuestStore.setState({ activeQuest: null });
+
+    useQuestStore.getState().completeQuest(true);
+
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'quest.complete' })
+    );
   });
 });

--- a/src/store/quest-store.test.ts
+++ b/src/store/quest-store.test.ts
@@ -1,7 +1,15 @@
 // Import after mocking
+import * as Sentry from '@sentry/react-native';
+
 import QuestTimer from '@/lib/services/quest-timer';
 import { useQuestStore } from '@/store/quest-store';
 import { type Quest } from '@/store/types';
+
+jest.mock('@sentry/react-native', () => ({
+  addBreadcrumb: jest.fn(),
+  setTag: jest.fn(),
+  setUser: jest.fn(),
+}));
 
 // Mock the dependencies
 jest.mock('@/lib/services/quest-timer', () => {
@@ -1575,6 +1583,102 @@ describe('QuestStore - refreshAvailableQuests', () => {
       // Also check that availableQuests is populated with client format
       expect(state.availableQuests.length).toBe(1);
       expect(state.availableQuests[0].id).toBe('quest-1');
+    });
+  });
+});
+
+describe('quest lifecycle breadcrumbs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('startQuest leaves a quest.start breadcrumb with the quest id', () => {
+    const quest = {
+      id: 'quest-77',
+      mode: 'story' as const,
+      title: 'Test Quest',
+      durationMinutes: 10,
+      reward: { xp: 100 },
+    };
+
+    useQuestStore.getState().startQuest(quest);
+
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'quest',
+      message: 'quest.start',
+      level: 'info',
+      data: { questId: 'quest-77', mode: 'story' },
+    });
+  });
+
+  it('prepareQuest leaves a quest.prepare breadcrumb with the quest id', () => {
+    const quest = {
+      id: 'quest-88',
+      mode: 'custom' as const,
+      title: 'Test Quest',
+      durationMinutes: 10,
+      reward: { xp: 100 },
+      category: 'personal' as const,
+    };
+
+    useQuestStore.getState().prepareQuest(quest);
+
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'quest',
+      message: 'quest.prepare',
+      level: 'info',
+      data: { questId: 'quest-88', mode: 'custom' },
+    });
+  });
+
+  it('cancelQuest leaves a quest.cancel breadcrumb with the active quest id', () => {
+    const activeQuest = {
+      id: 'quest-99',
+      mode: 'story' as const,
+      title: 'Test Quest',
+      durationMinutes: 10,
+      reward: { xp: 100 },
+      startTime: Date.now(),
+      status: 'active' as const,
+    };
+    useQuestStore.setState({ activeQuest });
+
+    useQuestStore.getState().cancelQuest();
+
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'quest',
+      message: 'quest.cancel',
+      level: 'info',
+      data: { questId: 'quest-99' },
+    });
+  });
+
+  it('failQuest leaves a quest.fail breadcrumb', () => {
+    useQuestStore.getState().failQuest();
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'quest', message: 'quest.fail' })
+    );
+  });
+
+  it('completeQuest leaves a quest.complete breadcrumb with the active quest id', () => {
+    const activeQuest = {
+      id: 'quest-55',
+      mode: 'story' as const,
+      title: 'Test Quest',
+      durationMinutes: 10,
+      reward: { xp: 100 },
+      startTime: Date.now() - 600000,
+      status: 'active' as const,
+    };
+    useQuestStore.setState({ activeQuest, lastCompletedQuestTimestamp: null });
+
+    useQuestStore.getState().completeQuest(true);
+
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'quest',
+      message: 'quest.complete',
+      level: 'info',
+      data: { questId: 'quest-55', mode: 'story' },
     });
   });
 });

--- a/src/store/quest-store.ts
+++ b/src/store/quest-store.ts
@@ -391,7 +391,7 @@ export const useQuestStore = create<QuestState>()(
             category: 'quest',
             message: 'quest.cancel',
             level: 'info',
-            data: { questId: activeQuest?.id },
+            data: { questId: (activeQuest ?? pendingQuest)?.id },
           });
           // End any active live activity when quest is canceled
           QuestTimer.stopQuest();
@@ -420,7 +420,7 @@ export const useQuestStore = create<QuestState>()(
             category: 'quest',
             message: 'quest.fail',
             level: 'info',
-            data: { questId: activeQuest?.id },
+            data: { questId: failedQuestDetails.id },
           });
           QuestTimer.stopQuest();
 

--- a/src/store/quest-store.ts
+++ b/src/store/quest-store.ts
@@ -148,17 +148,14 @@ export const useQuestStore = create<QuestState>()(
       },
 
       completeQuest: async (ignoreDuration = false) => {
-        Sentry.addBreadcrumb({
-          category: 'quest',
-          message: 'quest.complete',
-          level: 'info',
-          data: {
-            questId: get().activeQuest?.id,
-            mode: get().activeQuest?.mode,
-          },
-        });
         const { activeQuest, lastCompletedQuestTimestamp } = get();
         if (activeQuest && activeQuest.startTime) {
+          Sentry.addBreadcrumb({
+            category: 'quest',
+            message: 'quest.complete',
+            level: 'info',
+            data: { questId: activeQuest.id, mode: activeQuest.mode },
+          });
           const completionTime = Date.now();
           const duration = (completionTime - activeQuest.startTime) / 1000;
 
@@ -388,14 +385,14 @@ export const useQuestStore = create<QuestState>()(
       },
 
       cancelQuest: () => {
-        Sentry.addBreadcrumb({
-          category: 'quest',
-          message: 'quest.cancel',
-          level: 'info',
-          data: { questId: get().activeQuest?.id },
-        });
         const { activeQuest, pendingQuest, cooperativeQuestRun } = get();
         if (activeQuest || pendingQuest) {
+          Sentry.addBreadcrumb({
+            category: 'quest',
+            message: 'quest.cancel',
+            level: 'info',
+            data: { questId: activeQuest?.id },
+          });
           // End any active live activity when quest is canceled
           QuestTimer.stopQuest();
           set({
@@ -416,15 +413,15 @@ export const useQuestStore = create<QuestState>()(
       },
 
       failQuest: () => {
-        Sentry.addBreadcrumb({
-          category: 'quest',
-          message: 'quest.fail',
-          level: 'info',
-          data: { questId: get().activeQuest?.id },
-        });
         const { activeQuest, pendingQuest } = get();
         const failedQuestDetails = activeQuest || pendingQuest;
         if (failedQuestDetails) {
+          Sentry.addBreadcrumb({
+            category: 'quest',
+            message: 'quest.fail',
+            level: 'info',
+            data: { questId: activeQuest?.id },
+          });
           QuestTimer.stopQuest();
 
           // Ensure all required fields for Quest are present

--- a/src/store/quest-store.ts
+++ b/src/store/quest-store.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
@@ -106,6 +107,12 @@ export const useQuestStore = create<QuestState>()(
       cooperativeQuestRun: null,
       pendingInvitations: [],
       prepareQuest: (quest: LocalQuestTemplate) => {
+        Sentry.addBreadcrumb({
+          category: 'quest',
+          message: 'quest.prepare',
+          level: 'info',
+          data: { questId: quest.id, mode: quest.mode },
+        });
         const currentCooperativeQuestRun = get().cooperativeQuestRun;
         // Only clear cooperative quest data when preparing a non-cooperative quest
         // A quest is cooperative if mode is 'cooperative' OR if it's a custom quest with cooperative category
@@ -127,6 +134,12 @@ export const useQuestStore = create<QuestState>()(
       },
 
       startQuest: (quest: Quest) => {
+        Sentry.addBreadcrumb({
+          category: 'quest',
+          message: 'quest.start',
+          level: 'info',
+          data: { questId: quest.id, mode: quest.mode },
+        });
         const startedQuest = {
           ...quest,
           startTime: Date.now(),
@@ -135,6 +148,15 @@ export const useQuestStore = create<QuestState>()(
       },
 
       completeQuest: async (ignoreDuration = false) => {
+        Sentry.addBreadcrumb({
+          category: 'quest',
+          message: 'quest.complete',
+          level: 'info',
+          data: {
+            questId: get().activeQuest?.id,
+            mode: get().activeQuest?.mode,
+          },
+        });
         const { activeQuest, lastCompletedQuestTimestamp } = get();
         if (activeQuest && activeQuest.startTime) {
           const completionTime = Date.now();
@@ -366,6 +388,12 @@ export const useQuestStore = create<QuestState>()(
       },
 
       cancelQuest: () => {
+        Sentry.addBreadcrumb({
+          category: 'quest',
+          message: 'quest.cancel',
+          level: 'info',
+          data: { questId: get().activeQuest?.id },
+        });
         const { activeQuest, pendingQuest, cooperativeQuestRun } = get();
         if (activeQuest || pendingQuest) {
           // End any active live activity when quest is canceled
@@ -388,6 +416,12 @@ export const useQuestStore = create<QuestState>()(
       },
 
       failQuest: () => {
+        Sentry.addBreadcrumb({
+          category: 'quest',
+          message: 'quest.fail',
+          level: 'info',
+          data: { questId: get().activeQuest?.id },
+        });
         const { activeQuest, pendingQuest } = get();
         const failedQuestDetails = activeQuest || pendingQuest;
         if (failedQuestDetails) {

--- a/src/store/user-store.test.ts
+++ b/src/store/user-store.test.ts
@@ -1,0 +1,35 @@
+import * as Sentry from '@sentry/react-native';
+
+import { useUserStore } from './user-store';
+
+// Mock storage (persist middleware reads/writes through this)
+jest.mock('@/lib/storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('@sentry/react-native', () => ({
+  setUser: jest.fn(),
+}));
+
+describe('user-store Sentry correlation', () => {
+  beforeEach(() => {
+    useUserStore.setState({ user: null });
+    jest.clearAllMocks();
+  });
+
+  it('setUser reports id-only to Sentry (never email)', () => {
+    useUserStore.getState().setUser({
+      id: 'user-abc-123',
+      email: 'secret@example.com',
+    } as any);
+    // toHaveBeenCalledWith is an exact match: it fails if email is included.
+    expect(Sentry.setUser).toHaveBeenCalledWith({ id: 'user-abc-123' });
+  });
+
+  it('clearUser clears the Sentry user', () => {
+    useUserStore.getState().clearUser();
+    expect(Sentry.setUser).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/store/user-store.ts
+++ b/src/store/user-store.ts
@@ -1,4 +1,5 @@
 // src/store/user-store.ts
+import * as Sentry from '@sentry/react-native';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
@@ -30,12 +31,18 @@ export const useUserStore = create<UserState>()(
   persist(
     (set) => ({
       user: null,
-      setUser: (user) => set({ user }),
+      setUser: (user) => {
+        Sentry.setUser({ id: user.id }); // id only - no email (GDPR)
+        set({ user });
+      },
       updateUser: (userData) =>
         set((state) => ({
           user: state.user ? { ...state.user, ...userData } : null,
         })),
-      clearUser: () => set({ user: null }),
+      clearUser: () => {
+        Sentry.setUser(null);
+        set({ user: null });
+      },
     }),
     {
       name: 'user-storage',


### PR DESCRIPTION
Fixes REACT-NATIVE-6Y
Closes #380 (mobile half; server half is a separate emberglow-server PR)

## What

- **Bump `@sentry/react-native` 7.2.0 → 7.13.0** — bundles sentry-android **8.32.0** (≥ 8.25.0 floor), which carries getsentry/sentry-java#4788: the replay lifecycle lock is no longer held during connection-status work, closing the ABBA deadlock behind the prod Background ANR. **Native change — rides the next binary, not OTA.**
- **Per-`APP_ENV` config module** `src/lib/sentry-config.ts` (pure, tested, mutation-hardened).
- **Env-gated `Sentry.init`**: `enabled: false` in development, explicit `environment` tag, replay masking back to SDK defaults (the three `maskAll*: false` overrides are gone — replays were recording login emails and journal text in cleartext), sampled rates, `ignoreErrors: ['Network request failed', 'AbortError']`.
- **`Sentry.setUser` id-only** (GDPR — never email) on the user-store seam, cleared to `null` on logout. Every event now correlates with server logs / PostHog `distinct_id`.
- **`authState` tag** (`full` / `provisional` / `signedOut`) on every auth status transition (transient `hydrating` deliberately untagged — the 3-value contract has no honest mapping for it), plus **quest lifecycle breadcrumbs** (`quest.prepare/start/complete/cancel/fail`). Breadcrumbs record only when the action's guard actually proceeds, and fail/cancel carry the right `questId` on the pending-only path.

## Decision defaults (from the plan — veto here or adjust post-merge)

| Setting | Spec range | Chosen |
|---|---|---|
| `replaysSessionSampleRate` (prod) | 0.05–0.1 or 0 | **0.05** |
| `replaysOnErrorSampleRate` (prod) | keep | **1.0** (kept per spec) |
| `tracesSampleRate` (prod) | 0.1–0.2 | **0.15** |
| Mobile dev reporting | off or dev DSN | **`enabled: false` in development** |

## ⚠️ OTA note — corrects the plan

The plan claimed the JS config commits are OTA-eligible to 2.0.0 now. **From this branch that is unsafe**: an EAS Update built here would ship 7.13.0 JS onto 2.0.0 binaries whose native side is still RNSentry 7.2.0 / sentry-android 8.21.1 — an 11-minor JS/native mismatch in exactly the replay path this PR fixes. If you want the quota/PII config live before the next binary, cherry-pick `fc8839c a2e4e48 67e235f 9cb9750 bc4c17c 6e2d205` onto a branch that keeps `@sentry/react-native@7.2.0` and publish that. Otherwise everything rides the next binary together.

## Source maps (Task 6 evidence)

- **Prod JS symbolication is PARTIAL**: on the newest prod JS events (1.8.0+31, issues REACT-NATIVE-6P/6N), `node_modules` frames symbolicate cleanly while app frames in the same stack stay as raw `app:///index.android.bundle:1:NNNNNN` offsets. 2.0.0 has no JS exceptions yet (only native ANRs), so 2.0.0 is unverified. Follow-up: #383.
- `eas env:list` token check **skipped** (needs your per-use approval): run `eas env:list --environment production | grep -i sentry` and confirm `SENTRY_AUTH_TOKEN` is present.

## Known gaps / notes

- **`APP_ENV: 'preview'` builds get Sentry silently disabled** (falls to the dev config). Ticketed: #384.
- **Dev smoke not run**: the `enabled: false` gate couldn't be runtime-verified in the isolated worktree (no `.env.development`; secrets rules). One local `pnpm start` should confirm no Sentry network activity.
- Staging declares `replaysOnErrorSampleRate: 1.0` but the replay integration is only registered in production (pre-existing ternary, kept) — staging value is currently dead config.
- Plan deviation, flagged for veto: the plan's sketch put breadcrumbs on the *first line* of each action; they were moved *inside the guards* so a guard-rejected call (e.g. `cancelQuest()` from invitation-waiting with no quest) records no false trail. Negative tests pin this.
- `package.json` recorded `^7.13.0` (pnpm save-prefix) instead of the plan's `~7.13.0`; lockfile pins exactly 7.13.0.
- Branch also carries the pre-existing docs commit `c644f53` (invite-link design spec) that was already on `fix/sentry-errors` before this work.
- eslint on touched files: 4 errors, all confirmed pre-existing on main (`import/no-cycle` ×2, unused `get`, quest-store `max-lines-per-function`).

## Gates (at head)

- `pnpm test`: 184 suites, **2091 passed**, 3 skipped, 0 failures
- `pnpm type-check`: 0 errors; translations lint clean
- Every new assertion mutation-tested both ways (RED confirmed per mutation; details in the commit history / task reports)

## Post-release watch

Upstream #4788 targeted the replay *pause* path; the spec flags the *resume* path as residual risk. Watch REACT-NATIVE-6Y for recurrence after the next binary reaches devices.
