### PR TITLE
fix(auth): gate leaked provisional players behind the signup screen so their progress converts

### DIFF
--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -1,5 +1,8 @@
 import { endProvisionalSession, signIn } from '@/lib/auth';
-import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
+import {
+  ProvisionalRefreshUnavailable,
+  ProvisionalSessionExpired,
+} from '@/lib/auth/provisional-session';
 import {
   ExistingAccountConfirmationRequired,
   NoAccountForIdentity,
@@ -105,7 +108,15 @@ describe('auth.ts', () => {
     });
 
     it('should include provisional token in headers when available', async () => {
-      (getItem as jest.Mock).mockReturnValue('provisional-token-123'); // provisionalAccessToken
+      // Keyed, not blanket: a bare mockReturnValue hands the SAME string to
+      // every key, including `provisionalRefreshToken`, describing a disk
+      // state that cannot exist. These cases are about the Bearer header, so
+      // the honest shape is an access token with nothing to refresh with.
+      (getItem as jest.Mock).mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' || key === 'provisionalUserId'
+          ? 'provisional-token-123'
+          : null
+      );
       (authClient.post as jest.Mock).mockResolvedValue({ data: {} });
 
       await requestMagicLink('test@example.com');
@@ -123,7 +134,15 @@ describe('auth.ts', () => {
     });
 
     it('should include token in header when provisional token is available', async () => {
-      (getItem as jest.Mock).mockReturnValue('provisional-token-123'); // provisionalAccessToken
+      // Keyed, not blanket: a bare mockReturnValue hands the SAME string to
+      // every key, including `provisionalRefreshToken`, describing a disk
+      // state that cannot exist. These cases are about the Bearer header, so
+      // the honest shape is an access token with nothing to refresh with.
+      (getItem as jest.Mock).mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' || key === 'provisionalUserId'
+          ? 'provisional-token-123'
+          : null
+      );
       (authClient.post as jest.Mock).mockResolvedValue({ data: {} });
 
       await requestMagicLink('test@example.com');
@@ -435,7 +454,15 @@ describe('auth.ts', () => {
     });
 
     it('posts the credential with a provisional Bearer header when a provisional token exists', async () => {
-      (getItem as jest.Mock).mockReturnValue('provisional-token-123');
+      // Keyed, not blanket: a bare mockReturnValue hands the SAME string to
+      // every key, including `provisionalRefreshToken`, describing a disk
+      // state that cannot exist. These cases are about the Bearer header, so
+      // the honest shape is an access token with nothing to refresh with.
+      (getItem as jest.Mock).mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' || key === 'provisionalUserId'
+          ? 'provisional-token-123'
+          : null
+      );
 
       await socialSignIn(credential);
 
@@ -477,7 +504,15 @@ describe('auth.ts', () => {
     });
 
     it('clears provisional storage after a successful sign-in', async () => {
-      (getItem as jest.Mock).mockReturnValue('provisional-token-123');
+      // Keyed, not blanket: a bare mockReturnValue hands the SAME string to
+      // every key, including `provisionalRefreshToken`, describing a disk
+      // state that cannot exist. These cases are about the Bearer header, so
+      // the honest shape is an access token with nothing to refresh with.
+      (getItem as jest.Mock).mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' || key === 'provisionalUserId'
+          ? 'provisional-token-123'
+          : null
+      );
 
       await socialSignIn(credential);
 
@@ -498,7 +533,15 @@ describe('auth.ts', () => {
     });
 
     it('forwards confirmExistingAccount when the caller replays a confirmed credential', async () => {
-      (getItem as jest.Mock).mockReturnValue('provisional-token-123');
+      // Keyed, not blanket: a bare mockReturnValue hands the SAME string to
+      // every key, including `provisionalRefreshToken`, describing a disk
+      // state that cannot exist. These cases are about the Bearer header, so
+      // the honest shape is an access token with nothing to refresh with.
+      (getItem as jest.Mock).mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' || key === 'provisionalUserId'
+          ? 'provisional-token-123'
+          : null
+      );
 
       await socialSignIn(credential, true);
 
@@ -522,7 +565,15 @@ describe('auth.ts', () => {
     });
 
     it('throws a typed error carrying the account summary on the collision 409', async () => {
-      (getItem as jest.Mock).mockReturnValue('provisional-token-123');
+      // Keyed, not blanket: a bare mockReturnValue hands the SAME string to
+      // every key, including `provisionalRefreshToken`, describing a disk
+      // state that cannot exist. These cases are about the Bearer header, so
+      // the honest shape is an access token with nothing to refresh with.
+      (getItem as jest.Mock).mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' || key === 'provisionalUserId'
+          ? 'provisional-token-123'
+          : null
+      );
       (authClient.post as jest.Mock).mockRejectedValue(
         collision409({ name: 'Rowan', level: 12, dailyQuestStreak: 4 })
       );
@@ -542,7 +593,15 @@ describe('auth.ts', () => {
       // never picked a hero has no character — so `''` is a real wire value,
       // not a bug. Defaulting it here would hide it from the sheet, which is
       // the layer that decides the fallback copy.
-      (getItem as jest.Mock).mockReturnValue('provisional-token-123');
+      // Keyed, not blanket: a bare mockReturnValue hands the SAME string to
+      // every key, including `provisionalRefreshToken`, describing a disk
+      // state that cannot exist. These cases are about the Bearer header, so
+      // the honest shape is an access token with nothing to refresh with.
+      (getItem as jest.Mock).mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' || key === 'provisionalUserId'
+          ? 'provisional-token-123'
+          : null
+      );
       (authClient.post as jest.Mock).mockRejectedValue(
         collision409({ name: '', level: 1, dailyQuestStreak: 0 })
       );
@@ -555,7 +614,15 @@ describe('auth.ts', () => {
     });
 
     it('falls back to an empty summary when the collision 409 omits the account', async () => {
-      (getItem as jest.Mock).mockReturnValue('provisional-token-123');
+      // Keyed, not blanket: a bare mockReturnValue hands the SAME string to
+      // every key, including `provisionalRefreshToken`, describing a disk
+      // state that cannot exist. These cases are about the Bearer header, so
+      // the honest shape is an access token with nothing to refresh with.
+      (getItem as jest.Mock).mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' || key === 'provisionalUserId'
+          ? 'provisional-token-123'
+          : null
+      );
       (authClient.post as jest.Mock).mockRejectedValue(collision409(undefined));
 
       // toHaveProperty, not toMatchObject: the latter's subset semantics treat
@@ -571,7 +638,15 @@ describe('auth.ts', () => {
     it('rethrows the generic email-in-use 409 untouched (no details payload)', async () => {
       // The 409 the magic-link path already owns. Keying on status instead of
       // details.reason would swallow this one.
-      (getItem as jest.Mock).mockReturnValue('provisional-token-123');
+      // Keyed, not blanket: a bare mockReturnValue hands the SAME string to
+      // every key, including `provisionalRefreshToken`, describing a disk
+      // state that cannot exist. These cases are about the Bearer header, so
+      // the honest shape is an access token with nothing to refresh with.
+      (getItem as jest.Mock).mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' || key === 'provisionalUserId'
+          ? 'provisional-token-123'
+          : null
+      );
       const generic409 = axiosError(409, {
         code: 409,
         message: 'Email address is already in use by another account.',
@@ -582,7 +657,15 @@ describe('auth.ts', () => {
     });
 
     it('rethrows an axios error whose details.reason is some other reason', async () => {
-      (getItem as jest.Mock).mockReturnValue('provisional-token-123');
+      // Keyed, not blanket: a bare mockReturnValue hands the SAME string to
+      // every key, including `provisionalRefreshToken`, describing a disk
+      // state that cannot exist. These cases are about the Bearer header, so
+      // the honest shape is an access token with nothing to refresh with.
+      (getItem as jest.Mock).mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' || key === 'provisionalUserId'
+          ? 'provisional-token-123'
+          : null
+      );
       const otherReason = axiosError(409, {
         details: { reason: 'some-other-reason', account: { name: 'Rowan' } },
       });
@@ -629,7 +712,15 @@ describe('auth.ts', () => {
       // Load-bearing ordering: the confirm re-post has to still carry the
       // provisional Bearer header (so it lands on the conversion branch), and
       // dismissing the sheet has to leave the local hero alive.
-      (getItem as jest.Mock).mockReturnValue('provisional-token-123');
+      // Keyed, not blanket: a bare mockReturnValue hands the SAME string to
+      // every key, including `provisionalRefreshToken`, describing a disk
+      // state that cannot exist. These cases are about the Bearer header, so
+      // the honest shape is an access token with nothing to refresh with.
+      (getItem as jest.Mock).mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' || key === 'provisionalUserId'
+          ? 'provisional-token-123'
+          : null
+      );
       (authClient.post as jest.Mock).mockRejectedValue(
         collision409({ name: 'Rowan', level: 12, dailyQuestStreak: 4 })
       );
@@ -880,31 +971,63 @@ describe('auth.ts', () => {
       ],
       ['social', () => socialSignIn(credential), '/auth/social'],
     ])(
-      'keeps the session and still attempts the %s conversion when the refresh merely fails',
+      'keeps the session but ABANDONS the %s conversion when the refresh cannot be reached',
       async (_label, run, url) => {
         guestOnDisk();
         respond({
           '/auth/refresh-tokens': () =>
             Promise.reject(new Error('Network Error')),
+          // The server's REAL answer to a conversion carrying a token it
+          // cannot read: `auth.optional` swallows it, so this degrades into a
+          // plain signup that mints a second account and orphans the hero.
+          // Fixturing 'converted' here would have asserted the one outcome a
+          // stale token cannot produce.
           '/auth/magiclink': () => Promise.resolve({ data: {} }),
           '/auth/social': () =>
             Promise.resolve({
-              data: { tokens: realTokens, outcome: 'converted' },
+              data: { tokens: realTokens, outcome: 'created' },
+            }),
+        });
+
+        await expect(run()).rejects.toBeInstanceOf(
+          ProvisionalRefreshUnavailable
+        );
+
+        // Nothing was proven about the session, so it survives untouched…
+        expect(endProvisionalSession).not.toHaveBeenCalled();
+        expect(removeItem).not.toHaveBeenCalled();
+
+        // …and the conversion never went out. Asserting the exact URL list is
+        // what makes this fail if the abort is removed: a `rejects` assertion
+        // alone would still pass if the POST fired and something else threw.
+        expect(postedUrls()).toEqual(['/auth/refresh-tokens']);
+        expect(authClient.post).not.toHaveBeenCalledWith(
+          url,
+          expect.anything(),
+          expect.anything()
+        );
+      }
+    );
+
+    it.each([
+      ['magic link', () => requestMagicLink('me@example.com')],
+      ['social', () => socialSignIn(credential)],
+    ])(
+      'reports the unrefreshable %s conversion instead of failing silently',
+      async (_label, run) => {
+        guestWithNoRefreshToken();
+        respond({
+          '/auth/magiclink': () => Promise.resolve({ data: {} }),
+          '/auth/social': () =>
+            Promise.resolve({
+              data: { tokens: realTokens, outcome: 'created' },
             }),
         });
 
         await run();
 
-        expect(endProvisionalSession).not.toHaveBeenCalled();
-        expect(postedUrls()).toEqual(['/auth/refresh-tokens', url]);
-        expect(authClient.post).toHaveBeenCalledWith(
-          url,
-          expect.anything(),
-          expect.objectContaining({
-            headers: expect.objectContaining({
-              Authorization: 'Bearer stale-prov-access',
-            }),
-          })
+        expect(posthogClient.capture).toHaveBeenCalledWith(
+          'provisional_conversion_unrefreshable'
         );
       }
     );

--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -1,4 +1,4 @@
-import { signIn } from '@/lib/auth';
+import { endProvisionalSession, signIn } from '@/lib/auth';
 import {
   ExistingAccountConfirmationRequired,
   NoAccountForIdentity,
@@ -13,6 +13,7 @@ import {
   completeSignIn,
   isAuthenticated,
   logout,
+  ProvisionalSessionExpired,
   refreshAccessToken,
   refreshProvisionalTokens,
   removeTokens,
@@ -650,6 +651,206 @@ describe('auth.ts', () => {
         'signIn store update failed'
       );
     });
+  });
+
+  // A gated veteran guest arrives at the conversion screen with an access
+  // token that is almost always stale (they expire in 30 minutes and nothing
+  // behind the wall refreshes them). Both conversion endpoints use the
+  // server's `auth.optional`, which SWALLOWS an expired token and continues
+  // with no `req.user` — no 401, no signal — so the conversion silently
+  // becomes a plain sign-up and the progress it exists to save is lost.
+  describe('provisional refresh before conversion', () => {
+    const credential = {
+      provider: 'google' as const,
+      idToken: 'google-id-token',
+    };
+
+    const freshTokens = {
+      access: { token: 'fresh-prov-access', expires: '2025-01-02' },
+      refresh: { token: 'fresh-prov-refresh', expires: '2025-02-02' },
+    };
+
+    const realTokens = {
+      access: { token: 'real-access', expires: '2025-01-01' },
+      refresh: { token: 'real-refresh', expires: '2025-02-01' },
+    };
+
+    /** A guest who has been away long enough for the access token to lapse. */
+    const guestOnDisk = () =>
+      (getItem as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'provisionalAccessToken') return 'stale-prov-access';
+        if (key === 'provisionalRefreshToken') return 'prov-refresh';
+        if (key === 'provisionalUserId') return 'prov-user-1';
+        return null;
+      });
+
+    /** Route POSTs by URL so the refresh and the conversion can differ. */
+    const respond = (handlers: Record<string, () => unknown>) =>
+      (authClient.post as jest.Mock).mockImplementation((url: string) => {
+        const handler = handlers[url];
+        if (!handler) {
+          return Promise.reject(new Error(`unexpected POST to ${url}`));
+        }
+        return handler();
+      });
+
+    const postedUrls = () =>
+      (authClient.post as jest.Mock).mock.calls.map(([url]) => url);
+
+    beforeEach(() => {
+      (authClient.post as jest.Mock).mockClear();
+      // clearAllMocks does not clear implementations — pin the default so a
+      // mockImplementation from one test can't leak into the next.
+      (getItem as jest.Mock).mockReturnValue(null);
+      // Same reason: an earlier test leaves `signIn` throwing on purpose.
+      (signIn as jest.Mock).mockReset();
+      (getUserDetails as jest.Mock).mockResolvedValue({
+        id: 'user-123',
+        email: 'test@example.com',
+      });
+      (useUserStore.getState as jest.Mock).mockReturnValue({
+        setUser: jest.fn(),
+      });
+    });
+
+    it('sends the REFRESHED provisional token on the magic-link conversion', async () => {
+      guestOnDisk();
+      respond({
+        '/auth/refresh-tokens': () => Promise.resolve({ data: freshTokens }),
+        '/auth/magiclink': () => Promise.resolve({ data: {} }),
+      });
+
+      await requestMagicLink('me@example.com');
+
+      expect(postedUrls()).toEqual(['/auth/refresh-tokens', '/auth/magiclink']);
+      expect(authClient.post).toHaveBeenCalledWith(
+        '/auth/magiclink',
+        { email: 'me@example.com' },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer fresh-prov-access',
+          },
+        }
+      );
+    });
+
+    it('sends the REFRESHED provisional token on the social conversion', async () => {
+      guestOnDisk();
+      respond({
+        '/auth/refresh-tokens': () => Promise.resolve({ data: freshTokens }),
+        '/auth/social': () =>
+          Promise.resolve({
+            data: { tokens: realTokens, outcome: 'converted' },
+          }),
+      });
+
+      await socialSignIn(credential);
+
+      expect(postedUrls()).toEqual(['/auth/refresh-tokens', '/auth/social']);
+      expect(authClient.post).toHaveBeenCalledWith(
+        '/auth/social',
+        { ...credential, confirmExistingAccount: false },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer fresh-prov-access',
+          },
+        }
+      );
+    });
+
+    // The normal sign-in path must be untouched: no provisional session, no
+    // extra round trip, no new failure mode for users who never were guests.
+    it.each([
+      [
+        'magic link',
+        () => requestMagicLink('me@example.com'),
+        '/auth/magiclink',
+      ],
+      ['social', () => socialSignIn(credential), '/auth/social'],
+    ])(
+      'does not touch the refresh endpoint on the %s path when no provisional session exists',
+      async (_label, run, url) => {
+        (getItem as jest.Mock).mockReturnValue(null);
+        respond({
+          '/auth/magiclink': () => Promise.resolve({ data: {} }),
+          '/auth/social': () =>
+            Promise.resolve({
+              data: { tokens: realTokens, outcome: 'created' },
+            }),
+        });
+
+        await run();
+
+        expect(postedUrls()).toEqual([url]);
+      }
+    );
+
+    // Only a 401 on the REFRESH token proves the server disowned the session.
+    it.each([
+      ['magic link', () => requestMagicLink('me@example.com')],
+      ['social', () => socialSignIn(credential)],
+    ])(
+      'ends the session and abandons the %s conversion when the refresh token is rejected',
+      async (_label, run) => {
+        guestOnDisk();
+        respond({
+          '/auth/refresh-tokens': () =>
+            Promise.reject({ response: { status: 401 } }),
+        });
+
+        await expect(run()).rejects.toBeInstanceOf(ProvisionalSessionExpired);
+
+        expect(endProvisionalSession).toHaveBeenCalled();
+        // Aborted, not attempted: sending it anyway would create a SECOND,
+        // empty account for the same person under the same email.
+        expect(postedUrls()).toEqual(['/auth/refresh-tokens']);
+        // endProvisionalSession wipes on acknowledge, never underneath the
+        // notice — nothing here may clear the keys inline.
+        expect(removeItem).not.toHaveBeenCalled();
+      }
+    );
+
+    // A flaky network is not proof of anything. Wiping here would destroy an
+    // unclaimed hero over a dropped packet, and the stale token may well
+    // still be valid.
+    it.each([
+      [
+        'magic link',
+        () => requestMagicLink('me@example.com'),
+        '/auth/magiclink',
+      ],
+      ['social', () => socialSignIn(credential), '/auth/social'],
+    ])(
+      'keeps the session and still attempts the %s conversion when the refresh merely fails',
+      async (_label, run, url) => {
+        guestOnDisk();
+        respond({
+          '/auth/refresh-tokens': () =>
+            Promise.reject(new Error('Network Error')),
+          '/auth/magiclink': () => Promise.resolve({ data: {} }),
+          '/auth/social': () =>
+            Promise.resolve({
+              data: { tokens: realTokens, outcome: 'converted' },
+            }),
+        });
+
+        await run();
+
+        expect(endProvisionalSession).not.toHaveBeenCalled();
+        expect(postedUrls()).toEqual(['/auth/refresh-tokens', url]);
+        expect(authClient.post).toHaveBeenCalledWith(
+          url,
+          expect.anything(),
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: 'Bearer stale-prov-access',
+            }),
+          })
+        );
+      }
+    );
   });
 
   describe('isAuthenticated', () => {

--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -684,6 +684,19 @@ describe('auth.ts', () => {
         return null;
       });
 
+    /**
+     * A legacy install: an access token but NO refresh token. Reachable
+     * because `createProvisionalUser` stores the refresh token conditionally
+     * (`user.ts`), and `auth hydrate()` still carries a
+     * `provisionalRefreshToken || provisionalToken` fallback for this shape.
+     */
+    const guestWithNoRefreshToken = () =>
+      (getItem as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'provisionalAccessToken') return 'stale-prov-access';
+        if (key === 'provisionalUserId') return 'prov-user-1';
+        return null;
+      });
+
     /** Route POSTs by URL so the refresh and the conversion can differ. */
     const respond = (handlers: Record<string, () => unknown>) =>
       (authClient.post as jest.Mock).mockImplementation((url: string) => {
@@ -809,6 +822,50 @@ describe('auth.ts', () => {
         // endProvisionalSession wipes on acknowledge, never underneath the
         // notice — nothing here may clear the keys inline.
         expect(removeItem).not.toHaveBeenCalled();
+      }
+    );
+
+    // `doRefreshProvisionalTokens` answers 'dead' for a missing refresh token
+    // WITHOUT contacting the server. That is correct for its other caller —
+    // the provisional-client interceptor, which only asks after a 401 has
+    // already proven the access token rejected — but here we ask PROACTIVELY,
+    // with no such proof. Inheriting 'dead' would wipe a working session's
+    // character, quests and POIs (wipeGuestSession is explicitly "no
+    // salvage") on no server evidence at all, which is the exact loss this
+    // whole branch exists to prevent.
+    it.each([
+      [
+        'magic link',
+        () => requestMagicLink('me@example.com'),
+        '/auth/magiclink',
+      ],
+      ['social', () => socialSignIn(credential), '/auth/social'],
+    ])(
+      'attempts the %s conversion with the stored token when there is no refresh token to refresh WITH',
+      async (_label, run, url) => {
+        guestWithNoRefreshToken();
+        respond({
+          '/auth/magiclink': () => Promise.resolve({ data: {} }),
+          '/auth/social': () =>
+            Promise.resolve({
+              data: { tokens: realTokens, outcome: 'converted' },
+            }),
+        });
+
+        await run();
+
+        // No server was ever asked, so nothing proved this session dead.
+        expect(endProvisionalSession).not.toHaveBeenCalled();
+        expect(postedUrls()).toEqual([url]);
+        expect(authClient.post).toHaveBeenCalledWith(
+          url,
+          expect.anything(),
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: 'Bearer stale-prov-access',
+            }),
+          })
+        );
       }
     );
 

--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -1,4 +1,5 @@
 import { endProvisionalSession, signIn } from '@/lib/auth';
+import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
 import {
   ExistingAccountConfirmationRequired,
   NoAccountForIdentity,
@@ -13,7 +14,6 @@ import {
   completeSignIn,
   isAuthenticated,
   logout,
-  ProvisionalSessionExpired,
   refreshAccessToken,
   refreshProvisionalTokens,
   removeTokens,

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -76,16 +76,35 @@ export class ProvisionalSessionExpired extends Error {
  * never runs. `authClient` is a bare axios instance with no interceptors of
  * its own, so the refresh has to be explicit here.
  *
- * Only `'dead'` (a 401 for the REFRESH token itself) ends the session. A
- * `'error'` result is a network flake or 5xx and is proof of nothing: the
- * session is left alone and the conversion is attempted with the token we
- * already have, which may well still be valid. `authClient`'s 10s timeout
- * bounds the added wait.
+ * Ending the session requires SERVER PROOF — a 401 for the refresh token
+ * itself. Nothing else does:
+ *
+ * - No refresh token on disk: we return the stored access token and let the
+ *   conversion try. `doRefreshProvisionalTokens` reports `'dead'` for this
+ *   case without any network call, and that is right for its OTHER caller —
+ *   the provisional-client interceptor only asks after a 401 has already
+ *   proven the access token rejected, so "nothing left to refresh with" really
+ *   is unrecoverable there. Here we ask PROACTIVELY, with no such proof, so
+ *   inheriting that verdict would hand `wipeGuestSession` (explicitly "no
+ *   salvage") a working session's character, quests and POIs on no evidence.
+ *   The state is reachable: `createProvisionalUser` stores the refresh token
+ *   conditionally, and `hydrate()` still carries a fallback for installs
+ *   without one. Its contract is deliberately NOT changed — the interceptor
+ *   depends on it and is correct as written.
+ * - `'error'` (network flake, 5xx, malformed body): proof of nothing either.
+ *   Same outcome — keep the session, try with the token we have.
+ *
+ * `authClient`'s 10s timeout bounds the added wait.
  */
 const freshProvisionalAccessToken = async (): Promise<string | null> => {
   const stored = getItem('provisionalAccessToken');
   if (typeof stored !== 'string' || stored.length === 0) {
     return null;
+  }
+
+  const refreshToken = getItem('provisionalRefreshToken');
+  if (typeof refreshToken !== 'string' || refreshToken.length === 0) {
+    return stored;
   }
 
   const result = await refreshProvisionalTokens();

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,7 +2,10 @@ import axios from 'axios';
 import { OneSignal } from 'react-native-onesignal';
 
 import { endProvisionalSession, signIn } from '@/lib/auth';
-import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
+import {
+  ProvisionalRefreshUnavailable,
+  ProvisionalSessionExpired,
+} from '@/lib/auth/provisional-session';
 import type {
   ExistingAccountSummary,
   SocialSignInOutcome,
@@ -74,9 +77,21 @@ export interface RegisterResponse {
  *   The state is reachable: `createProvisionalUser` stores the refresh token
  *   conditionally, and `hydrate()` still carries a fallback for installs
  *   without one. Its contract is deliberately NOT changed — the interceptor
- *   depends on it and is correct as written.
- * - `'error'` (network flake, 5xx, malformed body): proof of nothing either.
- *   Same outcome — keep the session, try with the token we have.
+ *   depends on it and is correct as written. Reported to PostHog rather than
+ *   passed over in silence: this install shape mis-converts by construction,
+ *   and it is otherwise invisible — the conversion endpoints answer 200.
+ * - `'error'` (network flake, 5xx, timeout, malformed body): proof of nothing
+ *   either, so the session is likewise left alone — but the conversion is
+ *   ABANDONED rather than attempted, and the caller is told to retry.
+ *
+ * That last one is the asymmetry worth stating. Proceeding on a stale token
+ * does not fail loudly: `auth.optional` swallows it, the server sees no
+ * `req.user`, and a conversion degrades into a plain signup — a second
+ * account, the hero orphaned, no error anywhere. Aborting costs the user a
+ * retry. Orphaning costs them everything the gate exists to save, so the two
+ * are not close. Aborting is NOT correct for the no-refresh-token case above:
+ * that install can never refresh, so abandoning would strand it forever, while
+ * proceeding at least succeeds whenever the stored token is still valid.
  *
  * `authClient`'s 10s timeout bounds the added wait.
  */
@@ -88,6 +103,7 @@ const freshProvisionalAccessToken = async (): Promise<string | null> => {
 
   const refreshToken = getItem('provisionalRefreshToken');
   if (typeof refreshToken !== 'string' || refreshToken.length === 0) {
+    posthogClient.capture('provisional_conversion_unrefreshable');
     return stored;
   }
 
@@ -99,7 +115,9 @@ const freshProvisionalAccessToken = async (): Promise<string | null> => {
   if (result.status === 'refreshed') {
     return result.tokens.access.token;
   }
-  return stored;
+
+  posthogClient.capture('provisional_conversion_refresh_unavailable');
+  throw new ProvisionalRefreshUnavailable();
 };
 
 /**

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { OneSignal } from 'react-native-onesignal';
 
 import { endProvisionalSession, signIn } from '@/lib/auth';
+import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
 import type {
   ExistingAccountSummary,
   SocialSignInOutcome,
@@ -39,23 +40,6 @@ export interface User {
 export interface RegisterResponse {
   user: User;
   tokens: tokenService.AuthTokens;
-}
-
-/**
- * The provisional session a conversion was supposed to SAVE turned out to be
- * dead: the server rejected its refresh token. `endProvisionalSession` has
- * already told the user and armed the wipe, so the conversion is abandoned
- * rather than completed — see `freshProvisionalAccessToken`.
- *
- * Callers need not branch on it: the sign-in UIs' existing generic
- * "please try again" copy is harmless behind the modal alert, which the user
- * must acknowledge and which then resets them to onboarding.
- */
-export class ProvisionalSessionExpired extends Error {
-  constructor() {
-    super('The provisional session expired before it could be converted');
-    this.name = 'ProvisionalSessionExpired';
-  }
 }
 
 /**

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { OneSignal } from 'react-native-onesignal';
 
-import { signIn } from '@/lib/auth';
+import { endProvisionalSession, signIn } from '@/lib/auth';
 import type {
   ExistingAccountSummary,
   SocialSignInOutcome,
@@ -42,12 +42,72 @@ export interface RegisterResponse {
 }
 
 /**
+ * The provisional session a conversion was supposed to SAVE turned out to be
+ * dead: the server rejected its refresh token. `endProvisionalSession` has
+ * already told the user and armed the wipe, so the conversion is abandoned
+ * rather than completed — see `freshProvisionalAccessToken`.
+ *
+ * Callers need not branch on it: the sign-in UIs' existing generic
+ * "please try again" copy is harmless behind the modal alert, which the user
+ * must acknowledge and which then resets them to onboarding.
+ */
+export class ProvisionalSessionExpired extends Error {
+  constructor() {
+    super('The provisional session expired before it could be converted');
+    this.name = 'ProvisionalSessionExpired';
+  }
+}
+
+/**
+ * The access token to carry as a conversion request's Bearer header, or null
+ * when there is no provisional session at all.
+ *
+ * Why this exists: both conversion endpoints are `auth.optional` on the
+ * server, which SWALLOWS an expired access token and continues with no
+ * `req.user` — no 401, nothing to react to. Without `provisionalId` the
+ * magic-link verify skips conversion entirely and 404s, which the client maps
+ * to "That link has expired"; `/auth/social` likewise falls through to
+ * `no-account-for-identity`. Either way the user loops forever and the
+ * progress the whole gate exists to preserve is quietly lost.
+ *
+ * A gated veteran's access token is almost always stale on arrival: they
+ * expire in 30 minutes and nothing behind the wall refreshes them — no
+ * `(app)` screen mounts, so the interceptor that used to do it incidentally
+ * never runs. `authClient` is a bare axios instance with no interceptors of
+ * its own, so the refresh has to be explicit here.
+ *
+ * Only `'dead'` (a 401 for the REFRESH token itself) ends the session. A
+ * `'error'` result is a network flake or 5xx and is proof of nothing: the
+ * session is left alone and the conversion is attempted with the token we
+ * already have, which may well still be valid. `authClient`'s 10s timeout
+ * bounds the added wait.
+ */
+const freshProvisionalAccessToken = async (): Promise<string | null> => {
+  const stored = getItem('provisionalAccessToken');
+  if (typeof stored !== 'string' || stored.length === 0) {
+    return null;
+  }
+
+  const result = await refreshProvisionalTokens();
+  if (result.status === 'dead') {
+    endProvisionalSession();
+    throw new ProvisionalSessionExpired();
+  }
+  if (result.status === 'refreshed') {
+    return result.tokens.access.token;
+  }
+  return stored;
+};
+
+/**
  * Request a magic link for authentication
  */
 export const requestMagicLink = async (email: string): Promise<void> => {
-  try {
-    const provisionalToken = getItem('provisionalAccessToken');
+  // Outside the try: this is not a magic-link failure, and logging it as one
+  // would bury the real cause under the wrong message.
+  const provisionalToken = await freshProvisionalAccessToken();
 
+  try {
     console.log('provisionalToken exists:', !!provisionalToken);
 
     const body = { email };
@@ -57,7 +117,7 @@ export const requestMagicLink = async (email: string): Promise<void> => {
       'Content-Type': 'application/json',
     };
 
-    if (typeof provisionalToken === 'string' && provisionalToken.length > 0) {
+    if (provisionalToken) {
       headers.Authorization = `Bearer ${provisionalToken}`;
       console.log(
         'Adding Bearer token for provisional user:',
@@ -307,12 +367,16 @@ export const socialSignIn = async (
   // hard type error shipping a stale client against a newer server.
   outcome: SocialSignInOutcome | (string & {});
 }> => {
-  const provisionalToken = getItem('provisionalAccessToken');
+  // Refreshed first when a guest session exists — see
+  // `freshProvisionalAccessToken`. A stale token here does not fail loudly;
+  // it makes the server treat a conversion as a brand-new signup and strands
+  // the hero this screen promised to keep.
+  const provisionalToken = await freshProvisionalAccessToken();
 
   const headers: { [key: string]: string } = {
     'Content-Type': 'application/json',
   };
-  if (typeof provisionalToken === 'string' && provisionalToken.length > 0) {
+  if (provisionalToken) {
     headers.Authorization = `Bearer ${provisionalToken}`;
   }
 

--- a/src/app/first-quest-result.test.tsx
+++ b/src/app/first-quest-result.test.tsx
@@ -95,6 +95,15 @@ jest.mock('@/lib/auth', () => ({
   useAuth: (selector: any) => selector(mockAuthState),
 }));
 
+// `storage` (the raw MMKV export) is imported transitively by unrelated
+// modules (e.g. i18n utils), so a wholesale stub breaks the module graph
+// before any test runs. Spread the real module and override only `getItem`.
+const mockStorage: Record<string, unknown> = {};
+jest.mock('@/lib/storage', () => ({
+  ...jest.requireActual('@/lib/storage'),
+  getItem: (key: string) => mockStorage[key] ?? null,
+}));
+
 jest.mock('@/store/quest-store', () => ({
   useQuestStore: jest.fn(),
 }));
@@ -111,6 +120,7 @@ describe('FirstQuestResultScreen', () => {
     jest.clearAllMocks();
     // Default to the onboarding-era case: an unauthenticated first-quest run.
     mockAuthState.status = 'signOut';
+    for (const key of Object.keys(mockStorage)) delete mockStorage[key];
 
     mockUseOnboardingStore.mockImplementation((selector) =>
       selector(mockOnboardingStore as any)
@@ -133,6 +143,20 @@ describe('FirstQuestResultScreen', () => {
         OnboardingStep.VIEWING_SIGNUP_PROMPT
       );
       expect(mockOnboardingStore.setCurrentStep).toHaveBeenCalledWith(
+        OnboardingStep.COMPLETED
+      );
+    });
+
+    it('sends a hydrated PROVISIONAL session (signIn + provisional keys) to the signup prompt, not COMPLETED', () => {
+      mockAuthState.status = 'signIn';
+      mockStorage.provisionalAccessToken = 'prov-token';
+
+      render(<FirstQuestResultScreen />);
+
+      expect(mockOnboardingStore.setCurrentStep).toHaveBeenCalledWith(
+        OnboardingStep.VIEWING_SIGNUP_PROMPT
+      );
+      expect(mockOnboardingStore.setCurrentStep).not.toHaveBeenCalledWith(
         OnboardingStep.COMPLETED
       );
     });

--- a/src/app/first-quest-result.test.tsx
+++ b/src/app/first-quest-result.test.tsx
@@ -147,19 +147,24 @@ describe('FirstQuestResultScreen', () => {
       );
     });
 
-    it('sends a hydrated PROVISIONAL session (signIn + provisional keys) to the signup prompt, not COMPLETED', () => {
-      mockAuthState.status = 'signIn';
-      mockStorage.provisionalAccessToken = 'prov-token';
+    // Both arms of hasProvisionalSession's OR — either key alone is enough to
+    // mean "this is a guest", and only covering one left the other deletable.
+    it.each(['provisionalAccessToken', 'provisionalUserId'])(
+      'sends a hydrated PROVISIONAL session (signIn + %s) to the signup prompt, not COMPLETED',
+      (provisionalKey) => {
+        mockAuthState.status = 'signIn';
+        mockStorage[provisionalKey] = 'prov-value';
 
-      render(<FirstQuestResultScreen />);
+        render(<FirstQuestResultScreen />);
 
-      expect(mockOnboardingStore.setCurrentStep).toHaveBeenCalledWith(
-        OnboardingStep.VIEWING_SIGNUP_PROMPT
-      );
-      expect(mockOnboardingStore.setCurrentStep).not.toHaveBeenCalledWith(
-        OnboardingStep.COMPLETED
-      );
-    });
+        expect(mockOnboardingStore.setCurrentStep).toHaveBeenCalledWith(
+          OnboardingStep.VIEWING_SIGNUP_PROMPT
+        );
+        expect(mockOnboardingStore.setCurrentStep).not.toHaveBeenCalledWith(
+          OnboardingStep.COMPLETED
+        );
+      }
+    );
 
     it('should call clearRecentCompletedQuest when Continue button is pressed', () => {
       const { getByTestId } = render(<FirstQuestResultScreen />);

--- a/src/app/first-quest-result.tsx
+++ b/src/app/first-quest-result.tsx
@@ -7,6 +7,7 @@ import { FailedQuest } from '@/components/failed-quest';
 import { QuestComplete } from '@/components/QuestComplete';
 import { Button, FocusAwareStatusBar, Text, View } from '@/components/ui';
 import { useAuth } from '@/lib/auth';
+import { getItem } from '@/lib/storage';
 import { OnboardingStep, useOnboardingStore } from '@/store/onboarding-store';
 import { useQuestStore } from '@/store/quest-store';
 import { type Quest } from '@/store/types'; // Import Quest type for better type safety
@@ -22,9 +23,15 @@ export default function FirstQuestResultScreen() {
   // have an account yet. A character-less social account is routed back through
   // onboarding while already authenticated (see navigation-state-resolver), and
   // asking that user to "create an account" is asking for the one they are
-  // signed into. Decided once so both transitions below stay in agreement.
+  // signed into. BUT a provisional session also hydrates with status 'signIn'
+  // (see auth hydrate()), and a guest is exactly who the prompt is for — so
+  // 'signIn' only skips the prompt when no provisional keys are on disk. Same
+  // two-key check the resolver uses for hasProvisionalSession.
+  const hasProvisionalSession = !!(
+    getItem('provisionalUserId') || getItem('provisionalAccessToken')
+  );
   const stepAfterFirstQuest =
-    authStatus === 'signIn'
+    authStatus === 'signIn' && !hasProvisionalSession
       ? OnboardingStep.COMPLETED
       : OnboardingStep.VIEWING_SIGNUP_PROMPT;
   const resetFailedQuest = useQuestStore((state) => state.resetFailedQuest);

--- a/src/app/first-quest-result.tsx
+++ b/src/app/first-quest-result.tsx
@@ -7,7 +7,7 @@ import { FailedQuest } from '@/components/failed-quest';
 import { QuestComplete } from '@/components/QuestComplete';
 import { Button, FocusAwareStatusBar, Text, View } from '@/components/ui';
 import { useAuth } from '@/lib/auth';
-import { getItem } from '@/lib/storage';
+import { hasProvisionalSession } from '@/lib/auth/provisional-session';
 import { OnboardingStep, useOnboardingStore } from '@/store/onboarding-store';
 import { useQuestStore } from '@/store/quest-store';
 import { type Quest } from '@/store/types'; // Import Quest type for better type safety
@@ -25,13 +25,10 @@ export default function FirstQuestResultScreen() {
   // asking that user to "create an account" is asking for the one they are
   // signed into. BUT a provisional session also hydrates with status 'signIn'
   // (see auth hydrate()), and a guest is exactly who the prompt is for — so
-  // 'signIn' only skips the prompt when no provisional keys are on disk. Same
-  // two-key check the resolver uses for hasProvisionalSession.
-  const hasProvisionalSession = !!(
-    getItem('provisionalUserId') || getItem('provisionalAccessToken')
-  );
+  // 'signIn' only skips the prompt when no provisional keys are on disk —
+  // the same shared check the resolver's gate uses.
   const stepAfterFirstQuest =
-    authStatus === 'signIn' && !hasProvisionalSession
+    authStatus === 'signIn' && !hasProvisionalSession()
       ? OnboardingStep.COMPLETED
       : OnboardingStep.VIEWING_SIGNUP_PROMPT;
   const resetFailedQuest = useQuestStore((state) => state.resetFailedQuest);

--- a/src/app/login.test.tsx
+++ b/src/app/login.test.tsx
@@ -50,6 +50,17 @@ jest.mock('@/lib', () => ({
   useAuth: () => mockUseAuth(),
 }));
 
+// `storage` (the raw MMKV export) is imported transitively by unrelated
+// modules, so a wholesale stub breaks the module graph before any test runs.
+// Spread the real module and override only `getItem`. `hasProvisionalSession`
+// itself is deliberately NOT mocked: this suite has to prove the real check
+// runs, since the bug being fixed is that it never ran at all.
+const mockStorage: Record<string, unknown> = {};
+jest.mock('@/lib/storage', () => ({
+  ...jest.requireActual('@/lib/storage'),
+  getItem: (key: string) => mockStorage[key] ?? null,
+}));
+
 afterEach(() => {
   cleanup();
   jest.clearAllMocks();
@@ -59,6 +70,7 @@ describe('Login Screen', () => {
   beforeEach(() => {
     (useLocalSearchParams as jest.Mock).mockReturnValue({});
     mockUseAuth.mockReturnValue({ status: 'signOut' });
+    for (const key of Object.keys(mockStorage)) delete mockStorage[key];
   });
 
   it('renders LoginForm when user is not authenticated', () => {
@@ -78,6 +90,42 @@ describe('Login Screen', () => {
     const redirect = screen.getByTestId('redirect');
     expect(redirect).toBeOnTheScreen();
     expect(redirect.props.accessibilityHint).toBe('/');
+  });
+
+  // The conversion gate's ONLY email escape hatch. Every user the gate holds
+  // has status 'signIn' by construction — the gate sits BELOW the resolver's
+  // `signOut → login` branch, and a provisional session hydrates as 'signIn'
+  // (see auth hydrate()). A bare status check therefore redirected 100% of
+  // them straight back to the wall, so "Sign up with email" only ever
+  // flashed. Asserts the rendered screen, not that a redirect was requested:
+  // the old test asserted only the latter and could never see this.
+  it.each(['provisionalAccessToken', 'provisionalUserId'])(
+    'renders LoginForm for a signed-in GUEST arriving to convert (%s on disk)',
+    (provisionalKey) => {
+      mockUseAuth.mockReturnValue({ status: 'signIn' });
+      mockStorage[provisionalKey] = 'prov-value';
+      (useLocalSearchParams as jest.Mock).mockReturnValue({
+        intent: 'convert',
+      });
+
+      setup(<Login />);
+
+      expect(screen.getByTestId('login-form')).toBeOnTheScreen();
+      expect(screen.getByText('intent:convert')).toBeOnTheScreen();
+      expect(screen.queryByTestId('redirect')).not.toBeOnTheScreen();
+    }
+  );
+
+  // The other side of the same guard: a real account must still be bounced,
+  // or /login becomes reachable by anyone with a session.
+  it('still redirects a signed-in user with a real account and no provisional keys', () => {
+    mockUseAuth.mockReturnValue({ status: 'signIn' });
+    mockStorage.provisionalRefreshToken = 'survives-conversion';
+
+    setup(<Login />);
+
+    expect(screen.getByTestId('redirect')).toBeOnTheScreen();
+    expect(screen.queryByTestId('login-form')).not.toBeOnTheScreen();
   });
 
   it('passes error from URL params to LoginForm', () => {

--- a/src/app/login.tsx
+++ b/src/app/login.tsx
@@ -5,6 +5,7 @@ import { parseLoginIntent } from '@/components/login/copy';
 import { LoginForm } from '@/components/login-form';
 import { FocusAwareStatusBar } from '@/components/ui';
 import { useAuth } from '@/lib';
+import { hasProvisionalSession } from '@/lib/auth/provisional-session';
 
 export default function Login() {
   const params = useLocalSearchParams();
@@ -22,9 +23,20 @@ export default function Login() {
     }
   }, [params]);
 
-  // If we're already logged in, redirect to the home screen
+  // If we're already logged in, redirect to the home screen.
+  //
+  // `status === 'signIn'` does NOT mean "has a real account": a provisional
+  // session hydrates as 'signIn' too (see auth hydrate()). Every user the
+  // conversion gate holds is in exactly that state — the gate is the
+  // resolver's LAST branch, below `signOut → login`, so having a session is
+  // the definition of the gated population, not an edge case. Redirecting
+  // them sent the wall's one email escape hatch nowhere: `/` resolves to
+  // `(app)/index`, which is not in PRE_ACCOUNT_ZONE, so NavigationGate
+  // replaced them straight back onto /quest-completed-signup and "Sign up
+  // with email" only ever flashed. Same dead-link shape is-already-at-target
+  // documents having fixed three times already.
   const { status } = useAuth();
-  if (status === 'signIn') {
+  if (status === 'signIn' && !hasProvisionalSession()) {
     return <Redirect href="/" />;
   }
 

--- a/src/app/login.tsx
+++ b/src/app/login.tsx
@@ -27,9 +27,10 @@ export default function Login() {
   //
   // `status === 'signIn'` does NOT mean "has a real account": a provisional
   // session hydrates as 'signIn' too (see auth hydrate()). Every user the
-  // conversion gate holds is in exactly that state — the gate is the
-  // resolver's LAST branch, below `signOut → login`, so having a session is
-  // the definition of the gated population, not an edge case. Redirecting
+  // conversion gate holds is in exactly that state — the gate is the last
+  // branch that names a screen (Priority 5) and sits BELOW the resolver's
+  // `signOut → login` branch, so having a session is the definition of the
+  // gated population, not an edge case. Redirecting
   // them sent the wall's one email escape hatch nowhere: `/` resolves to
   // `(app)/index`, which is not in PRE_ACCOUNT_ZONE, so NavigationGate
   // replaced them straight back onto /quest-completed-signup and "Sign up

--- a/src/app/quest-completed-signup.test.tsx
+++ b/src/app/quest-completed-signup.test.tsx
@@ -392,6 +392,24 @@ describe('QuestCompletedSignupScreen', () => {
       expect(queryByText('Quest one · complete')).toBeNull();
     });
 
+    // The gate path's copy makes a FACTUAL CLAIM about the player's standing,
+    // so its fallbacks can't be the harmless generic ones the normal path
+    // uses: `?? 1` / `?? 0` would tell a level-40 veteran whose character
+    // hasn't loaded that they are a level 1 hero with 0 XP. Falling back to
+    // the first-quest framing is at worst vague; the alternative is wrong.
+    it('does not assert a standing it cannot know when the character has not loaded', () => {
+      mockOnboardingStore.isOnboardingComplete.mockReturnValue(true);
+      mockUseCharacterStore.mockImplementation((selector) =>
+        (selector as any)({ character: null })
+      );
+
+      const { getByText, queryByText } = render(<QuestCompletedSignupScreen />);
+
+      expect(queryByText('Level 1 hero')).toBeNull();
+      expect(queryByText('0 XP')).toBeNull();
+      expect(getByText('Quest one · complete')).toBeTruthy();
+    });
+
     it('keeps the first-quest copy for the normal onboarding arrival', () => {
       mockOnboardingStore.isOnboardingComplete.mockReturnValue(false);
 

--- a/src/app/quest-completed-signup.test.tsx
+++ b/src/app/quest-completed-signup.test.tsx
@@ -115,6 +115,14 @@ describe('QuestCompletedSignupScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    // jest.clearAllMocks() above only clears call history — it does not
+    // undo a prior .mockReturnValue()/.mockImplementation() (that's
+    // mockReset's job, which would also wipe every other mock in this
+    // file). mockOnboardingStore.isOnboardingComplete is a module-level
+    // jest.fn() shared across every test, so without re-establishing its
+    // default here, a test that calls .mockReturnValue(true) would leak
+    // that value into every later test that doesn't set it explicitly.
+    mockOnboardingStore.isOnboardingComplete.mockReturnValue(false);
     mockUseOnboardingStore.mockImplementation((selector) =>
       selector(mockOnboardingStore as any)
     );

--- a/src/app/quest-completed-signup.test.tsx
+++ b/src/app/quest-completed-signup.test.tsx
@@ -58,6 +58,10 @@ jest.mock('@/components/login/social-sign-in-buttons', () => {
           onPress={() => onSuccess('app', 'existing-account-login', 'google')}
         />
         <Pressable
+          testID="mock-social-success-onboarding-target"
+          onPress={() => onSuccess('onboarding', 'created', 'google')}
+        />
+        <Pressable
           testID="mock-social-error-email-in-use"
           onPress={() => onError('email-in-use')}
         />
@@ -314,6 +318,36 @@ describe('QuestCompletedSignupScreen', () => {
         expect(mockPosthogCapture).toHaveBeenCalledWith('signup_completed', {
           method: 'google',
         });
+      });
+    });
+
+    // The screen used to delegate its exit entirely to the conversion gate.
+    // That relies on a store write to re-render the resolver, and
+    // `completeSignIn` swallows a failed `getUserDetails()` while still
+    // resolving 'app' — so neither store is written, auth status was already
+    // 'signIn', nothing re-renders, and the user sits on the wall holding a
+    // valid real account. Navigating on the target the callback already
+    // carries costs one line (same shape as login-form.tsx).
+    it('lands a converted user in the app rather than waiting for the gate', async () => {
+      const { getByTestId } = render(<QuestCompletedSignupScreen />);
+
+      fireEvent.press(getByTestId('mock-social-success-google'));
+
+      await waitFor(() => {
+        expect(mockRouterReplace).toHaveBeenCalledWith('/(app)/');
+      });
+    });
+
+    // The target is not always 'app': a social identity that resolves to a
+    // hero-less account is routed back through onboarding. Hardcoding '/(app)/'
+    // would strand that user on a Play screen with no character.
+    it('honours an onboarding target instead of assuming the app', async () => {
+      const { getByTestId } = render(<QuestCompletedSignupScreen />);
+
+      fireEvent.press(getByTestId('mock-social-success-onboarding-target'));
+
+      await waitFor(() => {
+        expect(mockRouterReplace).toHaveBeenCalledWith('/onboarding');
       });
     });
 

--- a/src/app/quest-completed-signup.test.tsx
+++ b/src/app/quest-completed-signup.test.tsx
@@ -78,6 +78,7 @@ jest.mock('react-native-flash-message', () => ({
 // Mock stores
 const mockOnboardingStore = {
   setCurrentStep: mockSetOnboardingStep,
+  isOnboardingComplete: jest.fn(() => false),
 };
 
 jest.mock('@/store/onboarding-store', () => ({
@@ -361,6 +362,35 @@ describe('QuestCompletedSignupScreen', () => {
           })
         );
       });
+    });
+  });
+
+  describe('Conversion gate variant', () => {
+    it("shows the player's real standing when arriving via the conversion gate (onboarding complete)", () => {
+      mockOnboardingStore.isOnboardingComplete.mockReturnValue(true);
+      // Extend the character fixture for this test: a leaked veteran. Uses the
+      // file's existing mockUseCharacterStore double (defined at ~line 109),
+      // mirroring the beforeEach wiring at ~line 121.
+      mockUseCharacterStore.mockImplementation((selector) =>
+        (selector as any)({
+          character: { ...mockCharacterFixture, level: 5, currentXP: 1012 },
+        })
+      );
+
+      const { getByText, queryByText } = render(<QuestCompletedSignupScreen />);
+
+      expect(getByText('Level 5 hero')).toBeTruthy();
+      expect(getByText('1012 XP')).toBeTruthy();
+      expect(queryByText('Quest one · complete')).toBeNull();
+    });
+
+    it('keeps the first-quest copy for the normal onboarding arrival', () => {
+      mockOnboardingStore.isOnboardingComplete.mockReturnValue(false);
+
+      const { getByText, queryByText } = render(<QuestCompletedSignupScreen />);
+
+      expect(getByText('Quest one · complete')).toBeTruthy();
+      expect(queryByText(/hero$/)).toBeNull();
     });
   });
 });

--- a/src/app/quest-completed-signup.tsx
+++ b/src/app/quest-completed-signup.tsx
@@ -22,6 +22,7 @@ import {
   type SocialSignInOutcome,
 } from '@/lib/auth/social';
 import { useCharacterStore } from '@/store/character-store';
+import { useOnboardingStore } from '@/store/onboarding-store';
 import {
   colors,
   fontFamily,
@@ -158,6 +159,14 @@ export default function QuestCompletedSignupScreen() {
   const firstQuestXP =
     AVAILABLE_QUESTS.find((quest) => quest.id === 'quest-1')?.reward.xp ?? 0;
 
+  // Two audiences, one screen. Normal path: a guest fresh off quest one
+  // (onboarding still at VIEWING_SIGNUP_PROMPT) — show what they just earned.
+  // Gate path (see navigation-state-resolver Priority 5): a veteran guest
+  // routed here to convert — "Quest one · complete" would be false, so show
+  // their real standing instead.
+  const isConversionGate = useOnboardingStore((s) => s.isOnboardingComplete());
+  const heroCurrentXP = character?.currentXP ?? 0;
+
   return (
     <View
       style={[
@@ -174,7 +183,11 @@ export default function QuestCompletedSignupScreen() {
         entering={FadeInDown.duration(ANIM_DURATION)}
         style={styles.header}
       >
-        <EyebrowLabel tone="warm">Quest one · complete</EyebrowLabel>
+        <EyebrowLabel tone="warm">
+          {isConversionGate
+            ? `Level ${heroLevel} hero`
+            : 'Quest one · complete'}
+        </EyebrowLabel>
         <Text style={styles.title}>Claim your legend</Text>
       </Animated.View>
 
@@ -202,7 +215,9 @@ export default function QuestCompletedSignupScreen() {
             {`Level ${heroLevel} · ${heroTypeLabel}`}
           </Text>
         </View>
-        <Badge tone="warm">{`+${firstQuestXP} XP`}</Badge>
+        <Badge tone="warm">
+          {isConversionGate ? `${heroCurrentXP} XP` : `+${firstQuestXP} XP`}
+        </Badge>
       </Animated.View>
 
       <Animated.View

--- a/src/app/quest-completed-signup.tsx
+++ b/src/app/quest-completed-signup.tsx
@@ -164,7 +164,18 @@ export default function QuestCompletedSignupScreen() {
   // Gate path (see navigation-state-resolver Priority 5): a veteran guest
   // routed here to convert — "Quest one · complete" would be false, so show
   // their real standing instead.
-  const isConversionGate = useOnboardingStore((s) => s.isOnboardingComplete());
+  //
+  // Requires the character too, and not for tidiness: this variant's copy
+  // makes a factual claim about the player's standing, so `heroLevel`'s
+  // `?? 1` and `heroCurrentXP`'s `?? 0` would confidently tell a level-40
+  // veteran whose character hasn't loaded that they are a level 1 hero with
+  // 0 XP. The normal path's fallbacks are generic and harmless; these are
+  // not. Falling back to the first-quest framing is at worst vague. NOT a
+  // loading state — the screen's real job (signing up) works either way.
+  const isOnboardingComplete = useOnboardingStore((s) =>
+    s.isOnboardingComplete()
+  );
+  const isConversionGate = isOnboardingComplete && !!character;
   const heroCurrentXP = character?.currentXP ?? 0;
 
   return (

--- a/src/app/quest-completed-signup.tsx
+++ b/src/app/quest-completed-signup.tsx
@@ -99,19 +99,22 @@ export default function QuestCompletedSignupScreen() {
 
   const handleSocialSignInSuccess = useCallback(
     (
-      _target: 'onboarding' | 'app',
+      target: 'onboarding' | 'app',
       outcome: SocialSignInOutcome | (string & {}),
       provider: SocialProvider
     ) => {
-      // The user arriving here already has a provisional character and has
-      // completed quest-1 (that's how they reached this screen), so unlike
-      // the login screen's `created` case, no explicit routing decision is
-      // needed: `socialSignIn` (src/api/auth.ts) clears the provisional
-      // tokens as a side effect, and the globally-mounted NavigationGate's
-      // onboarding-sync heuristic (navigation-state-resolver.ts) then flips
-      // onboarding to COMPLETED and routes to `/(app)` on its own — the
-      // same mechanism the magic-link conversion path already relies on
-      // (see `completeSignIn`'s JSDoc).
+      // Navigate on the target the callback already carries, rather than
+      // leaving it to the conversion gate.
+      //
+      // Delegating looks sound — `socialSignIn` clears the provisional tokens,
+      // so the gate's next pass falls through to 'app'. But "next pass" needs
+      // something to re-render the resolver, and `hasProvisionalSession` is a
+      // plain MMKV read with no subscription. The re-render normally comes
+      // from `completeSignIn`'s store writes, which it skips when
+      // `getUserDetails()` fails or answers without an id/email — it swallows
+      // that and still resolves 'app'. Auth status was already 'signIn', so
+      // nothing changes and the user sits on this wall holding a valid real
+      // account until they restart. Same one-liner as login-form.tsx:161.
       //
       // This screen is reachable by a returning user too (e.g. reinstalled
       // the app, still has a provisional character + completed quest-1 on
@@ -123,6 +126,8 @@ export default function QuestCompletedSignupScreen() {
       if (outcome === SOCIAL_SIGNIN_OUTCOMES.CONVERTED) {
         posthog.capture('signup_completed', { method: provider });
       }
+
+      router.replace(target === 'app' ? '/(app)/' : '/onboarding');
     },
     [posthog]
   );

--- a/src/app/quest-completed-signup.tsx
+++ b/src/app/quest-completed-signup.tsx
@@ -150,11 +150,14 @@ export default function QuestCompletedSignupScreen() {
     []
   );
 
-  // Hero card data — real data throughout, no hardcoded name/XP/type. XP is
+  // Hero card data — real data throughout, no hardcoded name/XP/type.
+  //
+  // XP has two meanings here, one per audience. On the onboarding path it is
   // quest-1's reward preview from AVAILABLE_QUESTS (matching the
-  // first-quest-result.tsx precedent), not the character store's
-  // accumulated `currentXP`, since the card means "what you just earned",
-  // not "your lifetime total".
+  // first-quest-result.tsx precedent), because the card means "what you just
+  // earned". On the conversion-gate path it is the character store's
+  // accumulated `currentXP`, because a gated veteran's card means "what you
+  // stand to lose" — see `isConversionGate` and the badge below.
   const characterProfile = character
     ? CHARACTERS.find((c) => c.id === character.type)
     : undefined;

--- a/src/components/login/constants.ts
+++ b/src/components/login/constants.ts
@@ -45,3 +45,13 @@ export const EMAIL_IN_USE_ERROR_MESSAGE =
 /** Ditto for the catch-all failure copy. */
 export const GENERIC_SEND_ERROR_MESSAGE =
   'Login link failed to send. Please try again.';
+
+/**
+ * Shown when the request never reached the server — an axios error with no
+ * response, and the aborted-conversion case (`ProvisionalRefreshUnavailable`),
+ * which is the same situation one hop earlier. Both are retryable and neither
+ * is the user's fault, so they say the same thing rather than each carrying a
+ * hand-typed near-duplicate.
+ */
+export const NETWORK_ERROR_MESSAGE =
+  'Network error. Please check your connection and try again.';

--- a/src/components/login/hooks/use-magic-link.test.ts
+++ b/src/components/login/hooks/use-magic-link.test.ts
@@ -4,8 +4,12 @@ import { requestMagicLink } from '@/api/auth';
 // The REAL class, not a stand-in: the hook branches on `instanceof`, and
 // `provisional-session.ts` imports only `@/lib/storage`, so requiring it pulls
 // in none of the native modules the `@/api/auth` mock below exists to avoid.
-import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
+import {
+  ProvisionalRefreshUnavailable,
+  ProvisionalSessionExpired,
+} from '@/lib/auth/provisional-session';
 
+import { NETWORK_ERROR_MESSAGE } from '../constants';
 import { useMagicLink } from './use-magic-link';
 
 // Mock the requestMagicLink function
@@ -154,6 +158,32 @@ describe('useMagicLink', () => {
     // The alert owns the explaining; a second, vaguer message under it would
     // only compete with it.
     expect(result.current.error).toBe('');
+    expect(result.current.emailSent).toBe(false);
+  });
+
+  // The mirror image of the case above, and it must NOT be handled the same
+  // way: nothing was proven about the session, no alert is on screen, and the
+  // session is still intact. The conversion was abandoned precisely so the
+  // user can retry, so this is the one provisional branch that owes them copy.
+  it('shows retryable copy when the provisional refresh could not be reached', async () => {
+    mockedRequestMagicLink.mockRejectedValueOnce(
+      new ProvisionalRefreshUnavailable()
+    );
+
+    const { result } = renderHook(() => useMagicLink());
+
+    await result.current.requestMagicLink('test@example.com');
+
+    await waitFor(() =>
+      expect(mockCapture).toHaveBeenCalledWith(
+        'magic_link_request_provisional_refresh_unavailable',
+        { email: 'test@example.com' }
+      )
+    );
+    await waitFor(() =>
+      expect(result.current.error).toBe(NETWORK_ERROR_MESSAGE)
+    );
+    // Nothing was sent, so the success path must not have been entered.
     expect(result.current.emailSent).toBe(false);
   });
 

--- a/src/components/login/hooks/use-magic-link.test.ts
+++ b/src/components/login/hooks/use-magic-link.test.ts
@@ -1,6 +1,10 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 
 import { requestMagicLink } from '@/api/auth';
+// The REAL class, not a stand-in: the hook branches on `instanceof`, and
+// `provisional-session.ts` imports only `@/lib/storage`, so requiring it pulls
+// in none of the native modules the `@/api/auth` mock below exists to avoid.
+import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
 
 import { useMagicLink } from './use-magic-link';
 
@@ -116,6 +120,41 @@ describe('useMagicLink', () => {
         'This email address is already associated with an account. Please use a different email address.'
       );
     });
+  });
+
+  // Not a magic-link failure: the provisional session turned out to be dead,
+  // `endProvisionalSession` has already put a non-cancelable alert on screen,
+  // and acknowledging it wipes and resets to onboarding. Reporting it as a
+  // send failure buries a distinct, actionable cause under the catch-all
+  // `..._unknown` bucket and shows the user retry copy for something retrying
+  // cannot fix.
+  it('reports an expired provisional session as its own outcome, not a generic send failure', async () => {
+    mockedRequestMagicLink.mockRejectedValueOnce(
+      new ProvisionalSessionExpired()
+    );
+
+    const { result } = renderHook(() => useMagicLink());
+
+    await result.current.requestMagicLink('test@example.com');
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      'magic_link_request_provisional_session_expired',
+      { email: 'test@example.com' }
+    );
+    expect(mockCapture).not.toHaveBeenCalledWith(
+      'magic_link_request_failed',
+      expect.anything()
+    );
+    expect(mockCapture).not.toHaveBeenCalledWith(
+      'magic_link_request_failed_unknown',
+      expect.anything()
+    );
+    // The alert owns the explaining; a second, vaguer message under it would
+    // only compete with it.
+    expect(result.current.error).toBe('');
+    expect(result.current.emailSent).toBe(false);
   });
 
   it('should increment send attempts on each request', async () => {

--- a/src/components/login/hooks/use-magic-link.ts
+++ b/src/components/login/hooks/use-magic-link.ts
@@ -3,6 +3,7 @@ import { usePostHog } from 'posthog-react-native';
 import { useCallback, useState } from 'react';
 
 import { requestMagicLink } from '@/api/auth';
+import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
 
 import {
   EMAIL_IN_USE_ERROR_MESSAGE,
@@ -60,6 +61,19 @@ export function useMagicLink(): UseMagicLinkReturn {
         setEmailSent(true);
         onSuccess?.(email);
       } catch (err) {
+        // Not a send failure — nothing was ever sent, and nothing here is
+        // retryable. `endProvisionalSession` has already put a non-cancelable
+        // "Character Expired" alert on screen and acknowledging it wipes and
+        // resets to onboarding, so this branch deliberately sets no error copy
+        // (a second, vaguer message would only compete with the alert) and
+        // reports its own outcome instead of the catch-all `..._unknown`.
+        if (err instanceof ProvisionalSessionExpired) {
+          posthog.capture('magic_link_request_provisional_session_expired', {
+            email,
+          });
+          return;
+        }
+
         posthog.capture('magic_link_request_failed', { email });
 
         if (axios.isAxiosError(err)) {

--- a/src/components/login/hooks/use-magic-link.ts
+++ b/src/components/login/hooks/use-magic-link.ts
@@ -3,11 +3,15 @@ import { usePostHog } from 'posthog-react-native';
 import { useCallback, useState } from 'react';
 
 import { requestMagicLink } from '@/api/auth';
-import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
+import {
+  ProvisionalRefreshUnavailable,
+  ProvisionalSessionExpired,
+} from '@/lib/auth/provisional-session';
 
 import {
   EMAIL_IN_USE_ERROR_MESSAGE,
   GENERIC_SEND_ERROR_MESSAGE,
+  NETWORK_ERROR_MESSAGE,
 } from '../constants';
 import { emailSchema } from '../types';
 
@@ -74,6 +78,21 @@ export function useMagicLink(): UseMagicLinkReturn {
           return;
         }
 
+        // Deliberately NOT handled like the case above. That one is proven and
+        // final and owns an alert; this one proved nothing, left the session
+        // intact, and abandoned the conversion so the user could retry — so it
+        // is the branch that owes them a message. Reported under its own name
+        // because the send never happened: `magic_link_request_failed` would
+        // claim an attempt that was never made.
+        if (err instanceof ProvisionalRefreshUnavailable) {
+          setError(NETWORK_ERROR_MESSAGE);
+          posthog.capture(
+            'magic_link_request_provisional_refresh_unavailable',
+            { email }
+          );
+          return;
+        }
+
         posthog.capture('magic_link_request_failed', { email });
 
         if (axios.isAxiosError(err)) {
@@ -81,9 +100,7 @@ export function useMagicLink(): UseMagicLinkReturn {
             setError('Request timed out. Please try again.');
             posthog.capture('magic_link_request_failed_timeout', { email });
           } else if (!err.response) {
-            setError(
-              'Network error. Please check your connection and try again.'
-            );
+            setError(NETWORK_ERROR_MESSAGE);
             posthog.capture('magic_link_request_failed_network_error', {
               email,
             });

--- a/src/components/login/social-sign-in-buttons.test.tsx
+++ b/src/components/login/social-sign-in-buttons.test.tsx
@@ -8,7 +8,10 @@ import { socialSignIn } from '@/api/auth';
 // actual: the component branches on `instanceof`. `provisional-session.ts`
 // imports only `@/lib/storage`, so it pulls in none of the native modules the
 // `@/api/auth` mock exists to avoid.
-import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
+import {
+  ProvisionalRefreshUnavailable,
+  ProvisionalSessionExpired,
+} from '@/lib/auth/provisional-session';
 import {
   ExistingAccountConfirmationRequired,
   getAppleCredential,
@@ -317,6 +320,34 @@ describe('SocialSignInButtons', () => {
       );
       // The alert is already on screen; a flash message under it competes.
       expect(onError).not.toHaveBeenCalled();
+    });
+
+    // Same family, opposite handling. No alert was raised and the session is
+    // untouched, so silence here would leave a button that spun and did
+    // nothing — the user needs the retry prompt the expired case withholds.
+    it('surfaces an unreachable provisional refresh as a retryable failure', async () => {
+      mockGetGoogleCredential.mockResolvedValue({
+        provider: 'google',
+        idToken: 'google-id-token',
+      });
+      mockSocialSignIn.mockRejectedValue(new ProvisionalRefreshUnavailable());
+      const onError = jest.fn();
+
+      render(<SocialSignInButtons onSuccess={noop} onError={onError} />);
+      fireEvent.press(screen.getByTestId('google-sign-in-button'));
+
+      await waitFor(() => {
+        expect(mockCapture).toHaveBeenCalledWith(
+          'social_signin_provisional_refresh_unavailable',
+          { provider: 'google' }
+        );
+      });
+      expect(onError).toHaveBeenCalledWith('generic');
+      // Filed under its own cause, not the catch-all fault bucket.
+      expect(mockCapture).not.toHaveBeenCalledWith(
+        'social_signin_failure',
+        expect.anything()
+      );
     });
 
     it('records the native error code on social_signin_failure, so a DEVELOPER_ERROR is distinguishable from a network failure', async () => {

--- a/src/components/login/social-sign-in-buttons.test.tsx
+++ b/src/components/login/social-sign-in-buttons.test.tsx
@@ -4,6 +4,11 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 import { Platform, StyleSheet } from 'react-native';
 
 import { socialSignIn } from '@/api/auth';
+// The REAL class, for the same reason the two social errors below are required
+// actual: the component branches on `instanceof`. `provisional-session.ts`
+// imports only `@/lib/storage`, so it pulls in none of the native modules the
+// `@/api/auth` mock exists to avoid.
+import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
 import {
   ExistingAccountConfirmationRequired,
   getAppleCredential,
@@ -283,6 +288,35 @@ describe('SocialSignInButtons', () => {
         'social_signin_failure',
         expect.anything()
       );
+    });
+
+    // The provisional session turned out to be dead before the credential was
+    // ever exchanged. `endProvisionalSession` owns the explaining (a
+    // non-cancelable alert that wipes and resets on acknowledge), so this is
+    // neither a fault to log nor something the retry copy can help with.
+    it('reports an expired provisional session as its own outcome, not a generic social_signin_failure', async () => {
+      mockGetGoogleCredential.mockResolvedValue({
+        provider: 'google',
+        idToken: 'google-id-token',
+      });
+      mockSocialSignIn.mockRejectedValue(new ProvisionalSessionExpired());
+      const onError = jest.fn();
+
+      render(<SocialSignInButtons onSuccess={noop} onError={onError} />);
+      fireEvent.press(screen.getByTestId('google-sign-in-button'));
+
+      await waitFor(() => {
+        expect(mockCapture).toHaveBeenCalledWith(
+          'social_signin_provisional_session_expired',
+          { provider: 'google' }
+        );
+      });
+      expect(mockCapture).not.toHaveBeenCalledWith(
+        'social_signin_failure',
+        expect.anything()
+      );
+      // The alert is already on screen; a flash message under it competes.
+      expect(onError).not.toHaveBeenCalled();
     });
 
     it('records the native error code on social_signin_failure, so a DEVELOPER_ERROR is distinguishable from a network failure', async () => {

--- a/src/components/login/social-sign-in-buttons.tsx
+++ b/src/components/login/social-sign-in-buttons.tsx
@@ -14,7 +14,10 @@ import { showMessage } from 'react-native-flash-message';
 
 import { socialSignIn } from '@/api/auth';
 import { Button } from '@/components/emberglow';
-import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
+import {
+  ProvisionalRefreshUnavailable,
+  ProvisionalSessionExpired,
+} from '@/lib/auth/provisional-session';
 import {
   ExistingAccountConfirmationRequired,
   type ExistingAccountSummary,
@@ -206,6 +209,24 @@ export function SocialSignInButtons({
         posthog.capture('social_signin_provisional_session_expired', {
           provider,
         });
+        return;
+      }
+
+      // The sibling of the branch above, handled the opposite way. Nothing was
+      // proven, no alert was raised and the session still exists — silence
+      // would leave a button that spun and then did nothing. Logged because it
+      // names a real fault (an unreachable API host), and given its own event
+      // so it does not disappear into the `social_signin_failure` bucket that
+      // the Reliability dashboard reads as OAuth breakage.
+      if (error instanceof ProvisionalRefreshUnavailable) {
+        console.error(
+          `[SocialSignIn] ${provider} conversion abandoned — provisional refresh unreachable`,
+          error
+        );
+        posthog.capture('social_signin_provisional_refresh_unavailable', {
+          provider,
+        });
+        onError('generic');
         return;
       }
 

--- a/src/components/login/social-sign-in-buttons.tsx
+++ b/src/components/login/social-sign-in-buttons.tsx
@@ -14,6 +14,7 @@ import { showMessage } from 'react-native-flash-message';
 
 import { socialSignIn } from '@/api/auth';
 import { Button } from '@/components/emberglow';
+import { ProvisionalSessionExpired } from '@/lib/auth/provisional-session';
 import {
   ExistingAccountConfirmationRequired,
   type ExistingAccountSummary,
@@ -191,6 +192,23 @@ export function SocialSignInButtons({
    */
   const reportFailure = React.useCallback(
     (error: unknown, provider: SocialProvider) => {
+      // Handled here rather than in the caller's catch so the confirmed
+      // REPLAY gets it too — that path refreshes the provisional token again
+      // and can reach the same verdict, and a replay that grew its own copy
+      // would be the one that stops reporting it.
+      //
+      // Nothing to log and nothing to show: `endProvisionalSession` has
+      // already put a non-cancelable alert on screen, and acknowledging it
+      // wipes and resets to onboarding. Firing `social_signin_failure` would
+      // file an expected, server-proven branch as a fault, and `onError`
+      // would flash retry copy under an alert that retrying cannot satisfy.
+      if (error instanceof ProvisionalSessionExpired) {
+        posthog.capture('social_signin_provisional_session_expired', {
+          provider,
+        });
+        return;
+      }
+
       const { code, status } = describeFailure(error);
 
       // Every error that reaches here is the raw object `socialSignIn`

--- a/src/lib/auth/index.test.tsx
+++ b/src/lib/auth/index.test.tsx
@@ -262,6 +262,32 @@ describe('Auth Store', () => {
 
       alertSpy.mockRestore();
     });
+
+    // `refreshProvisionalTokens` is single-flight, so ONE 'dead' verdict is
+    // delivered to every joined caller — a gated guest tapping "Continue with
+    // Google" while a background provisional request 401s reaches this twice.
+    // Two stacked non-cancelable alerts each wipe on acknowledge, and the
+    // second runs against an already-signed-out store.
+    it('announces a dead session once, however many callers reach it', () => {
+      (useUserStore.getState as jest.Mock).mockReturnValue({
+        clearUser: jest.fn(),
+      });
+      const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+      endProvisionalSession();
+      endProvisionalSession();
+
+      expect(alertSpy).toHaveBeenCalledTimes(1);
+
+      // Acknowledging re-arms it: a LATER dead session is a new event and
+      // must still be announced, so the guard cannot be a one-way latch.
+      (alertSpy.mock.calls[0][2] as any)[0].onPress();
+      endProvisionalSession();
+      expect(alertSpy).toHaveBeenCalledTimes(2);
+
+      (alertSpy.mock.calls[1][2] as any)[0].onPress();
+      alertSpy.mockRestore();
+    });
   });
 
   describe('signOut', () => {

--- a/src/lib/auth/index.test.tsx
+++ b/src/lib/auth/index.test.tsx
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react-native';
 import Constants from 'expo-constants';
+import { router } from 'expo-router';
 import { Alert } from 'react-native';
 import { OneSignal } from 'react-native-onesignal';
 
@@ -113,6 +114,10 @@ jest.mock('./utils', () => ({
   getToken: jest.fn(),
   removeToken: jest.fn(),
   setToken: jest.fn(),
+}));
+
+jest.mock('expo-router', () => ({
+  router: { replace: jest.fn() },
 }));
 
 jest.mock('@/lib/storage', () => ({
@@ -232,9 +237,28 @@ describe('Auth Store', () => {
       expect(characterStoreMocks.mockResetCharacter).toHaveBeenCalled();
       expect(onboardingStoreMocks.mockResetOnboarding).toHaveBeenCalled();
 
-      // Signed out + onboarding reset ⇒ the resolver routes to
-      // /onboarding/welcome by its normal rules; no navigation code here.
       expect(useAuth.getState().status).toBe('signOut');
+
+      alertSpy.mockRestore();
+    });
+
+    // The wipe used to lean on the resolver to route to /onboarding. That
+    // works from `(app)`, the only place the interceptors could fire it — but
+    // NOT from `/quest-completed-signup` or `/login`, which the conversion
+    // gate made into call sites. Both are in PRE_ACCOUNT_ZONE, so
+    // `isAlreadyAtTarget('onboarding', …)` answers true and NavigationGate
+    // suppresses the redirect: data gone, screen unchanged, alert already
+    // promising a fresh start. Same dead-affordance shape as emberglow#365.
+    it('leaves the screen it was called from, not just the session', () => {
+      (useUserStore.getState as jest.Mock).mockReturnValue({
+        clearUser: jest.fn(),
+      });
+      const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+      endProvisionalSession();
+      (alertSpy.mock.calls[0][2] as any)[0].onPress();
+
+      expect(router.replace).toHaveBeenCalledWith('/onboarding/welcome');
 
       alertSpy.mockRestore();
     });

--- a/src/lib/auth/index.tsx
+++ b/src/lib/auth/index.tsx
@@ -306,6 +306,20 @@ export const signOut = () => _useAuth.getState().signOut();
 export const hydrateAuth = async () => _useAuth.getState().hydrate();
 
 /**
+ * Whether a dead-session notice is already on screen awaiting acknowledgement.
+ *
+ * `refreshProvisionalTokens` is single-flight, so one 'dead' verdict is handed
+ * to every caller that joined the in-flight refresh. Without this, a gated
+ * guest tapping "Continue with Google" while a background provisional request
+ * 401s gets two stacked non-cancelable alerts, each wiping on acknowledge —
+ * the second against an already-signed-out store.
+ *
+ * Not a one-way latch: `wipeGuestSession` clears it, so a later dead session
+ * (a new guest, a new lapse) is still announced.
+ */
+let sessionEnding = false;
+
+/**
  * Wipes the guest (provisional) session AND all local progress, signs out, and
  * lands the user on /onboarding/welcome.
  *
@@ -335,6 +349,10 @@ export const hydrateAuth = async () => _useAuth.getState().hydrate();
  * added here and not there leaves converted users gated forever.
  */
 export const wipeGuestSession = () => {
+  // Cleared here rather than in the alert's handler so the re-arm is tied to
+  // the wipe actually running, not to a particular caller remembering to.
+  sessionEnding = false;
+
   removeItem('provisionalAccessToken');
   removeItem('provisionalRefreshToken');
   removeItem('provisionalUserId');
@@ -370,6 +388,11 @@ export const wipeGuestSession = () => {
  * refreshProvisionalTokens' result contract.
  */
 export const endProvisionalSession = () => {
+  if (sessionEnding) {
+    return;
+  }
+  sessionEnding = true;
+
   Alert.alert(
     'Character Expired',
     'Sorry, but it looks like your temporary character expired — no worries, though, it only takes a couple of minutes to create a new one.',

--- a/src/lib/auth/index.tsx
+++ b/src/lib/auth/index.tsx
@@ -341,12 +341,17 @@ let sessionEnding = false;
  * Device preferences (reminder times etc.) are intentionally left alone;
  * only identity and progress are wiped.
  *
- * Sibling key list: `hasProvisionalSession` in `./provisional-session`
- * decides whether a guest session EXISTS from two of these four keys
- * (deliberately not `provisionalRefreshToken`, which conversion leaves on
- * disk, nor `provisionalEmail`). If you change which keys conversion clears,
- * change that check too — it is what walls a guest out of the app, so a key
- * added here and not there leaves converted users gated forever.
+ * Sibling key list: `hasProvisionalSession` in `./provisional-session` decides
+ * whether a guest session EXISTS from two of these four keys — deliberately
+ * not `provisionalRefreshToken` (conversion leaves it on disk on purpose) and
+ * not `provisionalEmail`.
+ *
+ * That invariant runs in one direction, and it does NOT run through this
+ * function: every key `hasProvisionalSession` reads must be cleared by BOTH
+ * conversion paths — `verifyMagicLink` and `socialSignIn` in `@/api/auth`.
+ * Add a key to the check that conversion does not clear and every converted
+ * user is walled behind the signup screen forever. Adding a `removeItem` here
+ * is harmless by comparison: this is the start-over wipe, not a conversion.
  */
 export const wipeGuestSession = () => {
   // Cleared here rather than in the alert's handler so the re-arm is tied to

--- a/src/lib/auth/index.tsx
+++ b/src/lib/auth/index.tsx
@@ -317,6 +317,13 @@ export const hydrateAuth = async () => _useAuth.getState().hydrate();
  *
  * Device preferences (reminder times etc.) are intentionally left alone;
  * only identity and progress are wiped.
+ *
+ * Sibling key list: `hasProvisionalSession` in `./provisional-session`
+ * decides whether a guest session EXISTS from two of these four keys
+ * (deliberately not `provisionalRefreshToken`, which conversion leaves on
+ * disk, nor `provisionalEmail`). If you change which keys conversion clears,
+ * change that check too — it is what walls a guest out of the app, so a key
+ * added here and not there leaves converted users gated forever.
  */
 export const wipeGuestSession = () => {
   removeItem('provisionalAccessToken');

--- a/src/lib/auth/index.tsx
+++ b/src/lib/auth/index.tsx
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react-native';
 import Constants from 'expo-constants';
+import { router } from 'expo-router';
 import { Alert } from 'react-native';
 import { OneSignal } from 'react-native-onesignal';
 import { create } from 'zustand';
@@ -305,10 +306,18 @@ export const signOut = () => _useAuth.getState().signOut();
 export const hydrateAuth = async () => _useAuth.getState().hydrate();
 
 /**
- * Wipes the guest (provisional) session AND all local progress, then signs
- * out. With onboarding reset and auth signed out, the navigation resolver
- * routes to /onboarding/welcome by its normal rules — no navigation code
- * here, same sanctioned pattern as the no-hero screen's reset button.
+ * Wipes the guest (provisional) session AND all local progress, signs out, and
+ * lands the user on /onboarding/welcome.
+ *
+ * The navigation is explicit rather than left to the resolver. Leaning on the
+ * resolver worked while the only callers were the `(app)` interceptors, but
+ * the conversion gate added call sites on `/quest-completed-signup` and
+ * `/login` — both members of PRE_ACCOUNT_ZONE, where
+ * `isAlreadyAtTarget('onboarding', …)` answers true and NavigationGate
+ * suppresses the redirect (`@/lib/navigation/is-already-at-target`). The user
+ * acknowledged an alert promising a fresh start, lost their character, and did
+ * not move. Every caller needs the exit, so the exit belongs here — the same
+ * conclusion `login-form.tsx`'s `discardHeroAndStartOver` reached separately.
  *
  * Deliberately no salvage: grafting saved local progress onto a freshly
  * provisioned account is the split-brain shape that produced the PR #364
@@ -342,6 +351,8 @@ export const wipeGuestSession = () => {
 
   // Also clears the user store and detaches PostHog/RevenueCat/OneSignal.
   _useAuth.getState().signOut();
+
+  router.replace('/onboarding/welcome');
 };
 
 /**

--- a/src/lib/auth/provisional-session.test.ts
+++ b/src/lib/auth/provisional-session.test.ts
@@ -1,0 +1,54 @@
+import { getItem } from '@/lib/storage';
+
+import { hasProvisionalSession } from './provisional-session';
+
+jest.mock('@/lib/storage');
+
+const mockGetItem = getItem as jest.MockedFunction<typeof getItem>;
+
+/** Only the named key is present; every other key reads as absent. */
+const onlyKey = (present: string, value: unknown = 'value') =>
+  mockGetItem.mockImplementation((key: string) =>
+    key === present ? (value as any) : null
+  );
+
+describe('hasProvisionalSession', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetItem.mockReturnValue(null);
+  });
+
+  it('is false when no provisional keys are on disk', () => {
+    expect(hasProvisionalSession()).toBe(false);
+  });
+
+  // Both arms of the OR, because a guest can be missing either half: the
+  // user id is written before the tokens (createProvisionalUser), and the
+  // access token is the half `hydrate()` keys off.
+  it.each(['provisionalUserId', 'provisionalAccessToken'])(
+    'is true when %s alone is on disk',
+    (key) => {
+      onlyKey(key);
+
+      expect(hasProvisionalSession()).toBe(true);
+    }
+  );
+
+  // The refresh token deliberately SURVIVES conversion (verifyMagicLink and
+  // socialSignIn clear the other three and leave it), so counting it would
+  // wall every converted user out of the app forever.
+  it('is false when only the provisional refresh token survives (post-conversion)', () => {
+    onlyKey('provisionalRefreshToken');
+
+    expect(hasProvisionalSession()).toBe(false);
+  });
+
+  // The three-key sites (resolver sync effect, profile-hooks) ask a different
+  // question and keep their own check — this helper must not silently answer
+  // it, or migrating them later becomes a no-op that looks safe.
+  it('is false when only the provisional email is on disk', () => {
+    onlyKey('provisionalEmail');
+
+    expect(hasProvisionalSession()).toBe(false);
+  });
+});

--- a/src/lib/auth/provisional-session.ts
+++ b/src/lib/auth/provisional-session.ts
@@ -1,0 +1,35 @@
+import { getItem } from '@/lib/storage';
+
+/**
+ * Is a guest (provisional) session on disk?
+ *
+ * Deliberately its OWN module rather than a member of `@/lib/auth`'s index:
+ * that module pulls in the auth store, Sentry, OneSignal, RevenueCat and four
+ * zustand stores, and the screens asking this question (login.tsx,
+ * first-quest-result.tsx) only need two MMKV reads. Keeping it separate also
+ * means a suite that stubs `@/lib/auth` wholesale still runs the REAL check
+ * against its own storage fixture, instead of a jest.fn that would agree with
+ * whatever the test asserted.
+ *
+ * ## Why these two keys, and only these two
+ *
+ * `provisionalUserId` and `provisionalAccessToken` are the two keys that BOTH
+ * conversion paths clear (`verifyMagicLink` / `socialSignIn` in
+ * `src/api/auth.ts`), so their absence is what "this guest now has a real
+ * account" looks like on disk.
+ *
+ * `provisionalRefreshToken` is NOT part of the check and must never be added:
+ * conversion deliberately leaves it behind, so counting it would wall every
+ * converted user behind the signup screen forever. That is the drift this
+ * helper exists to make impossible — the check used to be spelled out at each
+ * call site with a prose comment promising they matched.
+ *
+ * `provisionalEmail` is also excluded, and that is the deliberate difference
+ * from the THREE-key check used by the resolver's onboarding-sync effect
+ * (`navigation-state-resolver.ts`) and `profile-hooks.ts`. Those two ask a
+ * broader question — "is there any provisional residue at all" — and are
+ * intentionally left on their own spelling: migrating them silently changes
+ * behaviour on paths this branch never exercised.
+ */
+export const hasProvisionalSession = (): boolean =>
+  !!(getItem('provisionalUserId') || getItem('provisionalAccessToken'));

--- a/src/lib/auth/provisional-session.ts
+++ b/src/lib/auth/provisional-session.ts
@@ -55,3 +55,24 @@ export class ProvisionalSessionExpired extends Error {
     this.name = 'ProvisionalSessionExpired';
   }
 }
+
+/**
+ * The provisional session could not be REFRESHED, and nothing was proven about
+ * whether it is still alive: a network flake, a 5xx, a timeout, a malformed
+ * refresh body. Thrown by `freshProvisionalAccessToken` in `@/api/auth`.
+ *
+ * Unlike `ProvisionalSessionExpired` this leaves the session completely
+ * untouched — no alert, no wipe — so the two error types must not be handled
+ * the same way. The conversion is abandoned rather than attempted, because the
+ * only token we could send is one the conversion endpoints (`auth.optional`)
+ * silently ignore: they would answer 200 and mint a brand-new account, filing
+ * the hero this screen promises to keep under nobody. Retrying is the correct
+ * user action, so callers SHOULD show retryable copy — the opposite of the
+ * expired case.
+ */
+export class ProvisionalRefreshUnavailable extends Error {
+  constructor() {
+    super('The provisional session could not be refreshed');
+    this.name = 'ProvisionalRefreshUnavailable';
+  }
+}

--- a/src/lib/auth/provisional-session.ts
+++ b/src/lib/auth/provisional-session.ts
@@ -33,3 +33,25 @@ import { getItem } from '@/lib/storage';
  */
 export const hasProvisionalSession = (): boolean =>
   !!(getItem('provisionalUserId') || getItem('provisionalAccessToken'));
+
+/**
+ * The provisional session a conversion was supposed to SAVE turned out to be
+ * dead: the server answered 401 for its refresh token. `endProvisionalSession`
+ * has already told the user and armed the wipe, so the conversion is abandoned
+ * rather than completed — see `freshProvisionalAccessToken` in `@/api/auth`,
+ * which is the only thing that throws this.
+ *
+ * Lives HERE rather than next to its thrower for the same reason
+ * `@/lib/auth/social/errors.ts` exists: the sign-in UIs branch on
+ * `instanceof`, and their test suites mock `@/api/auth` wholesale. From this
+ * dependency-light module they get the REAL class without loading axios,
+ * OneSignal and four stores — so the branch is exercised against the same
+ * prototype chain production uses, instead of a hand-written double that would
+ * keep passing if the real class ever stopped being constructible.
+ */
+export class ProvisionalSessionExpired extends Error {
+  constructor() {
+    super('The provisional session expired before it could be converted');
+    this.name = 'ProvisionalSessionExpired';
+  }
+}

--- a/src/lib/navigation/is-already-at-target.test.ts
+++ b/src/lib/navigation/is-already-at-target.test.ts
@@ -23,7 +23,7 @@ describe('isAlreadyAtTarget', () => {
   describe('screens the user navigated to themselves', () => {
     // Captured from a real Android SDK 53 session: tapping "Cooperative Quests"
     // pushes /cooperative-quest-menu — a ROOT-level route, not one inside the
-    // (app) group. The resolver keeps returning its Priority 5 fall-through
+    // (app) group. The resolver keeps returning its Priority 6 fall-through
     // 'app' because nothing special is happening, and the gate replace()d the
     // user straight back to the Play screen before the menu could be read.
     //
@@ -73,7 +73,7 @@ describe('isAlreadyAtTarget', () => {
     //
     // The resolver only names 'streak-celebration' while
     // shouldShowStreakCelebration is true, so a user who taps in when it is
-    // false gets the Priority 5 fall-through 'app', and a strict
+    // false gets the Priority 6 fall-through 'app', and a strict
     // resolver-owns-this match read their deliberate arrival as a stale one.
     it('leaves the user on the streak screen they tapped into', () => {
       expect(

--- a/src/lib/navigation/is-already-at-target.ts
+++ b/src/lib/navigation/is-already-at-target.ts
@@ -43,12 +43,27 @@ const RESOLVER_OWNED_SEGMENTS: Record<ResolverOwnedSegment, true> = {
  * `quest-completed-signup.tsx`'s "Create account" button hit this.
  *
  * So for these three the resolver's answer is read as a default rather than a
- * mandate. That is safe precisely here and nowhere else: this zone is the
- * resolver's LAST branch (Priority 3-4), reached only once streak celebration,
- * pending quests and quest results have all declined to claim the user. Those
- * higher-priority screens stay strictly matched below — they are consequences
- * of state the user cannot opt out of, and a running quest must still evict
- * someone sitting on `/login`.
+ * mandate. That is safe precisely here and nowhere else: every branch that can
+ * name one of these screens is a LATE one (Priorities 3-5), reached only once
+ * streak celebration, pending quests and quest results have all declined to
+ * claim the user. Those higher-priority screens stay strictly matched below —
+ * they are consequences of state the user cannot opt out of, and a running
+ * quest must still evict someone sitting on `/login`.
+ *
+ * `quest-completed-signup` now has TWO of those branches, which the original
+ * "Priority 3-4" phrasing did not contemplate: the onboarding one (Priority 3,
+ * step VIEWING_SIGNUP_PROMPT) and the provisional-conversion gate (Priority 5),
+ * which fires with onboarding COMPLETE. The conclusion is unchanged — Priority
+ * 5 is later still — but the premise is not "the last branch", it is "after
+ * everything the user cannot opt out of".
+ *
+ * Known hole, deliberately left open: `onboarding` is in this zone, so a gated
+ * guest who reaches `/onboarding` satisfies the gate and is not evicted from
+ * it. That is reachable via plain `/login` → "Create a hero" when `character`
+ * is null (`login-form.tsx` deliberately leaves stray keys alone). It is not a
+ * lock — re-running onboarding mints fresh provisional keys, and the gate
+ * catches them again on the way out — but the gate is described elsewhere as a
+ * "hard wall" and it is not one at this seam.
  *
  * Letting the user actually REACH `/login?intent=convert` exposes that the
  * `convert` framing withholds its way back on purpose (`copy.ts:105-110` — that
@@ -69,7 +84,7 @@ const PRE_ACCOUNT_ZONE: Partial<Record<ResolverOwnedSegment, true>> = {
 
 /**
  * Resolver-owned screens that ALSO have their own entry points, and so must
- * survive the Priority 5 'app' fall-through.
+ * survive the Priority 6 'app' fall-through.
  *
  * `RESOLVER_OWNED_SEGMENTS` encodes "only the resolver puts you here", which
  * lets target 'app' read any membership as a stale state-driven arrival and
@@ -136,7 +151,7 @@ export function isAlreadyAtTarget(
     case 'loading':
       return false;
 
-    // 'app' is the resolver's Priority 5 fall-through, returned whenever nothing
+    // 'app' is the resolver's Priority 6 fall-through, returned whenever nothing
     // special is happening. It is the ABSENCE of a destination, not a
     // destination: a reason to leave a screen the resolver owns, and no reason
     // to move anywhere else. Matching it against the (app) group instead would

--- a/src/lib/navigation/navigation-state-resolver.test.ts
+++ b/src/lib/navigation/navigation-state-resolver.test.ts
@@ -92,6 +92,11 @@ const mockQuestState = {
   recentCompletedQuest: null as any,
   failedQuest: null as any,
   completedQuests: [] as any[],
+  // Priority 1's input. Absent from this object it read `undefined`, which is
+  // falsy and so behaved like `false` — the branch was reachable only by a
+  // test that added the field itself, and any test that did leaked it into
+  // every test after it (the resolver's first branch wins over all others).
+  shouldShowStreakCelebration: false,
   resetFailedQuest: jest.fn(),
   clearRecentCompletedQuest: jest.fn(),
 };
@@ -140,6 +145,7 @@ beforeEach(() => {
   mockQuestState.recentCompletedQuest = null;
   mockQuestState.failedQuest = null;
   mockQuestState.completedQuests = [];
+  mockQuestState.shouldShowStreakCelebration = false;
   mockQuestState.resetFailedQuest.mockClear();
   mockQuestState.clearRecentCompletedQuest.mockClear();
 
@@ -436,6 +442,57 @@ describe('Navigation State Resolver', () => {
       expect(result.current).toEqual({ type: 'quest-completed-signup' });
     }
   );
+
+  // The gate replaces the "default to app" outcome and NOTHING above it. That
+  // promise lives only in a comment, and the comment cannot fail: hoisting the
+  // gate to the top of the ladder (population held identical) passes all 2120
+  // tests, while a gated veteran with a running quest silently loses the timer
+  // screen, every quest result, and streak celebration. These pin the rank.
+  describe('the gate outranks nothing above it', () => {
+    const gatedVeteran = () => {
+      mockAuthState.status = 'signIn';
+      mockOnboardingState.isOnboardingComplete.mockReturnValue(true);
+      mockOnboardingState.currentStep = OnboardingStep.COMPLETED;
+      mockQuestState.completedQuests = [];
+      mockGetItem.mockImplementation((key: string) =>
+        key === 'provisionalAccessToken' ? 'prov-value' : null
+      );
+    };
+
+    it('still shows a gated guest their running quest', () => {
+      gatedVeteran();
+      mockQuestState.pendingQuest = { id: 'quest-9' };
+
+      const { result } = renderHook(() => useNavigationTarget());
+
+      expect(result.current).toEqual({
+        type: 'pending-quest',
+        questId: 'quest-9',
+      });
+    });
+
+    it('still shows a gated guest the result of a quest they just failed', () => {
+      gatedVeteran();
+      mockQuestState.failedQuest = { id: 'quest-9' };
+
+      const { result } = renderHook(() => useNavigationTarget());
+
+      expect(result.current).toEqual({
+        type: 'quest-result',
+        questId: 'quest-9',
+        outcome: 'failed',
+      });
+    });
+
+    it('still shows a gated guest their streak celebration', () => {
+      gatedVeteran();
+      mockQuestState.shouldShowStreakCelebration = true;
+
+      const { result } = renderHook(() => useNavigationTarget());
+
+      expect(result.current).toEqual({ type: 'streak-celebration' });
+    });
+  });
 
   it('updates navigation target when auth status changes from signOut to signIn', () => {
     // Start with signed out state

--- a/src/lib/navigation/navigation-state-resolver.test.ts
+++ b/src/lib/navigation/navigation-state-resolver.test.ts
@@ -417,19 +417,25 @@ describe('Navigation State Resolver', () => {
     expect(result.current).toEqual({ type: 'app' });
   });
 
-  it('gates a provisional session out of the app and onto the signup screen (leaked-guest conversion gate)', () => {
-    mockAuthState.status = 'signIn';
-    mockOnboardingState.isOnboardingComplete.mockReturnValue(true);
-    mockOnboardingState.currentStep = OnboardingStep.COMPLETED;
-    mockQuestState.completedQuests = [];
-    mockGetItem.mockImplementation((key: string) =>
-      key === 'provisionalAccessToken' ? 'prov-token' : null
-    );
+  // Both arms of hasProvisionalSession's OR: a guest can be missing either
+  // half (the user id is written before the tokens), and covering only one
+  // let the other arm be deleted without a single test noticing.
+  it.each(['provisionalAccessToken', 'provisionalUserId'])(
+    'gates a provisional session out of the app and onto the signup screen when %s is on disk (leaked-guest conversion gate)',
+    (provisionalKey) => {
+      mockAuthState.status = 'signIn';
+      mockOnboardingState.isOnboardingComplete.mockReturnValue(true);
+      mockOnboardingState.currentStep = OnboardingStep.COMPLETED;
+      mockQuestState.completedQuests = [];
+      mockGetItem.mockImplementation((key: string) =>
+        key === provisionalKey ? 'prov-value' : null
+      );
 
-    const { result } = renderHook(() => useNavigationTarget());
+      const { result } = renderHook(() => useNavigationTarget());
 
-    expect(result.current).toEqual({ type: 'quest-completed-signup' });
-  });
+      expect(result.current).toEqual({ type: 'quest-completed-signup' });
+    }
+  );
 
   it('updates navigation target when auth status changes from signOut to signIn', () => {
     // Start with signed out state

--- a/src/lib/navigation/navigation-state-resolver.test.ts
+++ b/src/lib/navigation/navigation-state-resolver.test.ts
@@ -417,6 +417,20 @@ describe('Navigation State Resolver', () => {
     expect(result.current).toEqual({ type: 'app' });
   });
 
+  it('gates a provisional session out of the app and onto the signup screen (leaked-guest conversion gate)', () => {
+    mockAuthState.status = 'signIn';
+    mockOnboardingState.isOnboardingComplete.mockReturnValue(true);
+    mockOnboardingState.currentStep = OnboardingStep.COMPLETED;
+    mockQuestState.completedQuests = [];
+    mockGetItem.mockImplementation((key: string) =>
+      key === 'provisionalAccessToken' ? 'prov-token' : null
+    );
+
+    const { result } = renderHook(() => useNavigationTarget());
+
+    expect(result.current).toEqual({ type: 'quest-completed-signup' });
+  });
+
   it('updates navigation target when auth status changes from signOut to signIn', () => {
     // Start with signed out state
     mockAuthState.status = 'signOut';

--- a/src/lib/navigation/navigation-state-resolver.ts
+++ b/src/lib/navigation/navigation-state-resolver.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { useAuth } from '@/lib/auth';
+import { hasProvisionalSession } from '@/lib/auth/provisional-session';
 import { getItem } from '@/lib/storage';
 import { useCharacterStore } from '@/store/character-store';
 import { OnboardingStep, useOnboardingStore } from '@/store/onboarding-store';
@@ -191,9 +192,7 @@ export function useNavigationTarget(): NavigationTarget {
   // Provisional users hydrate with status 'signIn' (see auth hydrate()), so
   // authStatus alone can't identify the onboarding first-quest flow after an
   // app restart — check for a provisional session as well.
-  const hasProvisionalSession = !!(
-    getItem('provisionalUserId') || getItem('provisionalAccessToken')
-  );
+  const hasGuestSession = hasProvisionalSession();
   // A signed-in, non-provisional user can ALSO be mid-onboarding: a social
   // signup with no hero is routed back through it fully authenticated, and no
   // provisional session ever exists on that path. Any started-but-unfinished
@@ -202,7 +201,7 @@ export function useNavigationTarget(): NavigationTarget {
   const isInOnboardingFlow =
     !isOnboardingComplete &&
     (authStatus === 'signOut' ||
-      hasProvisionalSession ||
+      hasGuestSession ||
       currentStep !== OnboardingStep.NOT_STARTED);
 
   // Priority 1: Streak celebration (highest priority to show before quest complete)
@@ -322,7 +321,7 @@ export function useNavigationTarget(): NavigationTarget {
   // streak celebration, quest results, onboarding — behaves as normal; only
   // the "default to app" outcome is replaced. Conversion clears the
   // provisional keys, so the next pass falls through to 'app'.
-  if (hasProvisionalSession) {
+  if (hasGuestSession) {
     console.log('🧭 Provisional session in main app - gating to signup');
     return { type: 'quest-completed-signup' };
   }

--- a/src/lib/navigation/navigation-state-resolver.ts
+++ b/src/lib/navigation/navigation-state-resolver.ts
@@ -315,7 +315,19 @@ export function useNavigationTarget(): NavigationTarget {
     return { type: 'login' };
   }
 
-  // Priority 5: Default to app
+  // Priority 5: Provisional-conversion gate. A guest session must never live
+  // in the main app: nothing ties the account to a person, so 30 days of
+  // inactivity kills the refresh token and orphans the character forever
+  // (there is no email to log back in with). Everything above this line —
+  // streak celebration, quest results, onboarding — behaves as normal; only
+  // the "default to app" outcome is replaced. Conversion clears the
+  // provisional keys, so the next pass falls through to 'app'.
+  if (hasProvisionalSession) {
+    console.log('🧭 Provisional session in main app - gating to signup');
+    return { type: 'quest-completed-signup' };
+  }
+
+  // Priority 6: Default to app
   console.log('🧭 Default to app');
   return { type: 'app' };
 }

--- a/src/lib/navigation/navigation-state-resolver.ts
+++ b/src/lib/navigation/navigation-state-resolver.ts
@@ -321,6 +321,21 @@ export function useNavigationTarget(): NavigationTarget {
   // streak celebration, quest results, onboarding — behaves as normal; only
   // the "default to app" outcome is replaced. Conversion clears the
   // provisional keys, so the next pass falls through to 'app'.
+  //
+  // "The next pass" is worth being precise about, because `hasProvisionalSession`
+  // is a plain MMKV read with NO subscription behind it — clearing the keys
+  // does not by itself re-run this hook. What re-runs it is the conversion's
+  // other side effects: `completeSignIn` calls `useUserStore.setUser()` and
+  // `characterStore.updateCharacter()`, both selected on above, and
+  // NavigationGate re-renders on every `usePathname()`/`useSegments()` change.
+  //
+  // Known gap, accepted for now: if conversion SUCCEEDS but `getUserDetails()`
+  // then throws (network), `completeSignIn` swallows it and still resolves
+  // 'app' — but neither store was written, and auth `status` was already
+  // 'signIn', so on the social path nothing re-renders. The user sits on the
+  // wall holding a valid real account until they restart the app or tap again.
+  // Fixing that properly means a reactive MMKV subscription, which is a larger
+  // change than this branch should carry.
   if (hasGuestSession) {
     console.log('🧭 Provisional session in main app - gating to signup');
     return { type: 'quest-completed-signup' };


### PR DESCRIPTION
## Why

A guest ("provisional") account leaked into the main app has no email attached to it. When its refresh token lapses after 30 days of inactivity, the character, XP, level and quest history are gone with no way to log back in. At least two real accounts are in this state.

The leak: `hydrate()` sets auth status to `'signIn'` when it finds a provisional access token, so **`authStatus === 'signIn'` does not mean "has a real account"**. The navigation resolver knew this and guarded with a provisional-key check; commit `7383a59` reused the raw status in `first-quest-result.tsx` without that guard. Any guest whose app restarted during quest one — normal behaviour, since the quest is *stay off your phone* — skipped the signup prompt and landed in the app permanently provisional.

## What this does

1. **Root cause** — `first-quest-result.tsx` only skips the signup prompt when signed in **and** no provisional keys are on disk.
2. **The gate** — a new last-priority rule in `navigation-state-resolver.ts`: a provisional session that would resolve to `{ type: 'app' }` resolves to `{ type: 'quest-completed-signup' }` instead. Quest-result and streak screens still show first (they sit higher in the ladder); only the final "default to app" is replaced. Conversion clears the provisional keys, so the next pass falls through to the app.
3. **Copy** — the signup screen now serves two audiences. Gated veterans see their real standing instead of a false "Quest one · complete / +30 XP".

Conversion itself is unchanged and already correct: `intent=convert` mutates the same Mongo document in place, `_id` preserved, `isProvisional` flipped false, all progress kept. **No server changes.**

## Fixes found during review

The gate exposed three defects that would have shipped with it:

- **`login.tsx` redirected every `signIn` user away** — and the gate's placement guarantees *all* gated users are `signIn`. The wall's "Sign up with email" button routed to a screen that immediately bounced back. Social sign-in worked, so it wasn't a lockout, but a user without Google/Apple had no working exit. The old test asserted only that `router.replace` was called, so it could never see this.
- **Conversion silently discarded the progress it exists to save** when the provisional access token was stale. The endpoints use `auth.optional`, which swallows an expired token and continues with no `req.user` — no 401, no signal — so the conversion degraded to a plain sign-up. A gated veteran's 30-minute access token is almost always stale, and behind the wall nothing refreshes it. Now refreshed before conversion, with a genuine refresh-token 401 routed to the existing dead-session wipe and a network flake explicitly *not* wiping.
- **A missing refresh token was treated as proof of death.** `doRefreshProvisionalTokens` returns `'dead'` with no network call when there is nothing to refresh with — correct for the 401 interceptor, where the server has already rejected the token, but the new proactive caller inherited that verdict with no proof and wiped the session. Reachable, because the refresh token is stored conditionally while the access token is stored unconditionally. Guarded in the caller; the interceptor's contract is untouched.

Also: `hasProvisionalSession()` extracted to `src/lib/auth/provisional-session.ts` so the two-key check has one spelling across its (now four) call sites — adding a key that conversion doesn't clear would have walled converted users forever, and dropping one would have silently disabled the gate. The three-key variants are deliberately left alone. Two invalidated design records in `is-already-at-target.ts` corrected.

## Testing

`pnpm test` — **185 suites, 2120 passed, 3 skipped, 0 failed** (main baseline: 184 / 2093). `pnpm type-check` — 0 errors. Repo-wide lint not run: main has a pre-existing red baseline.

Every behavioural change was written test-first with a verified RED phase and both-direction mutation checks, with the two directions required to be caught by *disjoint* tests — so a guard that never fires and one that always fires each fail different tests, and neither can ship inverted. The false-positive guard for the ~99% of users who are not provisional is `'redirects to app by default'`, which fails if the gate is over-applied.

## Before release

- [ ] Device check — the failure surface here is routing plus real HTTP, which Jest structurally cannot reach. Minimum: leaked-guest state → cold start → wall appears → tap "Sign up with email" → **LoginForm actually renders** → complete magic link → land in the app with level and XP intact. Then repeat via warm foreground after 30+ minutes backgrounded, to exercise the stale-token path.
- [ ] Watch PostHog for `$screen = /quest-completed-signup` from the known leaked accounts (`6a715a02a66a14bcc45c1f1a` is one) followed by `signup_completed`.

## Known, deliberately not fixed here

- `user.ts:398-405` stores `provisionalRefreshToken` conditionally while the access token is stored unconditionally — the write path that makes the half-session state reachable at all. Pre-existing.
- A guest signing in to an existing real account still goes through the provisional refresh, so a genuine 401 shows "Character Expired" mid-login. Costs a step, not a lockout; separating "convert" from "sign in" means threading login intent into the API layer.
- `PRE_ACCOUNT_ZONE` includes `onboarding`, so a gated user who reaches `/onboarding` isn't evicted. Not a lock — re-running onboarding mints fresh provisional keys — but it is a hole in a rule described as a hard wall. Documented in `is-already-at-target.ts`.
