### PR TITLE
fix(onboarding-music): never start playback while the app is backgrounded

### DIFF
--- a/src/hooks/use-onboarding-music.test.ts
+++ b/src/hooks/use-onboarding-music.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { AppState, type AppStateStatus } from 'react-native';
 
 import { useSettingsStore } from '@/store/settings-store';
 
@@ -30,6 +31,10 @@ beforeEach(() => {
   delete (mockPlayer as Partial<Record<'loop' | 'volume', unknown>>).volume;
   __resetAudioMock();
   useSettingsStore.setState(useSettingsStore.getInitialState());
+  // The backgrounded-app test overwrites this module-scoped value; reset it so
+  // every other test provably runs the foreground branch of the guard rather
+  // than inheriting whatever the previous test left behind.
+  (AppState as { currentState: AppStateStatus }).currentState = 'active';
 });
 
 describe('useOnboardingMusic', () => {
@@ -139,6 +144,53 @@ describe('useOnboardingMusic', () => {
     // unhandled rejection) — StoryNarration.tsx awaits inside try/catch for
     // the same reason.
     await waitFor(() => expect(mockPlayer.play).toHaveBeenCalled());
+  });
+
+  // REACT-NATIVE-71: first-quest tells the user to lock their phone, so the
+  // start() continuation can run with the app backgrounded — where iOS
+  // refuses to activate the audio session and expo-audio's sync play() throws.
+  // Music while backgrounded isn't wanted anyway; the hook must not ask.
+  it('does not start playback while the app is backgrounded', async () => {
+    (AppState as { currentState: AppStateStatus }).currentState = 'background';
+
+    renderHook(() => useOnboardingMusic());
+    // Flush the async start() continuation past the awaited session config.
+    await act(async () => {});
+
+    expect(mockPlayer.play).not.toHaveBeenCalled();
+  });
+
+  // AppState.currentState is null until the native module reports in (and
+  // 'unknown' on some Android launches). A guard written as `!== 'active'`
+  // would silently skip the music on every cold start — only a KNOWN
+  // background state may suppress playback.
+  it('starts playback when the app state is still indeterminate at cold start', async () => {
+    (AppState as { currentState: AppStateStatus | null }).currentState = null;
+
+    renderHook(() => useOnboardingMusic());
+
+    await waitFor(() => expect(mockPlayer.play).toHaveBeenCalled());
+  });
+
+  // The AppState check narrows the window but can't close it: the app can
+  // background between the check and the native call, and expo-audio's play()
+  // is synchronous native code that throws when iOS refuses the session.
+  // start() is fire-and-forget, so an uncaught throw becomes an unhandled
+  // rejection — exactly the REACT-NATIVE-71 Sentry event.
+  it('warns instead of rejecting when the OS refuses playback', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockPlayer.play.mockImplementationOnce(() => {
+      throw new Error('Session activation failed');
+    });
+
+    renderHook(() => useOnboardingMusic());
+    await act(async () => {});
+
+    expect(warn).toHaveBeenCalledWith(
+      'Failed to start the onboarding music',
+      expect.any(Error)
+    );
+    warn.mockRestore();
   });
 
   it('does not start when disabled, e.g. while onboarding is already complete', () => {

--- a/src/hooks/use-onboarding-music.ts
+++ b/src/hooks/use-onboarding-music.ts
@@ -4,6 +4,7 @@ import {
   useAudioPlayerStatus,
 } from 'expo-audio';
 import { useEffect } from 'react';
+import { AppState } from 'react-native';
 
 import { useSettingsStore } from '@/store/settings-store';
 
@@ -78,7 +79,26 @@ export const useOnboardingMusic = (
       // flight; without this the continuation would start the music again
       // right after the re-run of this effect paused it.
       if (cancelled) return;
-      player.play();
+      // The user can also LOCK THE PHONE while the call above is in flight —
+      // first-quest explicitly tells them to. iOS refuses to activate an
+      // audio session for a backgrounded app, so play() would throw
+      // (REACT-NATIVE-71). Backgrounded music isn't wanted anyway: skip, and
+      // let the next enabled/focus change start playback back in the flow.
+      // `=== 'background'`, NOT `!== 'active'`: currentState is null until
+      // the native module reports in (and 'unknown' on some Android
+      // launches), so only a KNOWN background state may suppress playback —
+      // the catch below covers whatever slips through.
+      if (AppState.currentState === 'background') return;
+      try {
+        player.play();
+      } catch (error) {
+        // The check above can't fully close the window — the app can
+        // background between it and this synchronous native call, and iOS
+        // then throws "Session activation failed" (REACT-NATIVE-71). Ambient
+        // music failing to start must never surface as an unhandled
+        // rejection.
+        console.warn('Failed to start the onboarding music', error);
+      }
     };
     start();
 


### PR DESCRIPTION
## Summary

Sentry [REACT-NATIVE-71](https://vaedros-software-llc.sentry.io/issues/7652347360/) (production, 2.1.0+47, iOS 26.5): `UnexpectedException: Session activation failed` thrown from `use-onboarding-music.ts:81`, surfaced as an unhandled promise rejection.

**Root cause:** the hook's `start()` continuation resumes after `await setAudioModeAsync(...)` and calls expo-audio's *synchronous* `player.play()`. If the user has backgrounded the app in that window — and `/onboarding/first-quest` explicitly tells them to lock their phone — iOS refuses to activate the audio session (correctly: we set `shouldPlayInBackground: false`) and the native throw escapes the fire-and-forget async function. The existing try/catch covered only `setAudioModeAsync`, not `play()`.

## Fix

Two additions at the throw site, no behavior change for foregrounded users:

1. **Guard:** skip `play()` when `AppState.currentState === 'background'`. Deliberately `=== 'background'` rather than `!== 'active'` — `currentState` is `null` until the native module reports in (and `'unknown'` on some Android launches), and the stricter guard silently killed cold-start playback (caught by `_layout.test.tsx`).
2. **Catch:** the app can still background between the check and the sync native call, so `play()` is wrapped and an OS refusal logs a `console.warn` instead of rejecting.

No background-music behavior existed to remove — iOS already pauses the track on lock; this stops us *asking* to start it there. Foreground-resume-on-return was deliberately left out (future "focus mode" scope).

## Verification

- TDD: all three new tests watched RED first (backgrounded → no play; indeterminate cold-start state → plays; OS refusal → warns, no rejection).
- Mutation-proven both ways: deleting the guard fails exactly the backgrounded test; **inverting** it fails 7 different tests (foreground + cold-start); removing the catch fails exactly the warn test.
- Full suite 2096 passed / 0 failed (the one red suite, `src/store/invite-store.test.ts`, is a pre-existing untracked orphan on main, untouched here); `type-check` 0; prettier clean.

Fixes REACT-NATIVE-71