### PR TITLE
fix(android): reserve the bottom safe-area inset on screens with no tab bar

### DIFF
--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useAuth } from '@/lib/auth';
 import useLockStateDetection from '@/lib/hooks/useLockStateDetection';
+import { hidesTabBar } from '@/lib/navigation/tab-bar-routes';
 import {
   colors,
   fontFamily,
@@ -28,11 +29,27 @@ const TAB_ICON_SIZE = 22;
  * edge then rides ~1 nav-bar higher on every Android device, squeezing the
  * scene above it. Add the inset explicitly instead.
  */
-const TAB_BAR_CONTENT_HEIGHT = 56;
+const TAB_BAR_CONTENT_HEIGHT = 60;
+
+/**
+ * Explicit line box for tab labels. Without it the label height comes from
+ * the platform font metrics, which run taller on some Android devices (and
+ * grow with the system font-size setting) — that variance is what pushed
+ * "Play" past the content zone on a Samsung while the emulator looked fine.
+ */
+const TAB_LABEL_LINE_HEIGHT = 16;
 
 /** Raised center-orb geometry. */
 const ORB_SIZE = 56;
 const ORB_RAISE = -20;
+
+/**
+ * Gap between the raised orb and its label. The orb column is inherently
+ * taller than a side tab's (ORB_SIZE + ORB_RAISE = 36px of flow height vs a
+ * 22px icon), so this gap plus the label has to fit what's left of
+ * TAB_BAR_CONTENT_HEIGHT: 36 + 4 + 2 + 16 = 58 <= 60.
+ */
+const ORB_LABEL_GAP = 4;
 
 // Tab icon component
 function TabBarIcon({
@@ -129,17 +146,15 @@ export default function TabLayout() {
           borderTopColor: colors.border.hairline,
           height: TAB_BAR_CONTENT_HEIGHT + insets.bottom,
           paddingBottom: insets.bottom,
-          // Hide tab bar for quest screens and pending-quest
-          display:
-            ['pending-quest', 'quest-discovery', 'invitation-waiting'].includes(
-              route.name
-            ) || route.name.startsWith('quest/')
-              ? 'none'
-              : 'flex',
+          // Shared with ScreenContainer, which reserves insets.bottom itself
+          // on exactly the routes this hides the bar on. One list, so the two
+          // cannot disagree about who covers the inset.
+          display: hidesTabBar(route.name) ? 'none' : 'flex',
         },
         tabBarLabelStyle: {
           fontFamily: fontFamily.semibold,
           fontSize: fontSize.caption,
+          lineHeight: TAB_LABEL_LINE_HEIGHT,
           marginBottom: 6,
           paddingTop: 2,
         },
@@ -178,7 +193,8 @@ export default function TabLayout() {
           tabBarLabelStyle: {
             fontFamily: fontFamily.semibold,
             fontSize: fontSize.caption,
-            marginTop: 8,
+            lineHeight: TAB_LABEL_LINE_HEIGHT,
+            marginTop: ORB_LABEL_GAP,
             paddingTop: 2,
           },
         }}

--- a/src/app/pending-quest.test.tsx
+++ b/src/app/pending-quest.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import { router } from 'expo-router';
 import React from 'react';
+import { StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ONBOARDING_QUEST_ID } from '@/components/quest-complete/constants';
 import { render } from '@/lib/test-utils';
@@ -373,6 +375,35 @@ describe('PendingQuestScreen', () => {
 
       expect(mockCancelQuest).toHaveBeenCalledTimes(1);
       expect(router.back).not.toHaveBeenCalled();
+    });
+  });
+
+  // This screen lives on the root stack, so no tab bar is ever below it to
+  // span the bottom safe-area inset. It already reads insets.top for the top
+  // edge; the bottom edge used a bare constant, which put "Cancel quest" over
+  // the Android navigation bar on 3-button-nav devices.
+  describe('Bottom safe area', () => {
+    /** A 3-button-nav Android device. The global mock defaults to 0, which
+     * would make this assertion vacuous — 0 + 36 is the broken value too. */
+    const BOTTOM_INSET = 48;
+
+    beforeEach(() => {
+      jest.mocked(useSafeAreaInsets).mockReturnValue({
+        top: 24,
+        right: 0,
+        bottom: BOTTOM_INSET,
+        left: 0,
+      });
+    });
+
+    it('clears the navigation bar below the cancel button', () => {
+      const { getByTestId } = render(<PendingQuestScreen />);
+
+      const padding = StyleSheet.flatten(
+        getByTestId('pending-quest-content').props.style
+      ).paddingBottom;
+
+      expect(padding).toBe(BOTTOM_INSET + 36);
     });
   });
 

