### PR TITLE
feat(stats): profile stats charts — 7-day activity chart + milestone progress

### DIFF
--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -246,6 +246,12 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="stats"
+        options={{
+          href: null,
+        }}
+      />
+      <Tabs.Screen
         name="quest-discovery"
         options={{
           href: null,

--- a/src/app/(app)/profile.test.tsx
+++ b/src/app/(app)/profile.test.tsx
@@ -138,6 +138,19 @@ jest.mock('@/features/guilds/components/guilds-section', () => ({
   GuildsSection: () => null,
 }));
 
+// Keeps the profile suite isolated from chart internals — matches how it
+// mocks other sub-components.
+jest.mock('@/features/stats/components/weekly-activity-card', () => {
+  const RN = jest.requireActual('react-native');
+  return {
+    WeeklyActivityCard: ({ onPress }: any) => (
+      <RN.Pressable testID="weekly-activity-card" onPress={onPress}>
+        <RN.Text>weekly-activity-card</RN.Text>
+      </RN.Pressable>
+    ),
+  };
+});
+
 // Mock hooks
 jest.mock('@/lib/hooks/use-profile-data', () => ({
   useProfileData: jest.fn(() => ({
@@ -461,6 +474,13 @@ describe('ProfileScreen', () => {
       await waitFor(() => {
         expect(mockRouterPush).toHaveBeenCalledWith('/skill-tree');
       });
+    });
+
+    it('navigates to /stats when the weekly activity card is pressed', async () => {
+      // Uses the same store setup as the surrounding passing tests (beforeEach).
+      render(<ProfileScreen />);
+      fireEvent.press(await screen.findByTestId('weekly-activity-card'));
+      expect(mockRouterPush).toHaveBeenCalledWith('/stats');
     });
   });
 

--- a/src/app/(app)/profile.tsx
+++ b/src/app/(app)/profile.tsx
@@ -23,6 +23,7 @@ import {
 import { GuildsSection } from '@/features/guilds/components/guilds-section';
 import { ActionCards } from '@/features/profile/components/profile-components';
 import { useCharacterSync } from '@/features/profile/hooks/profile-hooks';
+import { WeeklyActivityCard } from '@/features/stats/components/weekly-activity-card';
 import { useFriendManagement } from '@/lib/hooks/use-friend-management';
 import { useProfileData } from '@/lib/hooks/use-profile-data';
 import { useCharacterStore } from '@/store/character-store';
@@ -166,6 +167,9 @@ export default function ProfileScreen() {
             minutesSaved={totalMinutesOffPhone}
             streakCount={streakCount}
           />
+
+          {/* Last 7 days activity — tap for full stats */}
+          <WeeklyActivityCard onPress={() => router.push('/stats')} />
 
           {/* Links: Skills & Perks, Leaderboard, Achievements */}
           <ActionCards

--- a/src/app/(app)/stats.test.tsx
+++ b/src/app/(app)/stats.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { cleanup, render, screen } from '@/lib/test-utils';
+import { cleanup, render, screen, setup, waitFor } from '@/lib/test-utils';
 import { useQuestStore } from '@/store/quest-store';
 import { useUserStore } from '@/store/user-store';
 
@@ -11,8 +11,11 @@ jest.mock('posthog-react-native', () => ({
   usePostHog: () => ({ capture: mockCapture }),
 }));
 
+const mockRouterPush = jest.fn();
+const mockRouterReplace = jest.fn();
+
 jest.mock('expo-router', () => ({
-  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  useRouter: () => ({ push: mockRouterPush, replace: mockRouterReplace }),
 }));
 
 afterEach(() => {
@@ -84,5 +87,19 @@ describe('StatsScreen', () => {
 
     expect(mockCapture).toHaveBeenCalledTimes(1);
     expect(mockCapture).toHaveBeenCalledWith('stats_screen_viewed');
+  });
+
+  it('renders a back button that navigates to profile', async () => {
+    useQuestStore.setState({ completedQuests: [] });
+    useUserStore.setState({ user: null } as any);
+
+    const { user } = setup(<StatsScreen />);
+
+    const backButton = screen.getByLabelText('Go back');
+    await user.press(backButton);
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith('/profile');
+    });
   });
 });

--- a/src/app/(app)/stats.test.tsx
+++ b/src/app/(app)/stats.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+import { cleanup, render, screen } from '@/lib/test-utils';
+import { useQuestStore } from '@/store/quest-store';
+import { useUserStore } from '@/store/user-store';
+
+import StatsScreen from './stats';
+
+const mockCapture = jest.fn();
+jest.mock('posthog-react-native', () => ({
+  usePostHog: () => ({ capture: mockCapture }),
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}));
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+});
+
+// A quest completed today, 45 minutes. Store fixture is minimal but must
+// satisfy the Quest type used by getCompletedQuests.
+const makeCompletedQuest = () => ({
+  id: 'q1',
+  mode: 'custom' as const,
+  category: 'chores',
+  title: 'Test quest',
+  durationMinutes: 45,
+  reward: { xp: 10 },
+  startTime: Date.now() - 46 * 60 * 1000,
+  stopTime: Date.now(),
+  status: 'completed' as const,
+});
+
+describe('StatsScreen', () => {
+  it('renders chart, summary, and milestone sections from store data', () => {
+    useQuestStore.setState({ completedQuests: [makeCompletedQuest()] });
+    useUserStore.setState({ user: null } as any);
+
+    render(<StatsScreen />);
+
+    expect(screen.getByText('Your Stats')).toBeOnTheScreen();
+    expect(screen.getAllByTestId(/^activity-bar-/)).toHaveLength(7);
+    expect(screen.getByText('Next: 1 hour reclaimed')).toBeOnTheScreen();
+    expect(screen.getByText('45m reclaimed so far')).toBeOnTheScreen();
+  });
+
+  it('prefers the server lifetime total over the local sum', () => {
+    // Server total (1080 = 18h) deliberately != local sum (45m): if the
+    // precedence flips, BOTH assertions below fail — the fixture cannot
+    // pass vacuously.
+    useQuestStore.setState({ completedQuests: [makeCompletedQuest()] });
+    useUserStore.setState({
+      user: { totalMinutesOffPhone: 1080 },
+    } as any);
+
+    render(<StatsScreen />);
+
+    expect(screen.getByText('Next: 24 hours reclaimed')).toBeOnTheScreen();
+    expect(screen.getByText('18h reclaimed so far')).toBeOnTheScreen();
+  });
+
+  it('shows invitational empty state for a user with no quests', () => {
+    useQuestStore.setState({ completedQuests: [] });
+    useUserStore.setState({ user: null } as any);
+
+    render(<StatsScreen />);
+
+    expect(
+      screen.getByText('Complete a quest to light up your week')
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText('Your first milestone: 1 hour reclaimed')
+    ).toBeOnTheScreen();
+  });
+
+  it('captures stats_screen_viewed exactly once on mount', () => {
+    useQuestStore.setState({ completedQuests: [] });
+    useUserStore.setState({ user: null } as any);
+
+    render(<StatsScreen />);
+
+    expect(mockCapture).toHaveBeenCalledTimes(1);
+    expect(mockCapture).toHaveBeenCalledWith('stats_screen_viewed');
+  });
+});

--- a/src/app/(app)/stats.tsx
+++ b/src/app/(app)/stats.tsx
@@ -1,0 +1,76 @@
+import { usePostHog } from 'posthog-react-native';
+import React, { useEffect, useMemo } from 'react';
+import { StyleSheet } from 'react-native';
+
+import {
+  FocusAwareStatusBar,
+  ScreenContainer,
+  ScreenHeader,
+  ScrollView,
+  View,
+} from '@/components/ui';
+import { MilestoneProgress } from '@/features/stats/components/milestone-progress';
+import { WeeklyActivityChart } from '@/features/stats/components/weekly-activity-chart';
+import { WeeklySummary } from '@/features/stats/components/weekly-summary';
+import { aggregateDailyMinutes } from '@/features/stats/lib/daily-stats';
+import { useQuestStore } from '@/store/quest-store';
+import { useUserStore } from '@/store/user-store';
+import { spacing } from '@/theme';
+
+const DAYS_SHOWN = 7;
+
+export default function StatsScreen() {
+  const posthog = usePostHog();
+  const completedQuests = useQuestStore((state) => state.completedQuests);
+  const user = useUserStore((state) => state.user);
+
+  useEffect(() => {
+    posthog.capture('stats_screen_viewed');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const dailyStats = useMemo(
+    () => aggregateDailyMinutes(completedQuests, DAYS_SHOWN, Date.now()),
+    [completedQuests]
+  );
+
+  const totalMinutes =
+    user?.totalMinutesOffPhone ??
+    completedQuests.reduce((total, quest) => total + quest.durationMinutes, 0);
+
+  return (
+    <View style={styles.flex}>
+      <FocusAwareStatusBar />
+      <ScreenContainer>
+        <ScreenHeader
+          title="Your Stats"
+          subtitle="Every minute here is a minute you took back."
+        />
+        <ScrollView showsVerticalScrollIndicator={false}>
+          <View style={styles.section}>
+            <WeeklySummary stats={dailyStats} />
+          </View>
+          <View style={styles.section}>
+            <WeeklyActivityChart
+              stats={dailyStats}
+              variant="full"
+              emptyMessage="Complete a quest to light up your week"
+              testID="stats-weekly-chart"
+            />
+          </View>
+          <View style={styles.section}>
+            <MilestoneProgress totalMinutes={totalMinutes} />
+          </View>
+        </ScrollView>
+      </ScreenContainer>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  section: {
+    marginHorizontal: spacing[4],
+    marginTop: spacing[4],
+  },
+});

--- a/src/app/(app)/stats.tsx
+++ b/src/app/(app)/stats.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'expo-router';
 import { usePostHog } from 'posthog-react-native';
 import React, { useEffect, useMemo } from 'react';
 import { StyleSheet } from 'react-native';
@@ -20,6 +21,7 @@ import { spacing } from '@/theme';
 const DAYS_SHOWN = 7;
 
 export default function StatsScreen() {
+  const router = useRouter();
   const posthog = usePostHog();
   const completedQuests = useQuestStore((state) => state.completedQuests);
   const user = useUserStore((state) => state.user);
@@ -45,6 +47,8 @@ export default function StatsScreen() {
         <ScreenHeader
           title="Your Stats"
           subtitle="Every minute here is a minute you took back."
+          showBackButton
+          onBackPress={() => router.push('/profile')}
         />
         <ScrollView showsVerticalScrollIndicator={false}>
           <View style={styles.section}>

--- a/src/features/stats/components/milestone-progress.test.tsx
+++ b/src/features/stats/components/milestone-progress.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { render, screen } from '@/lib/test-utils';
+
+import { MilestoneProgress } from './milestone-progress';
+
+describe('MilestoneProgress', () => {
+  it('renders the teaser and no bar at zero', () => {
+    render(<MilestoneProgress totalMinutes={0} />);
+    expect(
+      screen.getByText('Your first milestone: 1 hour reclaimed')
+    ).toBeOnTheScreen();
+    expect(screen.queryByTestId('milestone-bar')).toBeNull();
+  });
+
+  it('renders next-milestone label, bar, and running total', () => {
+    render(<MilestoneProgress totalMinutes={1080} />);
+    expect(screen.getByText('Next: 24 hours reclaimed')).toBeOnTheScreen();
+    expect(screen.getByTestId('milestone-bar')).toBeOnTheScreen();
+    expect(screen.getByText('18h reclaimed so far')).toBeOnTheScreen();
+    expect(
+      screen.queryByText('Your first milestone: 1 hour reclaimed')
+    ).toBeNull();
+  });
+
+  it('renders the past-ladder state with no next label', () => {
+    render(<MilestoneProgress totalMinutes={63000} />);
+    expect(screen.getByText('1,050 hours reclaimed')).toBeOnTheScreen();
+    expect(screen.queryByText(/^Next:/)).toBeNull();
+  });
+});

--- a/src/features/stats/components/milestone-progress.tsx
+++ b/src/features/stats/components/milestone-progress.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { Text, View } from '@/components/ui';
+import { colors, fontFamily, fontSize, radii, spacing } from '@/theme';
+
+import { formatMinutes } from '../lib/daily-stats';
+import { getMilestoneProgress } from '../lib/milestones';
+
+export function MilestoneProgress({ totalMinutes }: { totalMinutes: number }) {
+  const progress = getMilestoneProgress(totalMinutes);
+  const fill = useSharedValue(0);
+
+  useEffect(() => {
+    fill.value = withTiming(progress.fraction, {
+      duration: 800,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [fill, progress.fraction]);
+
+  const fillStyle = useAnimatedStyle(() => ({
+    width: `${fill.value * 100}%`,
+  }));
+
+  if (totalMinutes === 0) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.teaser}>
+          Your first milestone: 1 hour reclaimed
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>{progress.label}</Text>
+      <View style={styles.track}>
+        <Animated.View
+          testID="milestone-bar"
+          style={[styles.fill, fillStyle]}
+        />
+      </View>
+      <Text style={styles.sublabel}>
+        {formatMinutes(totalMinutes)} reclaimed so far
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.surface.raised,
+    borderWidth: 1,
+    borderColor: colors.border.hairline,
+    borderRadius: radii.md,
+    padding: spacing[4],
+  },
+  label: {
+    fontFamily: fontFamily.display,
+    fontSize: fontSize.body,
+    lineHeight: fontSize.body * 1.15,
+    color: colors.text.primary,
+  },
+  teaser: {
+    fontFamily: fontFamily.display,
+    fontSize: fontSize.body,
+    lineHeight: fontSize.body * 1.15,
+    color: colors.text.primary,
+  },
+  track: {
+    marginTop: spacing[3],
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: colors.border.hairline,
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+    borderRadius: 5,
+    backgroundColor: colors.accent.primary,
+  },
+  sublabel: {
+    marginTop: spacing[2],
+    fontSize: fontSize.caption,
+    color: colors.text.muted,
+  },
+});

--- a/src/features/stats/components/weekly-activity-card.test.tsx
+++ b/src/features/stats/components/weekly-activity-card.test.tsx
@@ -38,7 +38,7 @@ describe('WeeklyActivityCard', () => {
     render(<WeeklyActivityCard onPress={jest.fn()} />);
     const card = screen.getByTestId('weekly-activity-card');
     expect(card.props.accessibilityLabel).toContain(
-      '42m across 1 days this week'
+      '42m across 1 day this week'
     );
   });
 });

--- a/src/features/stats/components/weekly-activity-card.test.tsx
+++ b/src/features/stats/components/weekly-activity-card.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { fireEvent, render, screen } from '@/lib/test-utils';
+import { useQuestStore } from '@/store/quest-store';
+
+import { WeeklyActivityCard } from './weekly-activity-card';
+
+jest.mock('lucide-react-native', () => ({
+  ChevronRight: () => null,
+}));
+
+describe('WeeklyActivityCard', () => {
+  it('renders the compact chart with 7 bars from store data', () => {
+    useQuestStore.setState({ completedQuests: [] });
+    render(<WeeklyActivityCard onPress={jest.fn()} />);
+    expect(screen.getAllByTestId(/^activity-bar-/)).toHaveLength(7);
+    expect(screen.getByText('LAST 7 DAYS')).toBeOnTheScreen();
+  });
+
+  it('fires onPress when tapped', () => {
+    useQuestStore.setState({ completedQuests: [] });
+    const onPress = jest.fn();
+    render(<WeeklyActivityCard onPress={onPress} />);
+    fireEvent.press(screen.getByTestId('weekly-activity-card'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  // The outer Pressable has accessible={true}, which on RN collapses its
+  // subtree into one opaque accessibility element — so the chart's own
+  // summary label (built in weekly-activity-chart.tsx) becomes unreachable
+  // to VoiceOver/TalkBack unless the boundary carries an explicit label of
+  // its own. Use a non-empty week so the label can't accidentally match the
+  // "no activity" fallback string.
+  it('exposes the chart summary as the pressable accessibility label', () => {
+    useQuestStore.setState({
+      completedQuests: [{ id: '1', durationMinutes: 42, stopTime: Date.now() }],
+    });
+    render(<WeeklyActivityCard onPress={jest.fn()} />);
+    const card = screen.getByTestId('weekly-activity-card');
+    expect(card.props.accessibilityLabel).toContain(
+      '42m across 1 days this week'
+    );
+  });
+});

--- a/src/features/stats/components/weekly-activity-card.tsx
+++ b/src/features/stats/components/weekly-activity-card.tsx
@@ -1,0 +1,85 @@
+import { ChevronRight } from 'lucide-react-native';
+import React, { useMemo } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+
+import { Text, View } from '@/components/ui';
+import { useQuestStore } from '@/store/quest-store';
+import {
+  colors,
+  fontFamily,
+  fontSize,
+  radii,
+  spacing,
+  tracking,
+} from '@/theme';
+
+import {
+  aggregateDailyMinutes,
+  getWeeklyActivityLabel,
+} from '../lib/daily-stats';
+import { WeeklyActivityChart } from './weekly-activity-chart';
+
+const DAYS_SHOWN = 7;
+
+// Self-contained card: reads the quest store itself so profile.tsx stays thin.
+export function WeeklyActivityCard({ onPress }: { onPress: () => void }) {
+  const completedQuests = useQuestStore((state) => state.completedQuests);
+  const dailyStats = useMemo(
+    () => aggregateDailyMinutes(completedQuests, DAYS_SHOWN, Date.now()),
+    [completedQuests]
+  );
+
+  // The Pressable below is an accessible={true} boundary, which on RN
+  // collapses its whole subtree (including WeeklyActivityChart's own
+  // accessibilityLabel) into one opaque element for VoiceOver/TalkBack — so
+  // the chart's summary must be re-stated here, on the boundary that
+  // actually gets announced. Mirrors StatsCard's one-explicit-label-per-
+  // accessible-boundary pattern (stats-card.tsx).
+  const accessibilityLabel = getWeeklyActivityLabel(dailyStats);
+
+  return (
+    <Pressable
+      testID="weekly-activity-card"
+      style={styles.card}
+      onPress={onPress}
+      accessible={true}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint="Tap to view your stats"
+    >
+      <View style={styles.headerRow}>
+        <Text style={styles.caption}>LAST 7 DAYS</Text>
+        <ChevronRight size={16} color={colors.text.muted} />
+      </View>
+      <WeeklyActivityChart
+        stats={dailyStats}
+        variant="compact"
+        emptyMessage="Complete a quest to light up your week"
+      />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.surface.raised,
+    borderWidth: 1,
+    borderColor: colors.border.hairline,
+    borderRadius: radii.md,
+    padding: spacing[4],
+    marginHorizontal: spacing[4],
+    marginTop: spacing[4],
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing[3],
+  },
+  caption: {
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.caption,
+    letterSpacing: fontSize.caption * tracking.wide,
+    color: colors.text.muted,
+  },
+});

--- a/src/features/stats/components/weekly-activity-chart.test.tsx
+++ b/src/features/stats/components/weekly-activity-chart.test.tsx
@@ -47,9 +47,7 @@ describe('WeeklyActivityChart', () => {
   });
 
   it('summarizes the week in the container accessibility label', () => {
-    render(
-      <WeeklyActivityChart stats={WEEK} variant="full" testID="chart" />
-    );
+    render(<WeeklyActivityChart stats={WEEK} variant="full" testID="chart" />);
     expect(screen.getByTestId('chart').props.accessibilityLabel).toBe(
       '3h across 4 days this week, best day Thu'
     );

--- a/src/features/stats/components/weekly-activity-chart.test.tsx
+++ b/src/features/stats/components/weekly-activity-chart.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import { render, screen } from '@/lib/test-utils';
+import { colors } from '@/theme';
+
+import type { DailyStat } from '../lib/daily-stats';
+import { WeeklyActivityChart } from './weekly-activity-chart';
+
+const day = (
+  date: string,
+  dayInitial: string,
+  dayShort: string,
+  minutes: number,
+  isToday = false
+): DailyStat => ({ date, dayInitial, dayShort, minutes, isToday });
+
+// Deliberately non-uniform minutes; today is NOT the best day, so the
+// today-highlight and best-day assertions cannot pass by coincidence.
+const WEEK: DailyStat[] = [
+  day('2026-07-27', 'M', 'Mon', 0),
+  day('2026-07-28', 'T', 'Tue', 45),
+  day('2026-07-29', 'W', 'Wed', 0),
+  day('2026-07-30', 'T', 'Thu', 90),
+  day('2026-07-31', 'F', 'Fri', 0),
+  day('2026-08-01', 'S', 'Sat', 15),
+  day('2026-08-02', 'S', 'Sun', 30, true),
+];
+
+const EMPTY_WEEK: DailyStat[] = WEEK.map((d) => ({ ...d, minutes: 0 }));
+
+describe('WeeklyActivityChart', () => {
+  it('renders one bar per day', () => {
+    render(<WeeklyActivityChart stats={WEEK} variant="full" />);
+    expect(screen.getAllByTestId(/^activity-bar-/)).toHaveLength(7);
+  });
+
+  it('gives zero-days the neutral stub color, not an accent or red', () => {
+    render(<WeeklyActivityChart stats={WEEK} variant="full" />);
+    const zeroBar = screen.getByTestId('activity-bar-2026-07-29');
+    expect(zeroBar).toHaveStyle({ backgroundColor: colors.border.hairline });
+  });
+
+  it('highlights today with the full accent color', () => {
+    render(<WeeklyActivityChart stats={WEEK} variant="full" />);
+    const todayBar = screen.getByTestId('activity-bar-2026-08-02');
+    expect(todayBar).toHaveStyle({ backgroundColor: colors.accent.primary });
+  });
+
+  it('summarizes the week in the container accessibility label', () => {
+    render(
+      <WeeklyActivityChart stats={WEEK} variant="full" testID="chart" />
+    );
+    expect(screen.getByTestId('chart').props.accessibilityLabel).toBe(
+      '3h across 4 days this week, best day Thu'
+    );
+  });
+
+  it('shows the empty message only when every day is zero', () => {
+    render(
+      <WeeklyActivityChart
+        stats={EMPTY_WEEK}
+        variant="full"
+        emptyMessage="Complete a quest to light up your week"
+      />
+    );
+    expect(
+      screen.getByText('Complete a quest to light up your week')
+    ).toBeOnTheScreen();
+  });
+
+  it('does NOT show the empty message when the week has activity', () => {
+    render(
+      <WeeklyActivityChart
+        stats={WEEK}
+        variant="full"
+        emptyMessage="Complete a quest to light up your week"
+      />
+    );
+    expect(
+      screen.queryByText('Complete a quest to light up your week')
+    ).toBeNull();
+  });
+});

--- a/src/features/stats/components/weekly-activity-chart.tsx
+++ b/src/features/stats/components/weekly-activity-chart.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { Text, View } from '@/components/ui';
+import {
+  colors,
+  fontFamily,
+  fontSize,
+  spacing,
+  tracking,
+  withAlpha,
+} from '@/theme';
+
+import {
+  type DailyStat,
+  formatMinutes,
+  getWeeklySummary,
+} from '../lib/daily-stats';
+
+export type WeeklyActivityChartProps = {
+  stats: DailyStat[];
+  variant: 'compact' | 'full';
+  emptyMessage?: string;
+  testID?: string;
+};
+
+const BAR_AREA_HEIGHT = { full: 96, compact: 56 } as const;
+const ZERO_STUB_HEIGHT = 4;
+
+function Bar({
+  stat,
+  maxMinutes,
+  areaHeight,
+  index,
+}: {
+  stat: DailyStat;
+  maxMinutes: number;
+  areaHeight: number;
+  index: number;
+}) {
+  const targetHeight =
+    stat.minutes === 0 || maxMinutes === 0
+      ? ZERO_STUB_HEIGHT
+      : Math.max((stat.minutes / maxMinutes) * areaHeight, ZERO_STUB_HEIGHT);
+  const height = useSharedValue(ZERO_STUB_HEIGHT);
+
+  useEffect(() => {
+    height.value = withDelay(
+      index * 60,
+      withTiming(targetHeight, {
+        duration: 600,
+        easing: Easing.out(Easing.cubic),
+      })
+    );
+  }, [height, index, targetHeight]);
+
+  const animatedStyle = useAnimatedStyle(() => ({ height: height.value }));
+
+  const backgroundColor =
+    stat.minutes === 0
+      ? colors.border.hairline
+      : stat.isToday
+        ? colors.accent.primary
+        : withAlpha(colors.accent.primary, 0.45);
+
+  return (
+    <View style={styles.barColumn}>
+      <View style={[styles.barTrack, { height: areaHeight }]}>
+        <Animated.View
+          testID={`activity-bar-${stat.date}`}
+          style={[styles.bar, { backgroundColor }, animatedStyle]}
+        />
+      </View>
+      <Text style={styles.dayLabel}>{stat.dayInitial}</Text>
+    </View>
+  );
+}
+
+export function WeeklyActivityChart({
+  stats,
+  variant,
+  emptyMessage,
+  testID,
+}: WeeklyActivityChartProps) {
+  const { totalMinutes, bestDay } = getWeeklySummary(stats);
+  const maxMinutes = Math.max(...stats.map((s) => s.minutes), 0);
+  const areaHeight = BAR_AREA_HEIGHT[variant];
+  const activeDays = stats.filter((s) => s.minutes > 0).length;
+
+  const accessibilityLabel =
+    totalMinutes === 0
+      ? 'No quest time this week yet'
+      : `${formatMinutes(totalMinutes)} across ${activeDays} days this week` +
+        (bestDay ? `, best day ${bestDay.dayShort}` : '');
+
+  return (
+    <View
+      testID={testID}
+      accessible={true}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="image"
+    >
+      <View style={styles.row}>
+        {stats.map((stat, index) => (
+          <Bar
+            key={stat.date}
+            stat={stat}
+            maxMinutes={maxMinutes}
+            areaHeight={areaHeight}
+            index={index}
+          />
+        ))}
+      </View>
+      {totalMinutes === 0 && emptyMessage ? (
+        <Text style={styles.emptyMessage}>{emptyMessage}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: spacing[2],
+  },
+  barColumn: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  barTrack: {
+    width: '100%',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  bar: {
+    width: '60%',
+    borderRadius: 3,
+  },
+  dayLabel: {
+    marginTop: spacing[1],
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.caption,
+    letterSpacing: fontSize.caption * tracking.wide,
+    color: colors.text.muted,
+  },
+  emptyMessage: {
+    marginTop: spacing[3],
+    fontSize: fontSize.caption,
+    color: colors.text.muted,
+    textAlign: 'center',
+  },
+});

--- a/src/features/stats/components/weekly-activity-chart.tsx
+++ b/src/features/stats/components/weekly-activity-chart.tsx
@@ -20,7 +20,7 @@ import {
 
 import {
   type DailyStat,
-  formatMinutes,
+  getWeeklyActivityLabel,
   getWeeklySummary,
 } from '../lib/daily-stats';
 
@@ -89,16 +89,10 @@ export function WeeklyActivityChart({
   emptyMessage,
   testID,
 }: WeeklyActivityChartProps) {
-  const { totalMinutes, bestDay } = getWeeklySummary(stats);
+  const { totalMinutes } = getWeeklySummary(stats);
   const maxMinutes = Math.max(...stats.map((s) => s.minutes), 0);
   const areaHeight = BAR_AREA_HEIGHT[variant];
-  const activeDays = stats.filter((s) => s.minutes > 0).length;
-
-  const accessibilityLabel =
-    totalMinutes === 0
-      ? 'No quest time this week yet'
-      : `${formatMinutes(totalMinutes)} across ${activeDays} days this week` +
-        (bestDay ? `, best day ${bestDay.dayShort}` : '');
+  const accessibilityLabel = getWeeklyActivityLabel(stats);
 
   return (
     <View

--- a/src/features/stats/components/weekly-summary.test.tsx
+++ b/src/features/stats/components/weekly-summary.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { render, screen } from '@/lib/test-utils';
+
+import type { DailyStat } from '../lib/daily-stats';
+import { WeeklySummary } from './weekly-summary';
+
+const day = (
+  date: string,
+  dayShort: string,
+  minutes: number
+): DailyStat => ({
+  date,
+  dayInitial: dayShort[0],
+  dayShort,
+  minutes,
+  isToday: false,
+});
+
+describe('WeeklySummary', () => {
+  it('shows weekly total and best day', () => {
+    render(
+      <WeeklySummary
+        stats={[day('2026-07-30', 'Thu', 90), day('2026-08-02', 'Sun', 90)]}
+      />
+    );
+    expect(screen.getByText('3h')).toBeOnTheScreen();
+    // Ties resolve to the FIRST best day (strict > in getWeeklySummary)
+    expect(screen.getByText('Thu · 1h 30m')).toBeOnTheScreen();
+  });
+
+  it('shows an em dash for best day when the week is empty', () => {
+    render(<WeeklySummary stats={[day('2026-08-02', 'Sun', 0)]} />);
+    expect(screen.getByText('0m')).toBeOnTheScreen();
+    expect(screen.getByText('—')).toBeOnTheScreen();
+  });
+});

--- a/src/features/stats/components/weekly-summary.test.tsx
+++ b/src/features/stats/components/weekly-summary.test.tsx
@@ -5,11 +5,7 @@ import { render, screen } from '@/lib/test-utils';
 import type { DailyStat } from '../lib/daily-stats';
 import { WeeklySummary } from './weekly-summary';
 
-const day = (
-  date: string,
-  dayShort: string,
-  minutes: number
-): DailyStat => ({
+const day = (date: string, dayShort: string, minutes: number): DailyStat => ({
   date,
   dayInitial: dayShort[0],
   dayShort,

--- a/src/features/stats/components/weekly-summary.tsx
+++ b/src/features/stats/components/weekly-summary.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { Text, View } from '@/components/ui';
+import {
+  colors,
+  fontFamily,
+  fontSize,
+  radii,
+  spacing,
+  tracking,
+} from '@/theme';
+
+import {
+  type DailyStat,
+  formatMinutes,
+  getWeeklySummary,
+} from '../lib/daily-stats';
+
+export function WeeklySummary({ stats }: { stats: DailyStat[] }) {
+  const { totalMinutes, bestDay } = getWeeklySummary(stats);
+
+  return (
+    <View style={styles.grid}>
+      <View
+        style={styles.tile}
+        accessible={true}
+        accessibilityRole="text"
+        accessibilityLabel={`${formatMinutes(totalMinutes)} this week`}
+      >
+        <Text style={styles.tileNumber}>{formatMinutes(totalMinutes)}</Text>
+        <Text style={styles.tileLabel}>This Week</Text>
+      </View>
+      <View
+        style={styles.tile}
+        accessible={true}
+        accessibilityRole="text"
+        accessibilityLabel={
+          bestDay
+            ? `Best day ${bestDay.dayShort}, ${formatMinutes(bestDay.minutes)}`
+            : 'No best day yet'
+        }
+      >
+        <Text style={styles.tileNumber}>
+          {bestDay
+            ? `${bestDay.dayShort} · ${formatMinutes(bestDay.minutes)}`
+            : '—'}
+        </Text>
+        <Text style={styles.tileLabel}>Best Day</Text>
+      </View>
+    </View>
+  );
+}
+
+// Mirrors the StatsCard tile styling (src/components/profile/stats-card.tsx),
+// including the Erstoria lineHeight convention.
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    gap: spacing[2],
+  },
+  tile: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.surface.raised,
+    borderWidth: 1,
+    borderColor: colors.border.hairline,
+    borderRadius: radii.md,
+    paddingVertical: spacing[4],
+    paddingHorizontal: spacing[2],
+  },
+  tileNumber: {
+    fontFamily: fontFamily.display,
+    fontSize: fontSize.h3,
+    lineHeight: fontSize.h3 * 1.15,
+    color: colors.text.primary,
+    textAlign: 'center',
+  },
+  tileLabel: {
+    marginTop: spacing[1],
+    fontFamily: fontFamily.semibold,
+    fontSize: fontSize.caption,
+    letterSpacing: fontSize.caption * tracking.wide,
+    textTransform: 'uppercase',
+    color: colors.text.muted,
+    textAlign: 'center',
+  },
+});

--- a/src/features/stats/lib/daily-stats.test.ts
+++ b/src/features/stats/lib/daily-stats.test.ts
@@ -1,6 +1,7 @@
 import {
   aggregateDailyMinutes,
   formatMinutes,
+  getWeeklyActivityLabel,
   getWeeklySummary,
 } from './daily-stats';
 
@@ -89,5 +90,35 @@ describe('formatMinutes', () => {
     expect(formatMinutes(120)).toBe('2h');
     expect(formatMinutes(125)).toBe('2h 5m');
     expect(formatMinutes(0)).toBe('0m');
+  });
+});
+
+describe('getWeeklyActivityLabel', () => {
+  it('uses singular "day" for a single active day', () => {
+    const stats = aggregateDailyMinutes([quest(NOW, 42)], 7, NOW);
+    // Sole active day is today (2026-08-02, a Sunday), so it's also the
+    // best day.
+    expect(getWeeklyActivityLabel(stats)).toBe(
+      '42m across 1 day this week, best day Sun'
+    );
+  });
+
+  it('uses plural "days" for multiple active days', () => {
+    const stats = aggregateDailyMinutes(
+      [
+        quest(new Date(2026, 7, 1, 10, 0).getTime(), 50), // Sat
+        quest(new Date(2026, 7, 2, 10, 0).getTime(), 20), // Sun
+      ],
+      7,
+      NOW
+    );
+    expect(getWeeklyActivityLabel(stats)).toBe(
+      '1h 10m across 2 days this week, best day Sat'
+    );
+  });
+
+  it('returns the no-activity fallback for an all-zero week, with no best-day suffix', () => {
+    const stats = aggregateDailyMinutes([], 7, NOW);
+    expect(getWeeklyActivityLabel(stats)).toBe('No quest time this week yet');
   });
 });

--- a/src/features/stats/lib/daily-stats.test.ts
+++ b/src/features/stats/lib/daily-stats.test.ts
@@ -1,0 +1,93 @@
+import {
+  aggregateDailyMinutes,
+  formatMinutes,
+  getWeeklySummary,
+} from './daily-stats';
+
+// Fixed reference: 2026-08-02 (Sunday) 12:00:00 LOCAL time. Constructed via
+// Date parts (not an ISO string) so the test is timezone-independent.
+const NOW = new Date(2026, 7, 2, 12, 0, 0).getTime();
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const quest = (stopTime: number | undefined, durationMinutes: number) => ({
+  stopTime,
+  durationMinutes,
+});
+
+describe('aggregateDailyMinutes', () => {
+  it('returns exactly `days` zero-filled entries ending today', () => {
+    const result = aggregateDailyMinutes([], 7, NOW);
+    expect(result).toHaveLength(7);
+    expect(result.every((d) => d.minutes === 0)).toBe(true);
+    expect(result[6].isToday).toBe(true);
+    expect(result[6].date).toBe('2026-08-02');
+    expect(result[0].date).toBe('2026-07-27');
+    // 2026-08-02 is a Sunday
+    expect(result[6].dayInitial).toBe('S');
+    expect(result[6].dayShort).toBe('Sun');
+  });
+
+  it('sums multiple quests on the same local day', () => {
+    const todayMorning = new Date(2026, 7, 2, 9, 0).getTime();
+    const todayEvening = new Date(2026, 7, 2, 20, 0).getTime();
+    const result = aggregateDailyMinutes(
+      [quest(todayMorning, 30), quest(todayEvening, 15)],
+      7,
+      NOW
+    );
+    expect(result[6].minutes).toBe(45);
+  });
+
+  it('buckets by LOCAL calendar day across midnight', () => {
+    const justBeforeMidnight = new Date(2026, 7, 1, 23, 58).getTime();
+    const justAfterMidnight = new Date(2026, 7, 2, 0, 2).getTime();
+    const result = aggregateDailyMinutes(
+      [quest(justBeforeMidnight, 20), quest(justAfterMidnight, 10)],
+      7,
+      NOW
+    );
+    expect(result[5].minutes).toBe(20); // Aug 1
+    expect(result[6].minutes).toBe(10); // Aug 2
+  });
+
+  it('excludes quests outside the window and quests without stopTime', () => {
+    const eightDaysAgo = NOW - 8 * DAY_MS;
+    const result = aggregateDailyMinutes(
+      [quest(eightDaysAgo, 60), quest(undefined, 60)],
+      7,
+      NOW
+    );
+    expect(result.every((d) => d.minutes === 0)).toBe(true);
+  });
+});
+
+describe('getWeeklySummary', () => {
+  it('totals minutes and finds the best day', () => {
+    const stats = aggregateDailyMinutes(
+      [
+        quest(new Date(2026, 7, 1, 10, 0).getTime(), 50),
+        quest(new Date(2026, 7, 2, 10, 0).getTime(), 20),
+      ],
+      7,
+      NOW
+    );
+    const summary = getWeeklySummary(stats);
+    expect(summary.totalMinutes).toBe(70);
+    expect(summary.bestDay?.date).toBe('2026-08-01');
+  });
+
+  it('returns bestDay null for an all-zero week', () => {
+    const summary = getWeeklySummary(aggregateDailyMinutes([], 7, NOW));
+    expect(summary.totalMinutes).toBe(0);
+    expect(summary.bestDay).toBeNull();
+  });
+});
+
+describe('formatMinutes', () => {
+  it('formats sub-hour, exact-hour, and mixed values', () => {
+    expect(formatMinutes(45)).toBe('45m');
+    expect(formatMinutes(120)).toBe('2h');
+    expect(formatMinutes(125)).toBe('2h 5m');
+    expect(formatMinutes(0)).toBe('0m');
+  });
+});

--- a/src/features/stats/lib/daily-stats.ts
+++ b/src/features/stats/lib/daily-stats.ts
@@ -68,3 +68,17 @@ export function formatMinutes(minutes: number): string {
   const rest = minutes % 60;
   return rest === 0 ? `${hours}h` : `${hours}h ${rest}m`;
 }
+
+// Shared between WeeklyActivityChart (its own accessibilityLabel) and
+// WeeklyActivityCard (the outer Pressable's accessibilityLabel) so the two
+// stay worded identically — see weekly-activity-card.tsx for why the card
+// needs its own copy of this string rather than relying on the chart's.
+export function getWeeklyActivityLabel(stats: DailyStat[]): string {
+  const { totalMinutes, bestDay } = getWeeklySummary(stats);
+  if (totalMinutes === 0) return 'No quest time this week yet';
+  const activeDays = stats.filter((s) => s.minutes > 0).length;
+  return (
+    `${formatMinutes(totalMinutes)} across ${activeDays} days this week` +
+    (bestDay ? `, best day ${bestDay.dayShort}` : '')
+  );
+}

--- a/src/features/stats/lib/daily-stats.ts
+++ b/src/features/stats/lib/daily-stats.ts
@@ -1,0 +1,70 @@
+import type { Quest } from '@/store/types';
+
+export type DailyStat = {
+  date: string; // 'YYYY-MM-DD', device-local calendar day
+  dayInitial: string;
+  dayShort: string;
+  minutes: number;
+  isToday: boolean;
+};
+
+const DAY_INITIALS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+const DAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function toLocalDateKey(timestamp: number): string {
+  const d = new Date(timestamp);
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${month}-${day}`;
+}
+
+export function aggregateDailyMinutes(
+  quests: Pick<Quest, 'stopTime' | 'durationMinutes'>[],
+  days: number,
+  now: number
+): DailyStat[] {
+  const minutesByDay = new Map<string, number>();
+  for (const q of quests) {
+    if (q.stopTime == null) continue;
+    const key = toLocalDateKey(q.stopTime);
+    minutesByDay.set(key, (minutesByDay.get(key) ?? 0) + q.durationMinutes);
+  }
+
+  const result: DailyStat[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    // Date arithmetic via setDate handles month boundaries and DST shifts;
+    // subtracting i * 86400000 from a timestamp does not.
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    const key = toLocalDateKey(d.getTime());
+    result.push({
+      date: key,
+      dayInitial: DAY_INITIALS[d.getDay()],
+      dayShort: DAY_SHORT[d.getDay()],
+      minutes: minutesByDay.get(key) ?? 0,
+      isToday: i === 0,
+    });
+  }
+  return result;
+}
+
+export function getWeeklySummary(stats: DailyStat[]): {
+  totalMinutes: number;
+  bestDay: DailyStat | null;
+} {
+  const totalMinutes = stats.reduce((sum, s) => sum + s.minutes, 0);
+  let bestDay: DailyStat | null = null;
+  for (const s of stats) {
+    if (s.minutes > 0 && (bestDay === null || s.minutes > bestDay.minutes)) {
+      bestDay = s;
+    }
+  }
+  return { totalMinutes, bestDay };
+}
+
+export function formatMinutes(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return rest === 0 ? `${hours}h` : `${hours}h ${rest}m`;
+}

--- a/src/features/stats/lib/daily-stats.ts
+++ b/src/features/stats/lib/daily-stats.ts
@@ -77,8 +77,9 @@ export function getWeeklyActivityLabel(stats: DailyStat[]): string {
   const { totalMinutes, bestDay } = getWeeklySummary(stats);
   if (totalMinutes === 0) return 'No quest time this week yet';
   const activeDays = stats.filter((s) => s.minutes > 0).length;
+  const dayNoun = activeDays === 1 ? 'day' : 'days';
   return (
-    `${formatMinutes(totalMinutes)} across ${activeDays} days this week` +
+    `${formatMinutes(totalMinutes)} across ${activeDays} ${dayNoun} this week` +
     (bestDay ? `, best day ${bestDay.dayShort}` : '')
   );
 }

--- a/src/features/stats/lib/milestones.test.ts
+++ b/src/features/stats/lib/milestones.test.ts
@@ -1,0 +1,50 @@
+import { getMilestoneProgress, MIN_FILL_FRACTION } from './milestones';
+
+describe('getMilestoneProgress', () => {
+  it('starts in the first segment with singular hour label', () => {
+    const p = getMilestoneProgress(30); // 30 min toward 1 hour
+    expect(p.prevMinutes).toBe(0);
+    expect(p.nextMinutes).toBe(60);
+    expect(p.fraction).toBeCloseTo(0.5);
+    expect(p.label).toBe('Next: 1 hour reclaimed');
+  });
+
+  it('reaching a milestone advances to the next segment', () => {
+    const p = getMilestoneProgress(60); // exactly 1 hour
+    expect(p.prevMinutes).toBe(60);
+    expect(p.nextMinutes).toBe(180);
+    expect(p.fraction).toBe(MIN_FILL_FRACTION); // 0 real progress into segment, endowed
+    expect(p.label).toBe('Next: 3 hours reclaimed');
+  });
+
+  it('computes fraction within a mid-ladder segment', () => {
+    // segment 12h (720) -> 24h (1440); 1080 min is halfway
+    const p = getMilestoneProgress(1080);
+    expect(p.prevMinutes).toBe(720);
+    expect(p.nextMinutes).toBe(1440);
+    expect(p.fraction).toBeCloseTo(0.5);
+    expect(p.label).toBe('Next: 24 hours reclaimed');
+  });
+
+  it('endowed progress: fraction never below MIN_FILL_FRACTION when total > 0', () => {
+    const p = getMilestoneProgress(1); // 1 minute of 60
+    expect(p.fraction).toBe(MIN_FILL_FRACTION);
+  });
+
+  it('endowed progress does NOT apply at zero', () => {
+    const p = getMilestoneProgress(0);
+    expect(p.fraction).toBe(0);
+  });
+
+  it('fraction is not clamped when real progress exceeds the minimum', () => {
+    const p = getMilestoneProgress(45); // 0.75 of first hour
+    expect(p.fraction).toBeCloseTo(0.75);
+  });
+
+  it('past the final milestone: full bar, hour-count label, null next', () => {
+    const p = getMilestoneProgress(63000); // 1050 hours, past 1000h
+    expect(p.nextMinutes).toBeNull();
+    expect(p.fraction).toBe(1);
+    expect(p.label).toBe('1,050 hours reclaimed');
+  });
+});

--- a/src/features/stats/lib/milestones.ts
+++ b/src/features/stats/lib/milestones.ts
@@ -1,0 +1,46 @@
+export const MILESTONE_HOURS: readonly number[] = [
+  1, 3, 6, 12, 24, 48, 100, 250, 500, 1000,
+];
+
+// Endowed-progress floor (Kivetz et al. 2006): once the user has any minutes,
+// the bar must show a visible sliver — never 0%.
+export const MIN_FILL_FRACTION = 0.04;
+
+export type MilestoneProgress = {
+  prevMinutes: number;
+  nextMinutes: number | null;
+  fraction: number;
+  label: string;
+};
+
+function hoursLabel(hours: number): string {
+  return hours === 1 ? '1 hour' : `${hours.toLocaleString('en-US')} hours`;
+}
+
+export function getMilestoneProgress(totalMinutes: number): MilestoneProgress {
+  const next = MILESTONE_HOURS.find((h) => h * 60 > totalMinutes);
+
+  if (next === undefined) {
+    const totalHours = Math.floor(totalMinutes / 60);
+    return {
+      prevMinutes: MILESTONE_HOURS[MILESTONE_HOURS.length - 1] * 60,
+      nextMinutes: null,
+      fraction: 1,
+      label: `${hoursLabel(totalHours)} reclaimed`,
+    };
+  }
+
+  const nextIndex = MILESTONE_HOURS.indexOf(next);
+  const prevMinutes = nextIndex === 0 ? 0 : MILESTONE_HOURS[nextIndex - 1] * 60;
+  const nextMinutes = next * 60;
+  const rawFraction = (totalMinutes - prevMinutes) / (nextMinutes - prevMinutes);
+  const fraction =
+    totalMinutes > 0 ? Math.max(rawFraction, MIN_FILL_FRACTION) : 0;
+
+  return {
+    prevMinutes,
+    nextMinutes,
+    fraction,
+    label: `Next: ${hoursLabel(next)} reclaimed`,
+  };
+}

--- a/src/features/stats/lib/milestones.ts
+++ b/src/features/stats/lib/milestones.ts
@@ -33,7 +33,8 @@ export function getMilestoneProgress(totalMinutes: number): MilestoneProgress {
   const nextIndex = MILESTONE_HOURS.indexOf(next);
   const prevMinutes = nextIndex === 0 ? 0 : MILESTONE_HOURS[nextIndex - 1] * 60;
   const nextMinutes = next * 60;
-  const rawFraction = (totalMinutes - prevMinutes) / (nextMinutes - prevMinutes);
+  const rawFraction =
+    (totalMinutes - prevMinutes) / (nextMinutes - prevMinutes);
   const fraction =
     totalMinutes > 0 ? Math.max(rawFraction, MIN_FILL_FRACTION) : 0;
 


### PR DESCRIPTION
> **Status 2026-08-07: rework pending.** Device QA found a wrong number on screen and a mechanic that duplicates the Achievements screen. The redesign below is agreed; a proper implementation plan will be written before any further code lands. Do not merge as-is.

## Summary

Adds locally-computed stats visualizations, per the 2026-08-02 profile-stats-charts plan:

- **`src/features/stats/lib/`** — pure aggregation: `aggregateDailyMinutes` (local-calendar-day bucketing, DST-safe via `setDate`), `getWeeklySummary`, `formatMinutes`, `getWeeklyActivityLabel`, and the milestone ladder (`getMilestoneProgress` with an endowed-progress floor — the bar never reads 0% once lifetime total > 0).
- **Three presentational components** — `WeeklyActivityChart` (7 bars, Reanimated staggered mount animation; zero-days render a neutral 4px stub, never red), `WeeklySummary` tiles, `MilestoneProgress` bar.
- **`/stats` screen** — composes all three from `useQuestStore`/`useUserStore`; registered with `href: null` in the Tabs layout (the plan claimed no layout change was needed — wrong for a Tabs navigator; without it the route appears as a 6th tab). Back button follows the achievements convention. Fires `stats_screen_viewed` once on mount.
- **Profile** — compact pressable `WeeklyActivityCard` between StatsCard and ActionCards, navigating to `/stats`. Explicit `accessibilityLabel` on the pressable boundary (nested `accessible` regions collapse the subtree, which had silently swallowed the chart's screen-reader summary).

No store changes, no API changes, no new dependencies.

---

# Device QA 2026-08-07 — two defects, redesign agreed

## Defect 1 (bug): the lifetime total is frozen at app boot

Observed on device: the screen showed **`4m` This Week** and **`1m` reclaimed so far** simultaneously, from the same four completed quests.

The two figures come from different sources and only one is live:

| Element | Source | Freshness |
|---|---|---|
| "This Week" tile, chart | `useQuestStore.completedQuests` → `aggregateDailyMinutes` | live — updated the moment a quest completes |
| "reclaimed so far", milestone bar | `useUserStore.user.totalMinutesOffPhone` | **frozen at app boot** |

Root cause chain:

1. `user` is persisted to MMKV (`store/user-store.ts:41`) and written in only three places.
2. `lib/auth/index.tsx:150` — `hydrate()`, runs **once per cold start**. This is the only routine refresh.
3. `api/auth.ts:155` — sign-in only.
4. `settings.tsx:643` — guarded by `if (!user)`, so it never refreshes an existing user, only fills a hole.
5. `lib/hooks/use-profile-data.ts:8-15` — hits `/users/me` on every Profile mount and **receives the correct value**, then discards it: it reads `details.email` and never calls `setUser`.
6. Quest completion writes to the quest store. Nothing writes `totalMinutesOffPhone`.

So the value is a boot-time snapshot. Server-side `calculateTotalQuestMinutes` (`unquest-server/src/models/user.model.js:329`) is correct; the app never asks again.

`user?.totalMinutesOffPhone ?? localSum` reads as a safe fallback but `??` only tests **existence**. A stale `1` is present, so the fallback never fires and the live local data sits unused.

**Blast radius is wider than this branch:** `profile.tsx:131` carries the identical expression, feeding the StatsCard "minutes saved" tile. Profile has been showing boot-stale minutes independently of this PR — putting a live number next to it on `/stats` is what made it visible.

## Defect 2 (design): "Next" duplicates the Achievements screen

`achievements.tsx:392-417` already defines a **`minutes` achievement category** — Time Saver (10 min), Time Guardian (100 min), Time Lord (1000 min), each with a progress bar. `features/stats/lib/milestones.ts:1-3` defines a **second, unrelated ladder over the identical stat**: 1h, 3h, 6h, 12h, 24h, 48h…

At 4 minutes the app therefore asserts two different next goals for the same number: `/stats` says *"Next: 1 hour reclaimed"*, `/achievements` says *"Time Saver — 4/10 minutes"*. Neither module imports the other, so `milestones.test.ts` and `achievements.test.tsx` both pass — each ladder is internally consistent. No test can catch "these two disagree" when neither knows the other exists.

There is also a **third** answer in play: `achievements.tsx:313-316` computes its minutes from local `completedQuests`, so Achievements reports 4m while Stats and Profile report 1m. One underlying stat, three screens, three numbers.

---

# Agreed redesign

Ruling: **Stats is a descriptive mirror; Achievements owns goals and rewards.** No goal ladders or threshold bars on `/stats`.

## Composition

| # | Section | Status |
|---|---|---|
| 1 | Header "Your Stats" + subtitle | unchanged |
| 2 | `WeeklySummary` — This Week / Best Day | unchanged |
| 3 | `WeeklyActivityChart` | unchanged |
| 4 | **Overview grid** — current streak, quests completed, time reclaimed all-time, average quest length | **new** |
| 5 | **Achievements link row** — `🏆 Achievements 2/9 ›` | **new** |
| 6 | `MilestoneProgress` | **deleted** |

Deletion is clean: `MilestoneProgress` has exactly one consumer (`stats.tsx:66`) and nothing outside `milestones.ts` / `milestone-progress.tsx` references `MILESTONE_HOURS`. Four files go — the component, `milestones.ts`, and both test files. This removes the competing ladder at the source rather than rewording it.

## Data flow

New `refreshUser()` in `src/lib/services/user.ts`:

```ts
export async function refreshUser(): Promise<UserDetails> {
  const details = await getUserDetails();
  useUserStore.getState().setUser(details);
  return details;
}
```

Three call sites, one function:

- **`/stats`** — on focus via `useFocusEffect`. Failure falls back to the last known value; this screen must never block or error on a network hiccup.
- **`use-profile-data.ts`** — replaces the current `getUserDetails()` call, which already fetches the full payload and discards all but `email`. This alone fixes Profile's stale "minutes saved" tile.
- **`settings.tsx:643`** — drop the `if (!user)` guard so it refreshes rather than only filling a hole.

Chart and weekly tiles keep reading local `completedQuests` — a 7-day window should not wait on the network. Overview tiles read the server fields. `avgQuestLength = totalMinutesOffPhone / totalQuestsCompleted`, derived from the two tiles beside it so it cannot drift from them; zero quests renders `—`, not a division by zero.

## Achievements count — deliberate scope inclusion

`generateAchievements()` (`achievements.tsx:319`) is a closure inside the component, so `/stats` cannot read it. It becomes a pure `buildAchievements({ streak, questCount, minutes })` in `src/features/achievements/lib/achievements.ts`, and **both** screens feed it the same refreshed server values.

This touches `achievements.tsx` beyond a pure extraction. Without it, the `2/9` on Stats can legitimately differ from the `2/9` on Achievements — reintroducing the exact class of bug being removed. Included deliberately.

## New components

`features/stats/components/overview-grid.tsx` and `achievements-link.tsx`. `WeeklySummary` and the new grid share an extracted `StatTile`; tile styling is already duplicated between `weekly-summary.tsx` and `profile/stats-card.tsx` and a third copy is not being added. `stats-card.tsx` is left alone to keep the diff out of Profile's layout — follow-up ticket below.

## Zero state

The majority case: per PostHog, ~6.9% of the 30-day onboarding cohort completes a first quest. `/stats` renders the real layout with `0m` / `0 quests` / `0-day streak` and a flat chart, plus a single "Start your first quest" CTA — teaching what the screen becomes rather than maintaining a second bespoke layout. Copy and CTA have to carry it so an all-zero grid does not read as broken.

## Testing

TDD, red first. The load-bearing regression test has a known trap: **the fixture must use server ≠ local** — e.g. server `1` / local `4`, the observed case. A fixture where the two are equal passes against the broken code and asserts nothing.

Mutations to run and record:

- Revert `refreshUser` to the discard-the-payload version → must go red.
- Make `refreshUser` fire unconditionally, then never fire → different tests must catch each direction.
- Set `totalQuestsCompleted` to 0 → average renders `—`, not `NaN`.

---

## Verification (as of the current, pre-rework tree)

- TDD throughout: every behavior red-first; mutations recorded per task — TZ-pinned UTC-bucketing mutation (America/New_York), endowed-progress guard mutated BOTH ways with different tests catching each direction, zero-day color swap, precedence flip, gutted onPress (nav test), forced singular/plural.
- Full suite: **189 suites / 2105 passed / 0 failed** (baseline at branch start: 182 / 2068). Type-check 0 errors. Translations clean. Repo-wide lint failures (77E/44W) confirmed pre-existing and confined to files this branch never touched; branch files lint-clean.
- Each task passed an independent scoped review; final whole-branch review clean after one fix wave (back button + "1 day/days" pluralization in the a11y label).

These figures cover the milestone-ladder implementation that the redesign removes. They will need re-establishing after rework.

## Remaining before merge

- [ ] Write the implementation plan for the redesign above
- [ ] Implement: delete `MilestoneProgress` + `milestones.ts`, add `refreshUser()` and its three call sites, add Overview grid + Achievements link, extract `buildAchievements`, zero state
- [ ] Re-run full suite, type-check, translations; record the mutation results listed above
- [ ] Simulator visual pass: chart and grid render/animate, tap-through to `/stats` and `/achievements`, back button returns, zero state reads as intentional, nothing renders red or `0%`. The Reanimated animations have still not been seen rendering — Jest cannot catch Fabric animation issues.

## Follow-ups to ticket

1. **`syncQuestRuns` is dead code** — declared at `quest-store.ts:68`, implemented at `:584`, called from nowhere. Its implementation merges server and local history, but since it never runs, `completedQuests` is install-local only (appended at `:247`). Consequence: after a reinstall or on a second device the chart shows an empty week while lifetime totals are correct. Real bug, wider than this branch.
2. Tile-styling duplication between `weekly-summary.tsx` and `profile/stats-card.tsx`.
3. Streak repair/forgiveness mechanics.
4. Server per-day aggregates endpoint (`/stats/me/daily`).
5. Quests-per-day toggle on the bar chart.