--- a/src/app/pending-quest.tsx
+++ b/src/app/pending-quest.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/emberglow';
 import { ONBOARDING_QUEST_ID } from '@/components/quest-complete/constants';
 import { BackgroundImage } from '@/components/ui';
+import { useBottomSafeAreaInset } from '@/lib/hooks/use-bottom-safe-area-inset';
 import { getQuestModeLabel } from '@/lib/utils/quest-utils';
 import { useQuestStore } from '@/store/quest-store';
 import { useUserStore } from '@/store/user-store';
@@ -55,6 +56,7 @@ export default function PendingQuestScreen() {
   const cancelQuest = useQuestStore((state) => state.cancelQuest);
   const userId = useUserStore((state) => state.user?.id);
   const insets = useSafeAreaInsets();
+  const bottomInset = useBottomSafeAreaInset();
 
   // Fetch quest reward preview
   // Custom and cooperative quests need questData, story quests need questTemplateId
@@ -140,12 +142,15 @@ export default function PendingQuestScreen() {
       />
 
       <View
+        testID="pending-quest-content"
         style={[
           styles.content,
           {
             paddingTop: insets.top + spacing[4],
             paddingHorizontal: UI_CONFIG.HORIZONTAL_PADDING,
-            paddingBottom: CONTENT_BOTTOM_PADDING,
+            // The background art is a sibling behind this layer, so it keeps
+            // bleeding under the navigation bar — only the content clears it.
+            paddingBottom: bottomInset + CONTENT_BOTTOM_PADDING,
           },
         ]}
       >

--- a/src/components/QuestComplete.test.tsx
+++ b/src/components/QuestComplete.test.tsx
@@ -1,6 +1,10 @@
+import { BottomTabBarHeightContext } from '@react-navigation/bottom-tabs';
+import { NavigationRouteContext } from '@react-navigation/native';
 import { fireEvent, render } from '@testing-library/react-native';
 import { router } from 'expo-router';
 import React from 'react';
+import { StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useQuestStore } from '@/store/quest-store';
 
@@ -351,9 +355,76 @@ describe('QuestComplete', () => {
 
       const { ScrollView } = require('react-native');
       const scrollView = UNSAFE_getByType(ScrollView);
-      expect(
-        scrollView.props.contentContainerStyle?.justifyContent
-      ).not.toBe('space-between');
+      expect(scrollView.props.contentContainerStyle?.justifyContent).not.toBe(
+        'space-between'
+      );
+    });
+  });
+
+  // The app runs edge-to-edge on Android, so content draws behind the
+  // navigation bar. This screen renders from two places and NEITHER has a
+  // visible tab bar below it to span the inset: (app)/quest/[id] inside the
+  // tab navigator with the bar hidden, and first-quest-result.tsx on the root
+  // stack. Without the inset, "Add reflection" sits under the nav bar.
+  describe('Bottom safe area', () => {
+    /** A 3-button-nav Android device. The global mock defaults every inset to
+     * 0, which would make these assertions vacuous — 0 + 24 is also the
+     * broken value — so each test must override it. */
+    const BOTTOM_INSET = 48;
+    const CONTENT_GAP = 24;
+
+    const paddingBottomOf = (el: any) =>
+      StyleSheet.flatten(el.props.style).paddingBottom;
+
+    beforeEach(() => {
+      jest.mocked(useSafeAreaInsets).mockReturnValue({
+        top: 24,
+        right: 0,
+        bottom: BOTTOM_INSET,
+        left: 0,
+      });
+    });
+
+    it('reserves the inset on a tab route that hides the tab bar', () => {
+      const { getByTestId } = render(
+        <BottomTabBarHeightContext.Provider value={104}>
+          <NavigationRouteContext.Provider
+            value={{ key: 'quest-key', name: 'quest/[id]' }}
+          >
+            <QuestComplete quest={mockStoryQuest} story="Test story" />
+          </NavigationRouteContext.Provider>
+        </BottomTabBarHeightContext.Provider>
+      );
+
+      expect(paddingBottomOf(getByTestId('quest-complete-content'))).toBe(
+        BOTTOM_INSET + CONTENT_GAP
+      );
+    });
+
+    it('reserves the inset outside the tab navigator', () => {
+      const { getByTestId } = render(
+        <QuestComplete quest={mockStoryQuest} story="Test story" />
+      );
+
+      expect(paddingBottomOf(getByTestId('quest-complete-content'))).toBe(
+        BOTTOM_INSET + CONTENT_GAP
+      );
+    });
+
+    it('omits the inset under a visible tab bar, which already spans it', () => {
+      const { getByTestId } = render(
+        <BottomTabBarHeightContext.Provider value={104}>
+          <NavigationRouteContext.Provider
+            value={{ key: 'journal-key', name: 'journal' }}
+          >
+            <QuestComplete quest={mockStoryQuest} story="Test story" />
+          </NavigationRouteContext.Provider>
+        </BottomTabBarHeightContext.Provider>
+      );
+
+      expect(paddingBottomOf(getByTestId('quest-complete-content'))).toBe(
+        CONTENT_GAP
+      );
     });
   });
 });

--- a/src/components/QuestComplete.tsx
+++ b/src/components/QuestComplete.tsx
@@ -5,6 +5,7 @@ import { ScrollView, StyleSheet, View } from 'react-native';
 import { Badge } from '@/components/emberglow';
 import { CompactRewardBreakdown } from '@/features/quest-result/components';
 import { useCustomQuestStory } from '@/hooks/useCustomQuestStory';
+import { useBottomSafeAreaInset } from '@/lib/hooks/use-bottom-safe-area-inset';
 import { calculatePerkBonuses } from '@/lib/perks';
 import {
   getCurrentUserAdjustedXP,
@@ -17,6 +18,9 @@ import { QuestCompleteActions } from './quest-complete/QuestCompleteActions';
 import { QuestCompleteHeader } from './quest-complete/QuestCompleteHeader';
 import { QuestCompleteStory } from './quest-complete/QuestCompleteStory';
 import type { QuestCompleteProps } from './quest-complete/types';
+
+/** Gap below the action buttons, before any bottom safe-area inset. */
+const CONTENT_BOTTOM_GAP = spacing[6];
 
 export function QuestComplete({
   quest,
@@ -32,6 +36,12 @@ export function QuestComplete({
   const customStory = useCustomQuestStory(quest);
   const displayStory = customStory || story;
   const currentUserId = useUserStore((state) => state.user?.id);
+
+  // This screen renders from two places with different things below it:
+  // (app)/quest/[id] inside the tab navigator with the bar hidden, and
+  // first-quest-result.tsx on the root stack. Neither spans the inset, so
+  // the action buttons have to clear the Android navigation bar themselves.
+  const bottomInset = useBottomSafeAreaInset();
 
   const adjustedXP = getCurrentUserAdjustedXP(quest, currentUserId);
 
@@ -70,7 +80,13 @@ export function QuestComplete({
           disableAnimations={disableEnteringAnimations}
         />
 
-        <View style={styles.content}>
+        <View
+          style={[
+            styles.content,
+            { paddingBottom: CONTENT_BOTTOM_GAP + bottomInset },
+          ]}
+          testID="quest-complete-content"
+        >
           <View style={styles.statsRow}>
             <Badge tone="warm">{`+${adjustedXP} XP`}</Badge>
             <Badge tone="neutral">{`${quest.durationMinutes} min offline`}</Badge>
@@ -125,7 +141,7 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingHorizontal: spacing[5],
     paddingTop: spacing[4],
-    paddingBottom: spacing[6],
+    // paddingBottom is applied inline — it carries the safe-area inset.
   },
   statsRow: {
     flexDirection: 'row',

--- a/src/components/failed-quest/index.test.tsx
+++ b/src/components/failed-quest/index.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { render, screen } from '@/lib/test-utils';
 import type { Quest } from '@/store/types';
@@ -56,5 +58,45 @@ describe('FailedQuest', () => {
     );
 
     expect(screen.getByText('CUSTOM QUEST')).toBeOnTheScreen();
+  });
+
+  // "Try Again" is a full-width primary CTA sitting directly above the Android
+  // navigation bar, so it needs real thumb clearance, not the 8px gap
+  // ScreenContainer gives ordinary screens. The screen asks for 32 via
+  // `paddingVertical`, but Yoga resolves padding by edge specificity rather
+  // than source order: ScreenContainer's `paddingBottom` wins over a later
+  // `paddingVertical`, so that 32 never reached the bottom edge. The value has
+  // to travel through `bottomPadding` instead.
+  describe('Bottom safe area', () => {
+    /** A 3-button-nav Android device. The global mock defaults every inset to
+     * 0, which would make this vacuous. 48 also differs from both the wanted
+     * gap (32) and the ScreenContainer default (8), so no two of the three can
+     * be confused for one another in the sum. */
+    const BOTTOM_INSET = 48;
+    const WANTED_GAP = 32;
+
+    beforeEach(() => {
+      jest.mocked(useSafeAreaInsets).mockReturnValue({
+        top: 24,
+        right: 0,
+        bottom: BOTTOM_INSET,
+        left: 0,
+      });
+    });
+
+    it('clears the navigation bar by the gap the screen asks for', () => {
+      render(
+        <FailedQuest
+          quest={{ ...baseQuest, mode: 'story' } as Quest}
+          onRetry={jest.fn()}
+        />
+      );
+
+      const padding = StyleSheet.flatten(
+        screen.getByTestId('failed-quest-content').props.style
+      ).paddingBottom;
+
+      expect(padding).toBe(BOTTOM_INSET + WANTED_GAP);
+    });
   });
 });

--- a/src/components/failed-quest/index.tsx
+++ b/src/components/failed-quest/index.tsx
@@ -73,7 +73,17 @@ export function FailedQuest({ quest, onRetry }: FailedQuestProps) {
         <View style={styles.overlay} />
       </BackgroundImage>
 
-      <ScreenContainer transparent style={styles.screenPadding}>
+      {/* The gap has to travel through `bottomPadding`, not the style prop:
+          ScreenContainer sets `paddingBottom` (inset + gap), and Yoga resolves
+          padding by edge specificity rather than source order, so a
+          `paddingVertical` here would lose at the bottom edge no matter that
+          it is applied later. */}
+      <ScreenContainer
+        testID="failed-quest-content"
+        transparent
+        bottomPadding={spacing[8]}
+        style={styles.screenPadding}
+      >
         {/* Title Section */}
         <Animated.View style={[styles.header, headerAnimatedStyle]}>
           <EyebrowLabel>
@@ -119,7 +129,8 @@ const styles = StyleSheet.create({
     backgroundColor: colors.surface.overlay,
   },
   screenPadding: {
-    paddingVertical: spacing[8],
+    // Top only — the bottom is ScreenContainer's, via `bottomPadding`.
+    paddingTop: spacing[8],
   },
   header: {
     marginTop: spacing[12],

--- a/src/components/ui/screen-container.test.tsx
+++ b/src/components/ui/screen-container.test.tsx
@@ -1,4 +1,5 @@
 import { BottomTabBarHeightContext } from '@react-navigation/bottom-tabs';
+import { NavigationRouteContext } from '@react-navigation/native';
 import * as React from 'react';
 import { StyleSheet, Text } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -6,6 +7,22 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { render, screen } from '@/lib/test-utils';
 
 import { ScreenContainer } from './screen-container';
+
+/**
+ * Places the subject on a named route inside the tab navigator, the way
+ * react-navigation does for a real tab scene. Both signals matter: the tab
+ * bar height context says "you are inside the tab navigator", the route name
+ * says "is the bar actually visible on this route".
+ */
+function onTabRoute(name: string, children: React.ReactNode) {
+  return (
+    <BottomTabBarHeightContext.Provider value={80}>
+      <NavigationRouteContext.Provider value={{ key: `${name}-key`, name }}>
+        {children}
+      </NavigationRouteContext.Provider>
+    </BottomTabBarHeightContext.Provider>
+  );
+}
 
 /** Matches a gesture-nav Android device (63px @ 2.625 density). */
 const BOTTOM_INSET = 24;
@@ -47,14 +64,50 @@ describe('ScreenContainer bottom spacing', () => {
 
   it('reserves the bottom inset for fullScreen routes that hide the tab bar', () => {
     render(
-      <BottomTabBarHeightContext.Provider value={80}>
+      onTabRoute(
+        'quest-discovery',
         <ScreenContainer testID="container" fullScreen>
           <Text>content</Text>
         </ScreenContainer>
-      </BottomTabBarHeightContext.Provider>
+      )
     );
 
     expect(paddingBottomOf('container')).toBe(BOTTOM_INSET + 32);
+  });
+
+  // `fullScreen` used to mean two unrelated things at once — "use 32px rather
+  // than 8px" AND "there is no tab bar below me". The route now owns the
+  // second question, so fullScreen must NOT smuggle in the inset on a route
+  // where the bar is genuinely visible and already spans it.
+  it('does not reserve the inset for fullScreen under a visible tab bar', () => {
+    render(
+      onTabRoute(
+        'journal',
+        <ScreenContainer testID="container" fullScreen>
+          <Text>content</Text>
+        </ScreenContainer>
+      )
+    );
+
+    expect(paddingBottomOf('container')).toBe(32);
+  });
+
+  // The tab bar is `display: 'none'` on quest routes, but react-navigation
+  // still reports a non-zero BottomTabBarHeightContext there: getTabBarHeight
+  // returns the numeric tabBarStyle height verbatim, and the value is frozen
+  // at mount (setTabBarHeight is never called). Nothing spans the inset on
+  // these routes, so the container has to.
+  it('reserves the bottom inset on tab routes that hide the tab bar', () => {
+    render(
+      onTabRoute(
+        'quest/[id]',
+        <ScreenContainer testID="container">
+          <Text>content</Text>
+        </ScreenContainer>
+      )
+    );
+
+    expect(paddingBottomOf('container')).toBe(BOTTOM_INSET + 8);
   });
 
   it('honors noPadding regardless of whether a tab bar sits below', () => {

--- a/src/components/ui/screen-container.tsx
+++ b/src/components/ui/screen-container.tsx
@@ -1,8 +1,7 @@
-import { BottomTabBarHeightContext } from '@react-navigation/bottom-tabs';
 import React from 'react';
 import { View, type ViewProps } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { useBottomSafeAreaInset } from '@/lib/hooks/use-bottom-safe-area-inset';
 import { colors } from '@/theme';
 
 interface ScreenContainerProps extends ViewProps {
@@ -30,9 +29,15 @@ interface ScreenContainerProps extends ViewProps {
  * container.
  *
  * Standard padding:
- * - Bottom: 8px, on screens with a tab bar (the bar already spans the inset)
- * - Bottom: insets.bottom + 32px (for full screens without tab bar, use fullScreen={true})
+ * - Bottom: 8px under a visible tab bar (the bar already spans the inset)
+ * - Bottom: insets.bottom + 8px everywhere else
  * - Horizontal: 16px (4 in Tailwind = 16px)
+ *
+ * `fullScreen` only swaps the 8px gap for 32px. It does NOT decide whether
+ * the safe-area inset is reserved — the route does, via `hidesTabBar`. Those
+ * two were previously conflated in this one prop, which is how "Try Again" on
+ * Quest Failed ended up under the Android navigation bar: the screen wanted
+ * the inset but not the extra 32px, and had no way to say so.
  *
  * Pass `transparent` on screens that render their own full-screen
  * background art/scrim behind this container — otherwise the flat canvas
@@ -48,19 +53,11 @@ export function ScreenContainer({
   style,
   ...props
 }: ScreenContainerProps) {
-  const insets = useSafeAreaInsets();
-  const tabBarHeight = React.useContext(BottomTabBarHeightContext);
-
   // Determine bottom padding: fullScreen uses 32px, tab screens use 8px
   const defaultBottomPadding = fullScreen ? 32 : 8;
   const finalBottomPadding = bottomPadding ?? defaultBottomPadding;
 
-  // A tab bar below us already spans insets.bottom, so reserving it here too
-  // would strand a dead strip of canvas above the bar. The context is still
-  // set on in-tab routes that hide the bar (quest-discovery, quest/reflection)
-  // — those pass fullScreen, which is why it also gates this.
-  const tabBarSpansInset = tabBarHeight !== undefined && !fullScreen;
-  const bottomInset = tabBarSpansInset ? 0 : insets.bottom;
+  const bottomInset = useBottomSafeAreaInset();
 
   return (
     <View

--- a/src/lib/hooks/use-bottom-safe-area-inset.ts
+++ b/src/lib/hooks/use-bottom-safe-area-inset.ts
@@ -1,0 +1,40 @@
+import { BottomTabBarHeightContext } from '@react-navigation/bottom-tabs';
+import { NavigationRouteContext } from '@react-navigation/native';
+import { useContext } from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { hidesTabBar } from '@/lib/navigation/tab-bar-routes';
+
+/**
+ * How much bottom safe-area inset *this* content layer has to reserve.
+ *
+ * The app runs edge-to-edge on Android (`react-native-edge-to-edge`, and
+ * mandatory from Android 16), so content draws behind the navigation bar and
+ * the root SafeAreaView deliberately omits the `bottom` edge. Exactly one
+ * element must reserve `insets.bottom`, and which one depends on the route:
+ *
+ * - Under a visible tab bar → the bar spans it (`height: 56 + insets.bottom`,
+ *   `paddingBottom: insets.bottom`), so content reserves nothing. Reserving
+ *   it anyway strands a dead strip of canvas above the bar.
+ * - Everywhere else (routes that hide the bar, and every root-stack screen)
+ *   → nothing below covers it, so the content layer owns it.
+ *
+ * Returns 0 or `insets.bottom`. Background art should sit *outside* whatever
+ * this pads — art is meant to bleed under the navigation bar, only buttons
+ * and text must clear it.
+ */
+export function useBottomSafeAreaInset(): number {
+  const insets = useSafeAreaInsets();
+  const tabBarHeight = useContext(BottomTabBarHeightContext);
+  const route = useContext(NavigationRouteContext);
+
+  // Two distinct questions, two distinct signals. The height context is
+  // truthful about "am I inside the tab navigator" (only BottomTabView sets
+  // it) but NOT about "is the bar visible here" — getTabBarHeight returns the
+  // numeric tabBarStyle height verbatim regardless of `display: 'none'`, and
+  // the value is frozen at mount because setTabBarHeight is never called.
+  const insideTabNavigator = tabBarHeight !== undefined;
+  const tabBarSpansInset = insideTabNavigator && !hidesTabBar(route?.name);
+
+  return tabBarSpansInset ? 0 : insets.bottom;
+}

--- a/src/lib/navigation/tab-bar-routes.test.ts
+++ b/src/lib/navigation/tab-bar-routes.test.ts
@@ -1,0 +1,45 @@
+import { hidesTabBar } from './tab-bar-routes';
+
+// This list is consumed twice — (app)/_layout.tsx sets tabBarStyle.display
+// from it, and useBottomSafeAreaInset decides whether content must reserve
+// insets.bottom from it. Dropping an entry silently puts that route's buttons
+// under the Android navigation bar, so the membership is asserted directly.
+describe('hidesTabBar', () => {
+  it.each([
+    'quest/[id]',
+    'quest/reflection',
+    'quest-discovery',
+    'invitation-waiting',
+    'pending-quest',
+  ])('reports the tab bar hidden on %s', (routeName) => {
+    expect(hidesTabBar(routeName)).toBe(true);
+  });
+
+  it.each(['journal', 'map', 'index', 'profile', 'settings'])(
+    'reports the tab bar visible on %s',
+    (routeName) => {
+      expect(hidesTabBar(routeName)).toBe(false);
+    }
+  );
+
+  // Routes registered with href:null still show the bar — they are pushed
+  // inside the tab navigator and were never in the hide list.
+  it.each(['leaderboard', 'achievements', 'skill-tree', 'custom-quest'])(
+    'leaves the tab bar visible on the in-tab route %s',
+    (routeName) => {
+      expect(hidesTabBar(routeName)).toBe(false);
+    }
+  );
+
+  // ScreenContainer passes route?.name, which is undefined outside a screen.
+  it('treats an unknown route as not hiding the bar', () => {
+    expect(hidesTabBar(undefined)).toBe(false);
+  });
+
+  // 'quest-discovery' must not be matched by the 'quest/' prefix rule, and
+  // 'quest/' must not swallow unrelated names that merely start with "quest".
+  it('matches the quest subtree by path segment, not by bare prefix', () => {
+    expect(hidesTabBar('questionnaire')).toBe(false);
+    expect(hidesTabBar('quest/anything/nested')).toBe(true);
+  });
+});

--- a/src/lib/navigation/tab-bar-routes.ts
+++ b/src/lib/navigation/tab-bar-routes.ts
@@ -1,0 +1,48 @@
+/**
+ * Single source of truth for which routes inside the `(app)` tab navigator
+ * hide the bottom tab bar.
+ *
+ * Two consumers depend on the same answer, and they must not drift:
+ *
+ * 1. `src/app/(app)/_layout.tsx` — sets `tabBarStyle.display` from it.
+ * 2. `ScreenContainer` — decides whether it has to reserve `insets.bottom`
+ *    itself, or whether the visible tab bar already spans it.
+ *
+ * The tab bar is the only thing that spans the bottom safe-area inset on tab
+ * screens (`height: 56 + insets.bottom`, `paddingBottom: insets.bottom`), so
+ * when it's hidden nothing does — content would sit under the Android
+ * navigation bar. Asking react-navigation is not an option: `getTabBarHeight`
+ * returns the numeric `tabBarStyle.height` verbatim with no regard for
+ * `display`, and `BottomTabBarHeightContext` is frozen at mount
+ * (`setTabBarHeight` is never called), so it reports a tab bar that isn't
+ * there. Hence a declared list rather than a runtime probe.
+ */
+
+/** Tab-navigator routes that render with the tab bar hidden. */
+const ROUTES_HIDING_TAB_BAR = [
+  'pending-quest',
+  'quest-discovery',
+  'invitation-waiting',
+] as const;
+
+/** Route-name prefixes whose whole subtree hides the tab bar. */
+const PREFIXES_HIDING_TAB_BAR = ['quest/'] as const;
+
+/**
+ * Whether the given tab-navigator route renders with the tab bar hidden.
+ *
+ * Only meaningful for routes inside the `(app)` tab navigator. Callers
+ * outside it (root-stack screens) have no tab bar at all and should not
+ * consult this — see `ScreenContainer`, which gates on the tab bar height
+ * context first.
+ */
+export function hidesTabBar(routeName: string | undefined): boolean {
+  if (!routeName) {
+    return false;
+  }
+
+  return (
+    (ROUTES_HIDING_TAB_BAR as readonly string[]).includes(routeName) ||
+    PREFIXES_HIDING_TAB_BAR.some((prefix) => routeName.startsWith(prefix))
+  );
+}


### PR DESCRIPTION
Fixes the four Android-only bottom-clipping bugs: buttons and labels sitting under the OS navigation bar.

- Tab bar "Play" label clipped
- pending-quest "Cancel quest" too close to the nav bar
- Quest Failed "Try Again" almost completely obscured
- Quest Complete "Add reflection" obscured when opened from the journal

## Why it only showed on real devices

The app runs edge-to-edge (`Theme.EdgeToEdge` is load-bearing in `styles.xml`, and Android 16 makes it mandatory), so content draws *behind* the navigation bar. Gesture nav reports `insets.bottom ≈ 24dp`; 3-button nav reports `~48dp`. All four bugs live in that delta — which is why the emulator looked fine and the Samsung didn't.

To reproduce on an emulator: `adb shell settings put secure navigation_mode 0`.

## Root cause

Exactly one element must reserve `insets.bottom`, and nothing owned that decision.

`ScreenContainer` inferred "a tab bar is below me" from `BottomTabBarHeightContext`, **which lies**: `getTabBarHeight` returns the numeric `tabBarStyle.height` verbatim with no regard for `display: 'none'`, and the value is frozen at mount (`setTabBarHeight` is never called). On `quest/*` routes it reported a tab bar that wasn't rendered, so the inset went unreserved.

`fullScreen` was then overloaded to paper over this — conflating *"use 32px rather than 8px"* with *"there is no bar below me"*. A screen that wanted the inset but not the extra 32px had no way to say so. That's exactly how Quest Failed ended up under the nav bar.

## The fix

Replace the inference with the fact, rather than layering a smarter check on top of a broken one:

- **`src/lib/navigation/tab-bar-routes.ts`** — one declared list of routes that hide the bar. `(app)/_layout.tsx` sets `tabBarStyle.display` from it and `useBottomSafeAreaInset` reads the same list, so the two cannot drift.
- **`src/lib/hooks/use-bottom-safe-area-inset.ts`** — combines two signals. The height context answers *"am I inside the tab navigator"* (that part was never the lie); the list answers *"is the bar visible here"*. Returns `0` or `insets.bottom`.
- **`ScreenContainer`**, **`QuestComplete`** and **`pending-quest`** consume it. `fullScreen` now only swaps the 8px gap for 32px — it no longer decides whether the inset is reserved.

Background art stays a **sibling** of the padded layer, so it keeps bleeding under the nav bar by design. Only buttons and text clear it.

Bug #1 was separate geometry: the raised centre orb column needs `36 + 4 + 2 + 16 = 58px` against the old 56px zone. The label also had no `lineHeight`, so the overflow tracked device font metrics — worse on a Samsung than on the emulator. Now `60` with an explicit `lineHeight: 16`.

### Second commit — `FailedQuest`

It declared `paddingVertical: spacing[8]` (32) and rendered 8. Yoga resolves padding by **edge specificity, not source order**, so `ScreenContainer`'s `paddingBottom` beats a consumer's later `paddingVertical`. `tsc`, `StyleSheet.flatten` and Jest all see two valid properties — only the device shows which wins. The gap now travels through the `bottomPadding` prop, and the style is narrowed to `paddingTop`.

## Verification

**185/185 suites, 2116 tests, `pnpm type-check` 0 errors**, lint clean apart from the pre-existing `QuestComplete.tsx` filename-case warning.

Every inset assertion overrides the global mock: `jest-setup.ts:321` mocks all insets to **0**, and `0 + 36 === 36` is the broken value too — a test written against the default fixture would pass against the shipped bug.

Mutations, both directions:
- drop `bottomPadding` → `56` (the shipped defect)
- force the inset to `0` → `32`
- force the inset **always on** → 3 *other* tests fail

The always-fires and never-fires mutations are caught by different tests, so a `return true` implementation cannot ship green.