### PR TITLE
Add Mutation testing and improve tests by killing survivors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,10 @@ build/
 # Jest
 coverage/
 
+# Stryker mutation testing
+.stryker-tmp/
+reports/
+
 # Debug
 .log/
 logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,180 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+unQuest is a React Native mobile app built with Expo that gamifies daily tasks through story-driven quests. The app uses TypeScript, React Navigation, TanStack Query, Zustand for state management, and NativeWind for styling.
+
+## Instructions
+
+- Avoid excessive politeness, flattery, or empty affirmations.
+- Avoid over-enthusiasm or emotionally charged language.
+- Be direct and factual, focusing on usefulness, clarity, and logic.
+- Prioritize truth and clarity over appeasing me.
+- Challenge assumptions or offer corrections anytime you get a chance.
+- Point out any flaws in the questions or solutions I suggest.
+- Use a test-driven development approach.
+
+## Common Development Commands
+
+### Testing
+```bash
+# Run all tests
+pnpm test
+
+# Run tests in watch mode
+pnpm test:watch
+
+# Run a single test file
+pnpm test src/app/(app)/index.test.tsx
+
+# Run tests with coverage
+pnpm test:ci
+```
+
+### Code Quality
+```bash
+# Run all checks (lint, type-check, translations, tests)
+pnpm check-all
+
+# Run linter
+pnpm lint
+
+# Type checking
+pnpm type-check
+
+# Lint translations
+pnpm lint:translations
+
+# Format code with Prettier (run before committing)
+pnpm prettier --write .
+```
+
+## Architecture Overview
+
+### Navigation Structure
+The app uses Expo Router (file-based routing) with the following key navigation flows:
+
+1. **Authentication Flow**: `/login` → provisional auth → full auth after quest completion
+2. **Onboarding Flow**: `/onboarding/*` → character selection → first quest → signup
+3. **Main App**: Tab navigation at `/(app)/*` with home, journal, map, profile, and settings
+
+The navigation state is managed by `navigation-state-resolver.ts` which determines routing based on:
+- Auth status (hydrating, signOut, signIn)
+- Onboarding completion status
+- Active quest states (pending, completed, failed)
+
+### State Management
+
+**Zustand Stores** (persisted with MMKV):
+- `quest-store.ts`: Manages active/pending/completed quests, quest progression
+- `character-store.ts`: User character data, XP, levels, streaks
+- `onboarding-store.ts`: Tracks onboarding progress through steps
+- `user-store.ts`: User profile data
+- `settings-store.ts`: App settings and preferences
+- `poi-store.ts`: Points of interest on the map
+
+**Key State Patterns**:
+- Direct subscriptions for real-time updates (e.g., quest state changes)
+- Persist middleware for offline support
+- Getters for accessing state outside React components
+
+### Quest System
+
+Quests are the core feature with two types:
+1. **Story Quests**: Pre-defined narrative quests with branching paths
+2. **Custom Quests**: User-created tasks
+
+Quest flow:
+1. User selects quest → `prepareQuest()` sets it as pending
+2. Navigate to `/pending-quest` → countdown → `startQuest()`
+3. Background timer runs → completion/failure → navigate to result screen
+4. Result screen shows XP gained, story progression, next options
+
+### API Layer
+
+- Uses Axios with TanStack Query for data fetching
+- Provisional authentication for new users (complete quests before signup)
+- Full authentication after email verification
+- API client with request/response interceptors for auth tokens
+
+### Testing Approach
+
+- Jest + React Native Testing Library
+- Test utilities in `src/lib/test-utils.tsx` with providers setup
+- Mock patterns for:
+  - Navigation (`expo-router`)
+  - Native modules (`react-native-reanimated`)
+  - Stores (Zustand mocks with shared state)
+- Focus on user interactions and state changes
+
+### Test-Driven Development (TDD)
+
+**IMPORTANT**: Always follow TDD principles when implementing new functionality:
+
+1. **Red Phase**: Write a failing test FIRST that describes the desired behavior
+   - Run the test to verify it fails for the right reason
+   - The test should fail because the functionality doesn't exist yet
+   - Use React Native Testing Library to test components from the user's perspective
+
+2. **Green Phase**: Write the minimal code needed to make the test pass
+   - Implement only what's necessary to satisfy the test
+   - Avoid over-engineering or adding features not covered by tests
+   - Focus on making the test pass, not on perfect code
+
+3. **Refactor Phase**: Clean up the code while keeping tests green
+   - Improve code quality, readability, and performance
+   - Ensure all tests still pass after refactoring
+   - Extract reusable logic into hooks or utilities as needed
+
+4. **Verify Phase (mutation testing)**: Prove each new assertion can actually fail
+   - Run `pnpm test:mutate <path-to-source-file>`. Stryker mutates operators,
+     conditionals, boundaries, and literals exhaustively — including forcing every
+     guard both always-true and always-false — and reports which mutants your tests
+     failed to kill. Use this instead of hand-editing source and restoring it.
+   - Every surviving mutant is either a test gap or an equivalent mutant (semantically
+     identical, unkillable). Classify it; don't reflexively chase the score.
+   - **Stryker does not mutate fixtures. This part stays manual:** data equal to a
+     fallback, a default, or the post-mutation value asserts nothing, and no tool can
+     detect that. Check it by hand.
+   - MANDATORY when there was no genuine Red phase — a test written against code that
+     already works has never been proven capable of failing.
+
+**Rules**:
+- Never write implementation code without a failing test that requires it
+- Run tests frequently (`pnpm test:watch`) to verify each small change
+- Write ONE test at a time, not multiple tests in a batch
+- Test user behavior and outcomes, not implementation details
+- Mock external dependencies (API calls, navigation, native modules)
+- Use `test-utils.tsx` wrapper for consistent test setup with providers
+- A passing test is not evidence until you have watched it fail — in the Red phase or under a mutation
+- Assume a new assertion is vacuous until mutation proves otherwise: `toMatchObject({})`, `expect.anything()` against `undefined`, RNTL matching hidden elements, and fixtures equal to their fallback all pass silently
+- Report mutation results when claiming a fix works ("reverting the fix fails 7 tests"), not just the green count
+
+### Key Technical Decisions
+
+1. **File-based routing** with Expo Router for simpler navigation
+2. **NativeWind** for utility-first styling (Tailwind for React Native)
+3. **Zustand** over Redux for simpler state management
+4. **MMKV** for fast persistent storage
+5. **Provisional auth** to reduce signup friction
+6. **Background timers** for quest tracking when app is backgrounded
+
+## Environment Configuration
+
+Environment variables are managed through `.env.{environment}` files:
+- `development`, `staging`, `production`
+- Validated with Zod schemas in `env.js`
+- Client vars exposed via `@env` import
+- Build-time vars used in `app.config.ts`
+
+## Code Conventions
+
+- **File naming**: kebab-case for all files
+- **Component structure**: Functional components with hooks
+- **Imports**: Absolute imports via `@/` alias
+- **State updates**: Prefer direct Zustand actions over hooks when possible
+- **Testing**: Co-locate tests with components, use `.test.tsx` extension
+- **Styling**: Use NativeWind classes, avoid inline styles
+- **Code formatting**: Run `pnpm prettier --write .` before committing changes

--- a/docs/superpowers/plans/2026-08-07-mutation-baseline.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-baseline.md
@@ -896,3 +896,55 @@ call into it, read the mock before reading the code.**
 | `if (questRunIdFromQuest)` → `false` | 1 |
 | `participants: questRunData.participants` → `[]` | 1 |
 | keep the pre-merge quest as `recentCompletedQuest` | 1 |
+
+### 8.4 A measured score for `revenuecat-service.ts`
+
+A single-module run finished in ~35 minutes. **Directly comparable to §6** —
+the same 263 mutants, so the denominator has not moved.
+
+| | §6 (f71242b) | §8 | change |
+| --- | --- | --- | --- |
+| Killed (incl. timeouts) | 151 | **196** | +45 |
+| No coverage | 56 | **7** | −49 |
+| Survived | 56 | 60 | +4 |
+| Total score | 57.41% | **74.52%** | +17.11 |
+| Covered score | 72.95% | **76.56%** | +3.61 |
+
+**One timeout, not seventy.** The fail-once-then-succeed mock design in §8.1
+is why. Compare §6, where a run logged 70 hangs and took over four hours.
+Survivors rising while no-coverage collapses is the expected shape (§6):
+reaching previously-unexecuted code converts a no-coverage mutant into a
+survivor.
+
+Of the 60 survivors, 32 are log text and roughly 15 more are the object
+literal inside a single `console.log` of customer info. The rest:
+
+- **`hasPremiumAccess` L150–153 is dead code.** `if (__DEV__) return true` at
+  L138 returns before it, so `if (this.testModeEnabled && __DEV__)` can never
+  be true. Not fixed here — out of scope for a test pass. Worth deleting.
+- `case NOT_PRESENTED` is equivalent: it falls through to `default`, which
+  returns the same `false`. Only the log differs.
+- `if (!this.isInitialized)` in `hasPremiumAccess` is equivalent in one
+  direction: removing it lets `refreshCustomerInfo` throw its own
+  not-initialized error, which the catch turns into the same `false`.
+- Genuine remaining gap: the two catch blocks in `presentPaywallIfNeeded`.
+
+### 8.5 The duplicate Android notification — fixed
+
+§6 recorded this as "a production defect to ticket, not a test gap". Fixed
+here instead. When the server had already activated a cooperative quest,
+`onPhoneLocked` posted the Android "Quest in progress" notification inside the
+activation branch and then fell through to the shared call at the end of the
+method, which posts the identical payload behind the identical guards. The
+inner call is gone.
+
+Written test-first: `toHaveBeenCalledTimes(1)` fails with "Expected 1,
+received 2" against the old code. That is a genuine red phase, so this one
+needed no mutation to prove.
+
+**This is the only production behaviour change the whole mutation-testing
+effort has produced.** Everything else on the branch is tests, dead-code
+removal, and config. Judge the work on the fake-coverage findings — the
+covered score started at 43%, meaning more than half of the code the tests
+executed could be arbitrarily broken with the suite still green — not on a
+bug count.

--- a/docs/superpowers/plans/2026-08-07-mutation-baseline.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-baseline.md
@@ -1,0 +1,584 @@
+# Mutation testing baseline — 2026-08-07
+
+Stryker pilot sweep over five modules. This document is the **handoff artifact**: it
+records what the sweep found, classifies every surviving mutant, and ends with a
+prioritized list of tests worth writing. It assumes no context from the session that
+produced it.
+
+- Branch: `chore/mutation-testing-pilot`
+- Raw report: `reports/mutation/index.html` (2.1 MB — do not open it in an agent
+  context; it has killed two sessions. Use `/tmp/mutation-report.json` with a targeted
+  `node -e` / `jq` query instead.)
+- Runtime: **30m38s**, 86.08 tests run per mutant on average.
+- **Do not re-run Stryker to re-read these numbers.** Everything is transcribed below.
+
+---
+
+## 1. Headline numbers
+
+| Metric | Value |
+| --- | --- |
+| Mutants generated | 1135 |
+| Killed | 174 |
+| **Survived** | **230** |
+| No coverage | 731 |
+| Timeout | 0 |
+| Errors | 0 |
+| **Total mutation score** | **15.33%** |
+| **Covered mutation score** | **43.07%** |
+
+### Why two scores, and why the gap matters
+
+- **Total score (15.33%)** = killed / all mutants. It counts every *no-coverage*
+  mutant as unkilled. It answers: "how much of this code is protected by tests at all?"
+- **Covered score (43.07%)** = killed / (killed + survived). It ignores code no test
+  executes and judges only the code tests *do* reach. It answers: "when a test does run
+  this line, does it actually assert anything about it?"
+
+The 28-point gap separates two completely different problems:
+
+- **731 of 1135 mutants (64%) are in code no test executes at all.** That is a coverage
+  problem: whole functions and whole branches are unreached. Writing assertions cannot
+  help; only new tests that call the code can.
+- **230 survivors are in code tests *do* execute but fail to check.** That is an
+  assertion-quality problem — the tests run the line, the line's behavior changes, and
+  the suite stays green. These are the highest-signal findings in this document.
+
+A reader who sees only "15.33%" concludes the test suite is worthless. A reader who sees
+only "43.07%" concludes coverage is fine and assertions are soft. Both are wrong. Report
+both numbers together, always.
+
+---
+
+## 2. Per-module results
+
+| Module | Total % | Covered % | Killed | Survived | No coverage | src lines | test lines | test:src ratio |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `src/store/scheduled-quests-store.ts` | **70.21** | 71.74 | 33 | 13 | 1 | 101 | 64 | 0.63 |
+| `src/store/settings-store.ts` | 29.03 | 34.62 | 9 | 17 | 5 | 82 | 31 | 0.38 |
+| `src/store/user-store.ts` | 25.93 | 30.43 | 7 | 16 | 4 | 60 | 35 | 0.58 |
+| `src/lib/services/revenuecat-service.ts` | 18.25 | 50.00 | 48 | 48 | 167 | 389 | 165 | 0.42 |
+| `src/lib/services/quest-timer.ts` | **10.04** | 36.15 | 77 | 136 | 554 | 1222 | 517 | 0.42 |
+
+### Was `--inPlace` required?
+
+**No.** Stryker's default sandbox mode (copying the project into `.stryker-tmp` and
+mutating there) worked throughout the sweep. The React Native / Metro / Jest toolchain
+did not need mutation-in-place to resolve modules. Nothing in the config sets
+`inPlace: true`, and nothing should. Keep it that way — `--inPlace` mutates the working
+tree, and an interrupted run leaves mutated source on disk.
+
+### The prediction that failed
+
+The five modules were picked by **test-to-source line ratio**, on the theory that the
+modules with the thinnest test files would score worst.
+
+That prediction was wrong, and it is worth stating plainly:
+
+- `scheduled-quests-store.ts` had one of the *lowest* ratios (101 src / 64 test = 0.63)
+  and scored **best by a wide margin — 70.21%**.
+- `quest-timer.ts` and `revenuecat-service.ts` had *similar* ratios (0.42 each) and
+  scored 10.04% and 18.25%.
+- `settings-store.ts` and `user-store.ts` have ratios of 0.38 and 0.58 — essentially the
+  same neighbourhood as `scheduled-quests-store.ts` — and scored 29% and 26%.
+
+Ratio explains almost nothing. What actually separated the modules:
+
+- `scheduled-quests-store.test.ts` asserts **resulting state** (`myRegistrations` ids,
+  lengths, the settled payload). Its 64 lines buy real detection.
+- `quest-timer.test.ts` is 517 lines that largely assert **that a call happened**
+  (`expect(updatePhoneLockStatus).toHaveBeenCalledWith(...)`) or, worse, that **nothing
+  threw** (`await expect(QuestTimer.onPhoneUnlocked()).resolves.not.toThrow()`). Length
+  without outcome assertions buys nothing.
+
+This is the entire argument for mutation testing over line counts or line coverage:
+**the only measurement that distinguishes these two files is whether changing the code
+makes a test go red.** Nothing derivable from file size, coverage %, or test count
+would have ranked `scheduled-quests-store.ts` first.
+
+---
+
+## 3. What has no tests at all (the 731)
+
+These are **not** enumerated individually — 731 entries would be unusable. They are
+mapped to the regions they fall in. Each region below is code that **no test in the
+suite executes**.
+
+### `src/lib/services/quest-timer.ts` — 554 no-coverage mutants (76% of the file's mutants)
+
+The class is ~1222 lines and the tests reach roughly the first 400. Untested regions,
+by what lives there:
+
+| Lines | Region | What is untested |
+| --- | --- | --- |
+| 40–42 | `parseIntSafe` body | The actual `parseInt` / `NaN` path — no test ever restores a start time from storage |
+| 73–75, 81–83 | `saveQuestData` else-branches | `removeItem('ONESIGNAL_ACTIVITY_ID')` / `removeItem('QUEST_RUN_ID')` when the ids are null |
+| 122–129, 139–140 | `loadQuestData` / `clearQuestData` catch blocks | Storage-failure handling |
+| 216–241 | `prepareQuest` cooperative-run-data block | `setCooperativeQuestRun(...)` — participant normalisation, host id, questId fallback chain |
+| 281–303 | `prepareQuest` iOS Live Activity catch + H2 registration failure path | |
+| 404–532 | `onPhoneLocked` cooperative branch | The whole retry ladder (`sendPhoneLockStatus`, `maxRetries`, `retryDelay`) and the activation-polling loop |
+| 559–564 | The 500 ms `setTimeout` body in `onPhoneLocked` | **`questStore.startQuest(quest)` — the line that actually starts a solo quest — never executes in any test.** Fake timers are never advanced. |
+| 577–590 | Android `BackgroundService.updateNotification` | |
+| 616–1196 | Everything from mid-`onPhoneUnlocked` to the end of `backgroundTask` | Quest failure on unlock, cooperative unlock handling, completion detection, the background loop, elapsed-time math, notification scheduling, `isRunning`, `getQuestRunId` |
+
+The practical summary: **quest-timer is tested up to the point where the phone locks,
+and not one line past it.** Everything about a quest completing, failing, or ticking is
+unexecuted by the suite.
+
+### `src/lib/services/revenuecat-service.ts` — 167 no-coverage mutants
+
+| Lines | Region | What is untested |
+| --- | --- | --- |
+| 29–32 | `enableTestMode` | |
+| 52–53 | Android `Purchases.configure` branch | The Google API key is never selected in a test |
+| 58–60, 70–71, 80–81, 87–88 | catch/throw paths of `initialize`, `loginUser`, `logoutUser`, `refreshCustomerInfo` | |
+| 95–103 | `refreshCustomerInfo` "No active account" recovery | The synthesised empty `CustomerInfo` fallback |
+| 150–198 | The real body of `hasPremiumAccess` | **Blocked by the `if (__DEV__) return true` short-circuit at L138** — under Jest `__DEV__` is true, so no test can ever reach the entitlement check |
+| 202–207 | `getOfferings` | |
+| 256–268, 286–326 | `presentPaywall` guards + `ERROR` / `NOT_PRESENTED` switch arms | |
+| 331–382 | Remaining public surface (customer-info getters / helpers at the end of the file) | |
+
+### The three stores — 10 no-coverage mutants total
+
+- `settings-store.ts` 52–56, 72–74: the bodies of `setDailyReminder`, `setStreakWarning`,
+  `setHasBeenPromptedForReminder`, and the rehydration error handler. **Three of the
+  store's six setters are never called by any test.**
+- `user-store.ts` 26, 39–40: `removeItemForStorage`, and the `updateUser` merge body
+  (`state.user ? { ...state.user, ...userData } : null`) — `updateUser` is never invoked.
+- `scheduled-quests-store.ts` 50: `removeItemForStorage`. That is the *only* unreached
+  line in the module, which is why it scored 70%.
+
+---
+
+## 4. Triage of the 230 survivors
+
+Every surviving mutant is in exactly one bucket. Arithmetic first, so the counts can be
+checked:
+
+| Module | Survivors | Real gap | Equivalent | Don't care |
+| --- | ---: | ---: | ---: | ---: |
+| `quest-timer.ts` | 136 | 100 | 7 | 29 |
+| `revenuecat-service.ts` | 48 | 32 | 0 | 16 |
+| `scheduled-quests-store.ts` | 13 | 13 | 0 | 0 |
+| `settings-store.ts` | 17 | 13 | 0 | 4 |
+| `user-store.ts` | 16 | 8 | 0 | 8 |
+| **Total** | **230** | **166** | **7** | **57** |
+
+**166 + 7 + 57 = 230.** ✓ (Per-module: 136 + 48 + 13 + 17 + 16 = 230. ✓)
+
+### Classification rules used
+
+So the next reader can check the judgement rather than trust it:
+
+1. **Real gap** — a test could kill this mutant, and the behavior it changes is
+   behavior a user or an operator would notice. Default bucket.
+2. **Equivalent** — the mutant is semantically identical to the original *for every
+   input the declared types permit*, so no test can ever kill it. Each one below carries
+   a one-line proof. "Hard to test" is never a reason to land here; only 7 of 230
+   qualified.
+3. **Don't care** — the mutated expression's entire observable effect is a
+   `console.log` / `console.error` message, or a `__DEV__`-only affordance that is not
+   part of a shipped build. These are real behavior changes, but asserting on log
+   strings is worse than not asserting at all. Where a "don't care" cluster suggests the
+   code should be deleted rather than tested, that is noted.
+
+Note on the `__DEV__` rule: mutants inside a `__DEV__` body (dev log level, test-mode
+simulation) are *don't care*. Mutants on a `__DEV__` **guard** that changes what
+production returns are *real gap* — see `revenuecat-service.ts:138`.
+
+---
+
+### 4.1 `src/store/settings-store.ts` — 17 survivors (13 real gap, 0 equivalent, 4 don't care)
+
+Existing test: `src/store/settings-store.test.ts` (31 lines) covers only `narratorVoice`
+and `onboardingSoundEnabled`. Every other field is untouched.
+
+#### Real gap (13)
+
+| Line | Mutation | What breaks unnoticed | What a test must assert to kill it |
+| --- | --- | --- | --- |
+| 36 | `getItemForStorage` body → `{}` | Persisted settings never load; store always starts at defaults | With `getItem` mocked to return a JSON blob, assert the rehydrated store has the persisted values |
+| 38 | `value ?? null` → `value && null` | Same: a stored value is discarded and read back as `null` | Same test as L36 — it must use a **non-empty** stored value |
+| 44 | `dailyReminder: {enabled:false,time:null}` → `{}` | Default reminder object loses both fields | `expect(getState().dailyReminder).toEqual({ enabled: false, time: null })` |
+| 45 | `enabled: false` → `true` | **Daily reminders default to ON**, scheduling notifications for users who never opted in | Assert `dailyReminder.enabled === false` on a fresh store |
+| **48** | `streakWarning: {...}` → `{}` | Streak-warning default loses `enabled` *and* `time` | `expect(getState().streakWarning).toEqual({ enabled: true, time: { hour: 18, minute: 0 } })` |
+| **49** | `enabled: true` → `false` | Streak warnings default OFF — the feature silently stops shipping to new users | Assert `streakWarning.enabled === true` on a fresh store |
+| **50** | `time: {hour:18,minute:0}` → `{}` | The 18:00 send time disappears | Assert the exact `{ hour: 18, minute: 0 }` object |
+| 52 | `setDailyReminder` → `() => undefined` | Setter is a no-op; the user's reminder choice is silently dropped | Call `setDailyReminder({enabled:true,time:{hour:7,minute:30}})`, assert the state changed |
+| 53 | `setStreakWarning` → `() => undefined` | Setter is a no-op | Call `setStreakWarning(...)`, assert the state changed |
+| 54 | `hasBeenPromptedForReminder: false` → `true` | The reminder prompt is suppressed for every new user — the prompt never shows | Assert it defaults to `false` |
+| 55 | `setHasBeenPromptedForReminder` → `() => undefined` | The "already prompted" flag never sets → prompt can re-fire | Call it with `true`, assert the state changed |
+| 63 | persist options object → `{}` | No storage name, no storage adapter — settings stop persisting entirely | Assert `setItem` is called with key `'unquest-settings'` after a mutation |
+| 64 | `name: 'unquest-settings'` → `""` | **Storage key changes → every existing user's settings are orphaned on upgrade** | Same assertion as L63; pin the literal key |
+
+> **Calibration note (required by the task brief).** Lines 48–51 —
+> `streakWarning: { enabled: true, time: { hour: 18, minute: 0 } }` — are **Real gap**,
+> not "don't care". That hardcoded 18:00 is a known live user-facing problem (a fixed
+> evening send time that fires while evening questers are mid-quest; see the streak
+> warning investigation, server issue #73). A default that encodes a product decision
+> with an open bug against it is exactly the kind of value a test must pin, so that
+> changing it is a deliberate, visible act.
+
+#### Don't care (4)
+
+| Line | Mutation | Why |
+| --- | --- | --- |
+| 70 | `onRehydrateStorage` body → `{}` | Whole handler's only effect is a `console.error` |
+| 71 | inner callback body → `{}` | Same |
+| 72 | `if (error)` → `true` / `false` (2 mutants) | Only decides whether a `console.error` prints |
+
+Worth noting rather than testing: this rehydration handler **swallows hydration errors**
+after logging them. If settings hydration is ever expected to fail recoverably, that
+deserves real handling, not a test on the log line.
+
+---
+
+### 4.2 `src/store/user-store.ts` — 16 survivors (8 real gap, 0 equivalent, 8 don't care)
+
+Existing test: `src/store/user-store.test.ts` (35 lines) asserts only the **Sentry**
+side effects of `setUser` / `clearUser`. It never checks that the store itself changed.
+That single omission accounts for most of this list.
+
+#### Real gap (8)
+
+| Line | Mutation | What breaks unnoticed | What a test must assert to kill it |
+| --- | --- | --- | --- |
+| 17 | `getItemForStorage` body → `{}` | Persisted user never rehydrates → user appears logged out after restart | Mock `getItem` to return a serialised user; assert the store rehydrates it |
+| 19 | `value ?? null` → `value && null` | Same, via a discarded value | Same test, with a non-empty stored value |
+| 22 | `setItemForStorage` body → `{}` | **The user is never written to storage** — nothing persists across launches | After `setUser(...)`, assert `setItem` was called with `'user-storage'` and a payload containing the id |
+| **36** | `set({ user })` → `set({})` | **`setUser` reports to Sentry but never stores the user.** The existing test passes because it only checks Sentry | `useUserStore.getState().setUser(u); expect(getState().user).toEqual(u)` |
+| 38 | `updateUser` arrow → `() => undefined` | `updateUser` is a silent no-op; profile/feature-flag updates never land | Seed a user, call `updateUser({ email: 'x' })`, assert the merged result — and assert `updateUser` on a null user leaves it null |
+| **44** | `set({ user: null })` → `set({})` | **`clearUser` clears the Sentry user but leaves the user in the store** — logout / account-wipe leaves stale identity behind | `setUser(u); clearUser(); expect(getState().user).toBeNull()` |
+| 47 | persist options → `{}` | User state stops persisting entirely | Assert `setItem` called with `'user-storage'` |
+| 48 | `name: 'user-storage'` → `""` | **Storage key changes → every existing user is logged out on upgrade** | Pin the literal key in the same assertion |
+
+L36 and L44 are the highest-value findings in this module: two of the app's most
+consequential state transitions (sign-in and wipe) are covered by tests that check the
+observability side effect and not the state change.
+
+#### Don't care (8)
+
+| Lines | Mutation | Why |
+| --- | --- | --- |
+| 54 | `onRehydrateStorage` body → `{}`; arrow → `() => undefined` (2) | Handler's only effect is two `console.log`s |
+| 55 | `'[UserStore] Rehydrated with user:'` → `""`; `state?.user?.id` → `state.user.id` / `state?.user.id` (3) | Console-log arguments |
+| 56 | `'[UserStore] Feature flags:'` → `""`; `state?.user?.featureFlags` → non-optional (3) | Console-log arguments |
+
+These eight should be **deleted, not tested**. They log a user id to the console on every
+launch (a small PII-in-logs smell) and their only failure mode — the optional-chaining
+mutants throwing when `state` is `undefined` after a failed hydration — exists solely
+because the log exists.
+
+---
+
+### 4.3 `src/store/scheduled-quests-store.ts` — 13 survivors (13 real gap, 0 equivalent, 0 don't care)
+
+The best-scoring module (70.21%), and the one whose remaining gaps are the most
+mechanical to close. The recurring cause: **every test operates on a one-element
+array**, where several distinct implementations are indistinguishable.
+
+| Line | Mutation | What breaks unnoticed | What a test must assert to kill it |
+| --- | --- | --- | --- |
+| 36 | `myRegistrations: []` → `["Stryker was here"]` | The initial/reset registration list is not empty | After `reset()`, `expect(getState().myRegistrations).toEqual([])` |
+| 41 | `getItemForStorage` body → `{}` | Registrations never rehydrate | Mock `getItem`, assert rehydrated registrations |
+| 43 | `value ?? null` → `value && null` | Same | Same test with a non-empty stored value |
+| 46 | `setItemForStorage` body → `{}` | Registrations never persist | Assert `setItem` called with `'scheduled-quests-storage'` after a mutation |
+| 63 | `.some(...)` → `.every(...)` | With **2+** registrations, upserting an existing one appends a duplicate instead of replacing it | Seed `[a, b]`, upsert an updated `b`, assert length 2 and no duplicate id |
+| 64 | inner ternary `r.id === run.id` → `true` | With **2+** registrations, upserting one **overwrites all of them** with the incoming run | Seed `[a, b]`, upsert updated `a`, assert `b` is untouched |
+| 82 | filter predicate → `() => undefined` | `recordSettlement` drops **every** registration, not just the settled one | Seed `[a, b]`, settle `a`, assert `b` survives |
+| 82 | filter predicate → `false` | Same as above | Same test |
+| 86 | `reset: () => set(initialState)` → `() => undefined` | `reset()` is a no-op — stale registrations survive logout/wipe | Populate the store, call `reset()`, assert both `myRegistrations` and `settlements` are empty |
+| 88 | persist options → `{}` | Nothing persists | Assert `setItem` called with `'scheduled-quests-storage'` |
+| 89 | `name: 'scheduled-quests-storage'` → `""` | Storage key change orphans persisted registrations | Pin the literal key |
+| 95 | `partialize` return → `{}` | Nothing is written to storage despite persist being configured | Assert the persisted payload contains `myRegistrations` and `settlements` |
+| 95 | `partialize` arrow → `() => undefined` | Same | Same |
+
+Why the existing tests miss these: `upserts a registration without duplicating` seeds
+`[a]`, upserts `a`, then upserts `b`. On a one-element array `.some` and `.every` agree,
+and the `.map` ternary has only one element to choose between — so three different
+implementations all produce the same result. **Adding a second element to that fixture
+kills L63 and L64 at once.** Likewise `records settlements by questRunId` seeds a single
+registration and asserts the list is empty afterwards — which an implementation that
+deletes everything also satisfies.
+
+---
+
+### 4.4 `src/lib/services/revenuecat-service.ts` — 48 survivors (32 real gap, 0 equivalent, 16 don't care)
+
+Existing test: `src/lib/services/revenuecat-service.test.ts` (165 lines). It is an
+**analytics test**, not a service test: every assertion is
+`expect(posthogClient.capture).toHaveBeenCalledWith(...)`. It never asserts a return
+value, never asserts `Purchases.*` was called with the right arguments, and never
+asserts internal state (`isInitialized`, `customerInfo`). That shape explains the whole
+list below.
+
+#### Real gap (32)
+
+Grouped by the behavior that goes unchecked.
+
+**A. Initialization and the singleton — 10 mutants (L15, L22, L37 ×2, L50 ×5, L51)**
+
+| Line | Mutation | What breaks unnoticed | Test that kills it |
+| --- | --- | --- | --- |
+| 15 | `private isInitialized = false` → `true` | The service claims to be initialized before `initialize()` runs, so the `refreshCustomerInfo` / `presentPaywall` guards never fire | Assert `refreshCustomerInfo()` rejects with `'RevenueCat not initialized'` before `initialize()` |
+| 22 | `if (!RevenueCatService.instance)` → `true` | `getInstance()` returns a **new instance every call** — the singleton is broken and `isInitialized` resets per caller | `expect(RevenueCatService.getInstance()).toBe(RevenueCatService.getInstance())` |
+| 37 | guard block → `{}` (drops the `return`) | `initialize()` is no longer idempotent — re-configures the SDK on every call | Call `initialize()` twice; assert `Purchases.configure` called exactly once |
+| 37 | `if (this.isInitialized)` → `false` | Same | Same |
+| 50 | `if (Platform.OS === 'ios')` → `true` / `false` (2) | The iOS branch is taken on Android, or never taken at all | With `Platform.OS = 'ios'`, assert `Purchases.configure` called with `{ apiKey: Env.REVENUECAT_APPLE_API_KEY }`; repeat for `'android'` and the Google key |
+| 50 | `===` → `!==` | iOS gets the Google key and vice-versa | Same |
+| 50 | `'ios'` → `""` | **Neither branch matches → `Purchases.configure` is never called and IAP is dead on both platforms** | Same |
+| 50 | if-block → `{}` | iOS never configures | Same |
+| 51 | `{ apiKey: Env.REVENUECAT_APPLE_API_KEY }` → `{}` | RevenueCat configured with **no API key** | Same — assert the exact object |
+
+The L50/L51 cluster is the most consequential in this module: every one of these ships a
+build where purchases silently do not work, and nothing in CI notices.
+
+**B. Login / logout / customer-info refresh — 7 mutants (L65, L66, L76, L77, L86, L87, L91)**
+
+| Line | Mutation | What breaks unnoticed | Test that kills it |
+| --- | --- | --- | --- |
+| 65, 66 | `loginUser` body / `try` block → `{}` (2) | `loginUser` is a no-op: `Purchases.logIn` never called, `this.customerInfo` never set — entitlements stay attached to the anonymous id | `await loginUser('u1')`; assert `Purchases.logIn` called with `'u1'` |
+| 76, 77 | `logoutUser` body / `try` block → `{}` (2) | `Purchases.logOut` never called — the previous user's entitlements persist into the next session | `await logoutUser()`; assert `Purchases.logOut` called |
+| 86 | `refreshCustomerInfo` body → `{}` | Returns `undefined` instead of `CustomerInfo`; every caller silently sees no entitlements | `await expect(refreshCustomerInfo()).resolves.toEqual(mockInfo)` |
+| 87 | `if (!this.isInitialized) throw` → `false` | The "not initialized" guard never fires; calls proceed against an unconfigured SDK | Assert the rejection before `initialize()` (same test as L15) |
+| 91 | `try` block → `{}` | Returns `undefined` and never caches `customerInfo` | Same as L86, plus assert a second call reuses/refreshes as intended |
+
+**C. `hasPremiumAccess` — 10 mutants (L130, L138 ×3, L140, L144 ×4, L146)**
+
+`hasPremiumAccess` has **no test at all**, and its first statement is
+`if (__DEV__) return true`. Under Jest `__DEV__` is `true`, so even an incidental call
+would return early and never reach the entitlement logic (which is why L150–198 is
+no-coverage).
+
+| Line | Mutation | What breaks unnoticed | Test that kills it |
+| --- | --- | --- | --- |
+| 130 | method body → `{}` | `hasPremiumAccess()` resolves `undefined` — every premium gate reads falsy | Any assertion on the return value |
+| 138 | `if (__DEV__)` → `true` | **Premium granted to every user in production** | Stub `global.__DEV__ = false` and assert the entitlement path is consulted |
+| 138 | `if (__DEV__)` → `false`; block → `{}` (2) | The dev override disappears | With `__DEV__ = true`, assert it resolves `true` without touching `Purchases` |
+| 140 | `return true` → `false` | Dev builds lose premium; more importantly the return value is unasserted anywhere | Same |
+| 144 | `if (!this.isInitialized)` → `this.isInitialized` / `true` / `false`; block → `{}` (4) | The uninitialized short-circuit inverts — an unconfigured SDK reports premium, or a configured one reports none | With `__DEV__ = false` and no `initialize()`, assert it resolves `false` |
+| 146 | `return false` → `true` | **Uninitialized SDK reports the user as premium** | Same |
+
+Note the structural finding: the `__DEV__` override at L138 makes the entire real
+entitlement path untestable *by construction*. Any test worth writing here must first
+control `__DEV__`.
+
+**D. Purchase / restore / paywall error paths and return values — 5 mutants (L227, L234, L258, L285, L299)**
+
+| Line | Mutation | What breaks unnoticed | Test that kills it |
+| --- | --- | --- | --- |
+| 227 | `error?.userCancelled` → `error.userCancelled` | A rejection with a nullish value throws a `TypeError` out of the catch block, masking the real failure | `mockRejectedValue(undefined)`; assert `purchase_failed` is still captured and the original rejection propagates |
+| 234 | `error?.code` → `error.code` | Same, in the `purchase_failed` payload | Same |
+| 258 | `if (!this.isInitialized)` → `false` | `presentPaywall` proceeds on an unconfigured SDK instead of returning `false` | Assert `presentPaywall()` resolves `false` and never calls `RevenueCatUI.presentPaywall` before `initialize()` |
+| 285 | `return true` (PURCHASED arm) → `false` | **A successful purchase reports failure to the caller**, so the UI never unlocks premium | `await expect(presentPaywall('settings')).resolves.toBe(true)` |
+| 299 | `return false` (CANCELLED arm) → `true` | **A cancelled paywall reports success**, unlocking premium for free | `await expect(presentPaywall('settings')).resolves.toBe(false)` |
+
+L285 and L299 are one-line fixes to the two existing paywall tests: those tests already
+drive the PURCHASED and CANCELLED paths and simply throw the return value away.
+
+#### Don't care (16)
+
+| Lines | Mutation | Why |
+| --- | --- | --- |
+| 38, 57, 69, 79, 237, 251, 275, 298 | `console.log` / `console.error` message strings → `""` (8) | Log text only |
+| 131 (×2) | `'[RevenueCat] Checking premium access...'` → `""`; its payload object → `{}` (2) | Log arguments only |
+| 139, 145 | Dev/uninitialized log strings → `""` (2) | Log text only |
+| 44 (×3) | `if (__DEV__) Purchases.setLogLevel(VERBOSE)` → `true` / `false` / `{}` | Sets SDK log verbosity in dev builds only; no shipped behavior |
+| 264 | `if (this.testModeEnabled && __DEV__)` → `false` | Disables a `__DEV__`-only purchase simulation shortcut; `testModeEnabled` can only be set by `enableTestMode()`, which is itself `__DEV__`-gated |
+
+---
+
+### 4.5 `src/lib/services/quest-timer.ts` — 136 survivors (100 real gap, 7 equivalent, 29 don't care)
+
+Existing test: `src/lib/services/quest-timer.test.ts` (517 lines, 13 tests). The two
+patterns that produce nearly all 136 survivors:
+
+1. **Assert-the-call, ignore-the-payload.** e.g. the H1 test asserts
+   `OneSignal.LiveActivities.startDefault` was called and checks only the *id* argument —
+   so every mutation of the attributes/content objects survives.
+2. **Assert-nothing-threw.** Both `onPhoneUnlocked` tests are literally
+   `await expect(QuestTimer.onPhoneUnlocked()).resolves.not.toThrow()`, with a comment
+   saying "the test passes if no errors are thrown". An **empty method body also does not
+   throw**, which is exactly why `L600 BlockStatement → {}` survives. The test named
+   *"marks quest as failed locally when phone is unlocked during quest"* asserts nothing
+   about failing a quest.
+
+#### Real gap (100), by region
+
+**A. Storage helpers — 2 mutants**
+
+| Line | Mutation | Consequence | Test that kills it |
+| --- | --- | --- | --- |
+| 39 | `parseIntSafe` body → `{}` | Returns `undefined` instead of a parsed start time | Export the helper (or drive it via `loadQuestData`) and assert a stored `'1700000000000'` round-trips to a number |
+| 40 | `if (value && typeof value === 'string')` → `false` | **`parseIntSafe` always returns `null` → a restored quest has no start time and is treated as never started** | Mock `getItem('QUEST_TIMER_START_TIME')` to a numeric string, call `loadQuestData` via `onPhoneLocked`, assert the restored start time is used |
+
+**B. `saveQuestData` (L61–88) — 11 mutants**
+
+No test asserts what gets written to MMKV. All of these silently break quest restoration
+after an app kill.
+
+| Line | Mutation | Consequence |
+| --- | --- | --- |
+| 62 | `if (this.questTemplate)` → `true` | Persists `"null"` as the template when there is no quest |
+| 66 | `if (this.questStartTime)` → `false`; block → `{}` (2) | Start time never persisted → restored quest restarts from zero |
+| 67 | `'QUEST_TIMER_START_TIME'` → `""` | Start time written to the wrong key → lost |
+| 71 | `if (this.oneSignalActivityId)` → `true` / `false`; block → `{}` (3) | Activity id written when null / never written → the Live Activity card cannot be dismissed |
+| 72 | `'ONESIGNAL_ACTIVITY_ID'` → `""` | Activity id lost |
+| 79 | `if (this.questRunId)` → `true` | Writes a null run id |
+| 81 | else-block → `{}` | Stale `QUEST_RUN_ID` is never removed → a new quest can attach to a dead run |
+| 82 | `'QUEST_RUN_ID'` → `""` | Run id lost |
+
+**Test that kills the cluster:** after `prepareQuest(...)` + `onPhoneLocked()`, assert
+`setItem` was called with each of `'QUEST_TIMER_TEMPLATE'`, `'QUEST_TIMER_START_TIME'`,
+`'ONESIGNAL_ACTIVITY_ID'`, `'QUEST_RUN_ID'` and the expected values; and in a second case
+with a null activity id, assert `removeItem('ONESIGNAL_ACTIVITY_ID')`. (`stopQuest`
+already has the mirror-image assertions on `removeItem` — copy that style.)
+
+**C. `loadQuestData` (L91–131) — 15 mutants**
+
+| Line | Mutation | Consequence |
+| --- | --- | --- |
+| 91, 92 | method body / `try` block → `{}` (2) | **Restoration is a complete no-op** — a quest never survives an app restart |
+| 94, 100, 104 | storage keys `'QUEST_TIMER_TEMPLATE'` / `'QUEST_TIMER_START_TIME'` / `'ONESIGNAL_ACTIVITY_ID'` → `""` (3) | Reads the wrong key → nothing restores |
+| 95 | `if (templateJson)` → `true` / `false`; block → `{}` (3) | Template never restored, or `parseJson(null)` nulls it out |
+| 118 | `if (this.oneSignalActivityId)` → `true` / `false`; block → `{}` (3) | The restored activity id is never pushed into the quest store → the UI loses the Live Activity handle |
+| 120 | `if (typeof store.setLiveActivityId === 'function')` → `false`; `!==`; `'function'` → `""`; block → `{}` (4) | `setLiveActivityId` is never called on restore |
+
+**Test that kills the cluster:** seed `getItem` with all four keys, invoke restoration,
+then assert (a) the template/start-time/run-id are restored, and (b)
+`useQuestStore.getState().setLiveActivityId` was called with the stored activity id.
+
+**D. `prepareQuest` — 27 mutants**
+
+| Line | Mutation | Consequence | Test that kills it |
+| --- | --- | --- | --- |
+| 160 | `if (notificationsEnabled)` → `true` / `false`; block → `{}` (3) | `clearAllNotifications()` is called when notifications are disabled, or never called — stale quest notifications survive into the new quest | Mock `areNotificationsEnabled` both ways; assert `clearAllNotifications` called / not called |
+| 181 | `&&` → `\|\|` | **Every `mode: 'custom'` quest throws "Cooperative quest must have an existing quest run ID"** — custom quests stop working entirely | `prepareQuest({ mode: 'custom', category: 'fitness', ... })` must resolve and call `createQuestRun` |
+| 181 | `mode === 'custom'` → `true` / `!==`; `'custom'` → `""` (4) | The custom+cooperative discriminator misfires: a cooperative custom quest silently creates a solo run, or a solo one throws | `prepareQuest({ mode:'custom', category:'cooperative' })` **must throw**; `{ mode:'custom', category:'fitness' }` **must not** |
+| 216 | `if (questRun.invitationId && questRun.participants)` → `\|\|` / `true` / `false` (3) | Cooperative run data is written to the store for a solo run, or never written for a coop run | Have `createQuestRun` resolve with and without `invitationId`/`participants`; assert `setCooperativeQuestRun` called exactly in the coop case |
+| 264 | pending `attributes` object → `{}` | Live Activity card starts with **no title/description** | Assert the 2nd argument of `startDefault` equals `{ title: 'Quest Ready', description: 'Lock your phone to begin your quest' }` |
+| 268 | pending `pendingContent` object → `{}` | Card starts with no duration and no status | Assert the 3rd argument equals `{ durationMinutes, status: 'pending' }` |
+| 270 | `status: 'pending'` → `""` | **The card renders in the wrong state** (this is the same class of defect as the historical "QUEST COMPLETE" Live Activity bug) | Same assertion |
+| 278 | `if (typeof store.setLiveActivityId === 'function')` → `false`; `!==`; `'function'` → `""`; block → `{}` (4) | The freshly minted activity id never reaches the quest store | Assert `setLiveActivityId` called with the same id passed to `startDefault` |
+| 294 | `Platform.OS === 'ios'` → `true` | On Android, `prepareQuest` calls `updatePhoneLockStatus` for a live activity that does not exist | With `Platform.OS = 'android'`, assert `updatePhoneLockStatus` is **not** called during prepare |
+| 316 | `taskIcon: { name, type }` → `{}` | `BackgroundService.start` gets no icon — Android foreground service fails to start | Assert the options object passed to `BackgroundService.start` |
+| 317, 318 | `'ic_launcher'` / `'mipmap'` → `""` (2) | Same | Same |
+| 321 | `foregroundServiceType: ['specialUse']` → `[]` | **Android 14+ rejects a foreground service with no declared type** — the background timer dies on modern Android | Same |
+| 331 | `('recap' in t ? t.recap : t.title) \|\| 'Focus...'` → `true` / `false` / `&&`; `'recap'` → `""` (4) | The Android persistent notification shows the wrong (or empty) quest description | Assert `options.parameters.questDescription` for a template with `recap` and one without |
+
+**E. `onPhoneLocked` — 34 mutants**
+
+| Line | Mutation | Consequence | Test that kills it |
+| --- | --- | --- | --- |
+| 350 | duplicate-lock guard block → `{}` (drops the `return`); `if (this.isPhoneLocked)` → `false` (2) | Duplicate lock events fall through and re-run the whole start sequence | The existing *"should handle duplicate phone lock calls"* test is vacuous — it only asserts `updatePhoneLockStatus` was not called, which a second guard at L358 already prevents. Rewrite it: prepare a quest, lock, lock again, assert `startDefault` / `updatePhoneLockStatus` / `saveQuestData` side effects happened **exactly once** |
+| 355 | `this.isPhoneLocked = true` → `false` | The lock flag never sets, so the 500 ms starter at L559 bails and the quest never starts | Assert the solo quest starts after the timer runs (see G below) |
+| 358 | `if (this.questTemplate && !this.questStartTime)` → `true`; `&&` → `\|\|` (2) | Lock handling runs with no template, or **re-stamps `questStartTime` on an already-running quest** (resetting elapsed time to zero) | Lock twice with `isPhoneLocked` reset in between; assert `questStartTime` did not change |
+| 362 | `if (Platform.OS === 'ios')` → `true` / `false` / `!==`; `'ios'` → `""`; block → `{}` (5) | The Live Activity update on lock is skipped, or attempted on Android | Assert `startDefault` is called on iOS and not on Android |
+| 364 | `this.oneSignalActivityId \|\| uuidv4()` → `&&` | A **new** activity id is minted on lock instead of reusing the prepare-time id — the server's stale-activity sweep then dismisses the live card (this is the H1 defect class) | Assert the id used at lock equals the id minted at prepare |
+| 366 | active `attributes` object → `{}` | Live Activity loses title/description at quest start | Assert the 2nd argument of the lock-time `startDefault` |
+| 369 | `'description' in this.questTemplate` → `""` | Always falls back to `'Focus on your quest'`, discarding the quest's own description | Assert the description for a template that has one |
+| 371 | `'Focus on your quest'` → `""` | Empty description for templates without one | Assert the fallback |
+| 373 | `updatedContent` object → `{}` | Card has no duration/status at start | Assert the 3rd argument |
+| 375 | `status: 'active'` → `""` | **Card never flips from pending to active** — the visible symptom users report as a stuck card | Assert `status: 'active'` |
+| 395 | `cooperativeQuestRun && cooperativeQuestRun.id === this.questRunId` → `true` / `false` (2) | Solo quests are treated as cooperative (so they never start) or coop quests as solo (so they double-start) | Two tests: solo lock ⇒ `startQuest` called; coop lock ⇒ `startQuest` **not** called and the coop path taken |
+| 397 | `if (this.questRunId)` → `true` | Server lock-status call attempted with a null run id | Prepare with a failed `createQuestRun`, lock, assert `updatePhoneLockStatus` not called |
+| 398 | `if (isCooperativeQuest)` → `true` / `false` (2) | Coop quests use the solo endpoint and vice-versa | Same two tests as L395 |
+| 556 | `if (!isCooperativeQuest)` → `isCooperativeQuest` / `true` / `false`; block → `{}` (4) | **The solo quest never starts** (or a coop quest double-starts) | See L557 |
+| 557 | `setTimeout` callback body → `{}` | `questStore.startQuest(...)` never runs | `jest.useFakeTimers()`, lock, `jest.advanceTimersByTime(500)`, assert `startQuest` called with `{ ...template, startTime, status: 'active' }` |
+| 559 | `if (this.isPhoneLocked)` → `true` / `false` (2) | A quest starts even though the user unlocked within the 500 ms window, or never starts at all | Lock, unlock before advancing timers, advance, assert `startQuest` **not** called |
+| 577 | `Platform.OS === 'android' && BackgroundService.isRunning()` → `true` / `false` / `\|\|`; `=== 'android'` → `true` / `!==`; `'android'` → `""` (6) | `updateNotification` is called when no service is running (throws) or never called (the Android notification stays on "Lock your phone to begin") | With `Platform.OS='android'` and `isRunning()` true, assert `updateNotification` called with the in-progress title; with `isRunning()` false, assert not called |
+
+**F. `onPhoneUnlocked` — 10 mutants**
+
+| Line | Mutation | Consequence | Test that kills it |
+| --- | --- | --- | --- |
+| 600 | **whole method body → `{}`** | **Unlocking the phone does nothing at all — the quest is never failed.** Both existing tests still pass because they only assert the promise does not reject | Prepare + lock a quest, unlock, assert the quest store recorded a failure (and that `isPhoneLocked` is false) |
+| 602 | `this.isPhoneLocked = false` → `true` | The lock flag stays true after unlock; the next lock event is swallowed by the L350 guard and the 500 ms starter can fire for a quest the user abandoned | Unlock, then lock again, assert the second lock is processed |
+| 607 | `!this.questRunId \|\| !this.questStartTime \|\| !this.questTemplate` → `true` / `false`; sub-condition → `false`; `\|\|` → `&&` (×2); `!this.questRunId` → `this.questRunId`; `!this.questStartTime` → `this.questStartTime`; block → `{}` (8) | The early return inverts: either **every** unlock is ignored (quests never fail) or an unlock with no active quest proceeds into the failure path | Two tests: (a) unlock with no prepared quest ⇒ no store writes, no server calls; (b) unlock mid-quest ⇒ the failure path runs |
+
+**G. `stopQuest` — 1 mutant**
+
+| Line | Mutation | Consequence | Test that kills it |
+| --- | --- | --- | --- |
+| 1201 | `if (BackgroundService.isRunning())` → `true` | `BackgroundService.stop()` is called when no service is running | With `isRunning()` mocked false, assert `stop` is **not** called (the existing Android test only covers the `true` case) |
+
+#### Equivalent (7)
+
+Each of these is unkillable, with the proof:
+
+| Line | Mutation | Why no test can kill it |
+| --- | --- | --- |
+| 27 | `if (jsonString && typeof jsonString === 'string')` → `true` | For the declared type `string \| null \| undefined`: `JSON.parse(null)` coerces to `"null"` and returns `null` — the same value the original returns; `JSON.parse(undefined)` throws and the catch returns `null`. Identical return for every permitted input. |
+| 27 | sub-condition `typeof jsonString === 'string'` → `true` | Given the declared type, `jsonString && typeof jsonString === 'string'` is exactly `Boolean(jsonString)`. The `typeof` operand can only ever be redundant. |
+| 27 | `&&` → `\|\|` | Differs only for `''`, where the mutant enters the `try`, `JSON.parse('')` throws, and the catch returns `null` — the same value. |
+| 40 | `if (value && typeof value === 'string')` → `true` | `parseInt(null)` / `parseInt(undefined)` / `parseInt('')` all yield `NaN`, and the `!isNaN` check then returns `null` — identical to the original for every permitted input. |
+| 40 | `&&` → `\|\|` | Only `''` differs, and it reaches the same `NaN → null` result. |
+| 120 | `if (typeof store.setLiveActivityId === 'function')` → `true` | `useQuestStore` always defines `setLiveActivityId`, so the guard is always true. The `else` branch (a `console.warn`) is dead code. |
+| 278 | same guard in `prepareQuest` → `true` | Same reason. |
+
+The three `L27` / two `L40` entries also carry a design note: **the `typeof x === 'string'`
+operand in both helpers is unreachable defensive code** given the TypeScript signature.
+Deleting it is a better outcome than testing it.
+
+#### Don't care (29)
+
+| Lines | Mutation | Why |
+| --- | --- | --- |
+| 109 (×2), 110 (×2), 111 | `'[QuestTimer] Loaded quest data:'` → `""`, its payload object → `{}`, `!!this.questTemplate` flips, `this.questTemplate?.id` → non-optional | All inside one `console.log` |
+| 149 (×2), 175, 188, 197, 199, 200, 210 | Log messages and log payload objects in `prepareQuest` | Log-only |
+| 249, 250 | `catch` block of `createQuestRun` → `{}`; its message string → `""` | The catch body is a `console.error` plus a comment; the "continue anyway" behavior is the *absence* of a rethrow and is already covered |
+| 320, 322, 325 | `color: '#77c5bf'` → `""`, `progressBar` object → `{}`, `indeterminate: true` → `false` | Cosmetics of the Android notification |
+| 347, 351, 360, 378, 381, 388 | Log message strings in `onPhoneLocked` | Log-only |
+| 539, 545 | Log message strings in the solo lock-status branch | Log-only |
+| 601, 608 | `'Phone unlocked'`, `'No active quest found on unlock.'` | Log-only |
+| 1200 | `'Stopping quest timer and background service.'` | Log-only |
+
+---
+
+## 5. Prioritized follow-up list
+
+**No tests were written as part of this baseline.** This is the work list for the next
+session, ordered by risk — the damage a real bug in that code would do, weighted by how
+convincingly the current tests pretend to cover it. Start at #1.
+
+Every item below is a **Real gap**. Nothing from the Equivalent or Don't-care buckets is
+worth work; if anything, four of the don't-care clusters argue for *deleting* code
+(the `user-store` rehydration `console.log`s, and the redundant `typeof x === 'string'`
+operands in `quest-timer`'s two parse helpers).
+
+| # | Item | Why it ranks here |
+| --- | --- | --- |
+| 1 | **`quest-timer.ts` `onPhoneUnlocked` (L600, L602, L607 ×8)** — assert the quest is actually failed on unlock, and that an unlock with no active quest is a no-op. | The whole method body can be deleted and the suite stays green. A test named *"marks quest as failed locally when phone is unlocked during quest"* asserts only that nothing threw. Failing a quest on unlock is the app's core rule; it is currently unprotected **and** carries a test that claims otherwise. |
+| 2 | **`quest-timer.ts` solo quest start (L556 ×4, L557, L559 ×2, L355, L395 ×2, L398 ×2)** — `jest.useFakeTimers()`, lock, advance 500 ms, assert `questStore.startQuest` is called with `status: 'active'`; and that unlocking inside the window cancels it. | `startQuest` — the line that makes a quest exist — is in the no-coverage set (L559–564). The solo/cooperative discriminator that routes into it is unasserted. If this breaks, the timer runs and nothing starts. |
+| 3 | **`quest-timer.ts` `prepareQuest` mode discriminator (L181 ×5)** — a `mode:'custom'` quest with a non-cooperative category must prepare normally; `mode:'custom'` + `category:'cooperative'` must throw. | One operator flip (`&&` → `\|\|`) makes **every custom quest** throw "Cooperative quest must have an existing quest run ID". Custom quests are a shipped feature with zero tests through this branch. |
+| 4 | **`revenuecat-service.ts` `initialize` platform keys (L50 ×5, L51, L37 ×2, L15, L22)** — assert `Purchases.configure` gets the Apple key on iOS and the Google key on Android, exactly once. | Six independent mutations here each ship a build where in-app purchases silently do not work. This is the only revenue path in the app and nothing in CI touches it. |
+| 5 | **`revenuecat-service.ts` `presentPaywall` return values (L285, L299, L258)** — assert `resolves.toBe(true)` for PURCHASED and `toBe(false)` for CANCELLED. | Cheapest high-value fix in the document: the two existing paywall tests already drive both paths and discard the return value. Two added lines. A flipped return either unlocks premium for a cancelled paywall or fails to unlock a paid one. |
+| 6 | **`user-store.ts` `setUser` / `clearUser` state (L36, L44, L38)** — assert the store contains the user after `setUser`, is `null` after `clearUser`, and that `updateUser` merges. | Both existing tests assert only the Sentry side effect. `set({ user })` can be replaced with `set({})` and they pass. Sign-in and account-wipe are exactly the transitions the provisional-auth work depends on. |
+| 7 | **`quest-timer.ts` persistence round-trip (`saveQuestData` 11 + `loadQuestData` 15 = 26 mutants)** — assert the four MMKV keys are written with the right values, cleared when null, and read back on restore. | Every storage-key literal can be blanked without a test noticing. Symptom in production is a quest that vanishes when the OS kills the app — hard to reproduce, easy to prevent. |
+| 8 | **`settings-store.ts` defaults and setters (L44, L45, L48–L50, L52–L55)** — pin `dailyReminder`, `streakWarning` (`enabled: true`, `{ hour: 18, minute: 0 }`), `hasBeenPromptedForReminder: false`, and assert each setter mutates state. | The 18:00 streak-warning default is a **known live user-facing problem** (fixed evening send time; server issue #73). Whatever it changes to, it must change deliberately — an untested default is a silent one. Three of six setters are also never invoked by any test. |
+| 9 | **`scheduled-quests-store.ts` two-element fixtures (L63, L64, L82 ×2)** — seed `[a, b]` instead of `[a]` in the upsert and settlement tests. | Highest kills-per-keystroke in the sweep: changing one fixture from one element to two kills four survivors, because `.some`/`.every` and the map ternary are indistinguishable on a single-element array. |
+| 10 | **`quest-timer.ts` Live Activity payloads (L264, L268, L270, L364, L366, L369, L371, L373, L375)** — assert the `attributes` and `content` arguments of both `startDefault` calls, not just the id. | Wrong Live Activity content is a defect class this project has already shipped once (the "QUEST COMPLETE" card). L364 in particular reintroduces the stale-id bug that H1 was written to fix — and the H1 test does not catch it. |
+| 11 | **`quest-timer.ts` Android background service (L316, L317, L318, L321, L331 ×4, L577 ×6)** — assert the options passed to `BackgroundService.start`, and the `updateNotification` guard. | `foregroundServiceType: ['specialUse']` → `[]` kills the background timer on Android 14+. The existing Android test asserts only that `start` was called. |
+| 12 | **`quest-timer.ts` restore-side store wiring (L118 ×3, L120 ×4, L278 ×4, L294)** — assert `setLiveActivityId` is called with the restored/minted id, and that prepare does not register a live activity on Android. | Loses the handle needed to dismiss the Live Activity card; platform leakage calls iOS-only APIs on Android. |
+| 13 | **`revenuecat-service.ts` `hasPremiumAccess` (L130, L138 ×3, L140, L144 ×4, L146)** — stub `global.__DEV__ = false` and assert the real entitlement path; with `__DEV__ = true` assert the override. | The `if (__DEV__) return true` short-circuit makes 49 lines of entitlement logic unreachable by any test *by construction*. Ranked below #4 only because a mistake here is dev-visible sooner. |
+| 14 | **`revenuecat-service.ts` session lifecycle (L65, L66, L76, L77, L86, L87, L91) and error null-safety (L227, L234)** — assert `Purchases.logIn`/`logOut` are called, that `refreshCustomerInfo` returns and caches, and that a nullish rejection does not throw out of the catch. | Entitlements attached to the wrong app-user id survive across accounts. Lower priority than #4 because failures here are visible in support reports rather than silent. |
+| 15 | **Persist-key pinning across all three stores (`settings-store` L63/L64, `user-store` L47/L48, `scheduled-quests-store` L88/L89/L95 ×2)** — assert `setItem` is called with the literal storage key and a payload containing the expected fields. | Blanking a persist key orphans every existing user's data on upgrade. Cheap, mechanical, and one shared test shape covers all three stores. |
+| 16 | **`quest-timer.ts` notification clearing and misc guards (L160 ×3, L216 ×3, L39, L40, L62, L1201)** | Remaining real gaps; individually low blast radius. |
+
+### Cheapest wins, if time is short
+
+- #9 — one fixture change, 4 mutants.
+- #5 — two assertion lines added to existing tests, 3 mutants.
+- #6 — three assertions in an existing 35-line test file, 3 mutants.
+- #15 — one test shape reused three times, 8 mutants.
+
+### Re-running
+
+```bash
+pnpm test:mutate:audit          # full sweep over the configured modules (~30 min)
+pnpm test:mutate -- <glob>      # single module
+```
+
+Config: `stryker.config.mjs`. Do not add `inPlace: true`. When re-running after fixes,
+compare **covered score** module-by-module against §2 — the total score will move for
+reasons (new tests reaching new code) that have nothing to do with assertion quality.

--- a/docs/superpowers/plans/2026-08-07-mutation-baseline.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-baseline.md
@@ -1,5 +1,11 @@
 # Mutation testing baseline — 2026-08-07
 
+> **STATUS 2026-08-09: the follow-up work in §5 is DONE.** All 16 prioritized items
+> are implemented, plus a second pass over what the first pass left behind. Results
+> and what deliberately went unfixed are in §6 at the bottom. Everything above §6 is
+> preserved as the original baseline — read it for the *reasoning*, not as a to-do
+> list.
+
 Stryker pilot sweep over five modules. This document is the **handoff artifact**: it
 records what the sweep found, classifies every surviving mutant, and ends with a
 prioritized list of tests worth writing. It assumes no context from the session that
@@ -604,3 +610,107 @@ reasons (new tests reaching new code) that have nothing to do with assertion qua
 header above. If you want a fresh JSON dump, add `'json'` to the `reporters` array in
 `stryker.config.mjs` before running, or re-extract it from the new `index.html`'s
 embedded `app.report` object.
+
+---
+
+## 6. Results — 2026-08-09
+
+All 16 items in §5 are implemented, plus a second pass over the survivors the
+first pass left behind. Branch `chore/mutation-testing-pilot`, 11 further
+commits, still no PR.
+
+### Scores
+
+Verified by a complete, clean audit (1107 mutants, 0 timeouts, 0 errors) taken
+at commit `f71242b`. The two later test commits add ~10 assertions and can only
+have improved these numbers; they are not reflected below. Full suite green
+throughout: 185 suites / 2231 tests, `tsc --noEmit` clean.
+
+| Module | total% | covered% |
+| --- | --- | --- |
+| `scheduled-quests-store.ts` | 70.21 → 97.87 | 71.74 → **100.00** |
+| `user-store.ts` | 25.93 → 94.74 | 30.43 → **100.00** |
+| `settings-store.ts` | 29.03 → 80.65 | 34.62 → 86.21 |
+| `revenuecat-service.ts` | 18.25 → 57.41 | 50.00 → 72.95 |
+| `quest-timer.ts` | 10.04 → 42.17 | 36.15 → 72.25 |
+| **All files** | 15.33 → **50.14** | 43.07 → **75.41** |
+
+Killed 174 → 555. No-coverage 731 → 371. Survived 230 → 181.
+
+**Compare covered score, not total.** The mutant population fell 1135 → 1107
+because dead defensive code was deleted, so the two totals are not measuring the
+same denominator.
+
+**Survivor count is a bad progress metric.** It barely moved while kills
+tripled, because reaching previously-unexecuted code *converts* a no-coverage
+mutant into a survivor. Judge by killed and no-coverage.
+
+### The finding that mattered most, and that Stryker could not report
+
+`quest-timer.test.ts` mocked the quest store with `activeQuest: { id: … }`. The
+solo-start path is guarded by `if (!questStore.activeQuest && …)`, so
+`questStore.startQuest` — the line that makes a quest exist — was **structurally
+unreachable in every test**, and appeared in the *no-coverage* bucket rather
+than as a survivor. §4 read that as "the tests do not reach this code". The
+truth was that a single fixture default suppressed it.
+
+Stryker does not mutate fixtures, so it cannot surface this class at all. When a
+region reads as no-coverage despite tests that plainly call into it, suspect the
+mock's default state before believing the code is unreached.
+
+Second instance of the same shape: `Env.*` is `undefined` in every Jest test
+repo-wide (`Env = Constants.expoConfig?.extra ?? {}`, and Jest populates no
+`extra`). The iOS and Android `Purchases.configure` branches were therefore
+indistinguishable — both configured `{ apiKey: undefined }`. The fix needs an
+`expo-constants` stub *plus* a guard test asserting the two keys differ, or the
+branch tests silently go vacuous again the next time someone edits the stub.
+
+### Source deleted rather than tested
+
+- `parseJson` / `parseIntSafe`: the `typeof x === 'string'` operands. The
+  signatures already guarantee it — unkillable by construction (§4.5).
+- Both `typeof store.setLiveActivityId === 'function'` guards. The store always
+  defines it, so the `else` was dead code.
+- `user-store`'s `onRehydrateStorage`. Its only effect was logging a user id and
+  feature flags to the console on every launch.
+
+### Deliberately left alive
+
+- **`settings-store`'s last 4 survivors** sit in an `onRehydrateStorage` handler
+  whose only effect is a `console.error`. Unlike the user-store logs, an error
+  log on hydration failure has diagnostic value. 86.21% is this module's
+  practical ceiling.
+- **`onPhoneLocked` updates the Android notification twice for cooperative
+  quests** — once in the activation branch, once at the end — with identical
+  payloads. The only way to kill that block is `toHaveBeenCalledTimes(2)`, which
+  would pin the duplication in place and make deduplicating it a test failure.
+  **This is a production defect to ticket, not a test gap.**
+
+### Config changes, and a warning about run time
+
+`stryker.config.mjs` gained a `json` reporter (`reports/mutation/report.json` —
+query it with `node -e`, never read the 2.1 MB HTML into an agent context),
+`dryRunTimeoutMinutes: 20`, `timeoutMS: 10000`, and `concurrency: 8`.
+
+The audit now takes **50+ minutes**, not the original 30, and can take much
+longer. Three causes, all understood:
+
+1. A covered mutant costs a jest run; a no-coverage mutant is free. Halving
+   no-coverage roughly doubles the work.
+2. **The new tests reach unbounded loops in production code** — `presentPaywall`
+   re-invokes itself after enabling test mode, and the cooperative lock-status
+   ladder retries on a timer. Mutants that make either unbounded hang until
+   Stryker's timeout. These are legitimate kills, but each costs the full
+   timeout, and the effective timeout is `dryRunNetTime × 1.5 + timeoutMS`, so
+   trimming `timeoutMS` alone barely helps. One run logged 70 hangs and ran
+   over four hours.
+3. At `concurrency: 12` the box saturated and `login-form.test.tsx` (a
+   pre-existing slow suite, ~24s) blew Jest's 5s per-test default *during the
+   dry run*, aborting the whole audit. Hence 8.
+
+**Report the TimedOut column alongside the score** — Stryker counts a timeout as
+a kill.
+
+`{ advanceTimers: true }` was tried on the quest-timer fake clock to stop the
+hangs. It does not work — the loops are in production code, not the clock — and
+it introduces nondeterminism under parallel load. Reverted; do not retry it.

--- a/docs/superpowers/plans/2026-08-07-mutation-baseline.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-baseline.md
@@ -714,3 +714,73 @@ a kill.
 `{ advanceTimers: true }` was tried on the quest-timer fake clock to stop the
 hangs. It does not work — the loops are in production code, not the clock — and
 it introduces nondeterminism under parallel load. Reverted; do not retry it.
+
+---
+
+## 7. `backgroundTask` — 2026-08-09, second pass
+
+`quest-timer.ts` L926–1197 was the single largest untested region left in the
+audit set: **~180 no-coverage mutants in one function**, and the function is the
+loop that actually runs a quest while the phone is locked — elapsed-time maths,
+the progress notification, completion detection, teardown. No test had executed
+a line of it.
+
+### How to test it at all
+
+`BackgroundService.start` is mocked, so the task is never invoked. The tests
+pull it back off the mock:
+
+```ts
+const backgroundTask = BackgroundService.start.mock.calls[0][0];
+await backgroundTask(taskData);
+```
+
+The loop is `while (BackgroundService.isRunning())`, so `isRunning` is the exit
+control. **Every test must either drive the loop to an explicit `break` or flip
+`isRunning` false.** Otherwise the loop's
+`await new Promise(r => setTimeout(r, updateInterval))` never resolves under
+fake timers and the test hangs rather than failing. For a test that needs
+exactly one iteration:
+
+```ts
+let iterations = 0;
+BackgroundService.isRunning.mockImplementation(() => iterations++ < 1);
+const running = backgroundTask(taskDataFor(15));
+await jest.advanceTimersByTimeAsync(9000); // the loop's update interval
+await running;
+```
+
+Covered: the no-task-data guard, elapsed-progress maths, completion at the
+duration boundary (Live Activity + teardown), the Android-only completion
+notification, unlock detection, the stuck-in-pending cooperative completion, and
+both cooperative server-activation outcomes.
+
+Progress is asserted at **50%**, deliberately — 0 and 100 are both values that
+several mutants of the percentage expression also produce, so asserting at
+either end would have been vacuous.
+
+### Verified by mutation, not by a green run
+
+| Mutation | Tests failed (was 0 for all) |
+| --- | --- |
+| `backgroundTask` body emptied | 7 |
+| progress percentage `* 100` → `* 0` | 2 |
+| completion boundary `>=` → `>` | 4 |
+| `if (!taskData) return` disabled | 1 |
+
+### Re-measuring quest-timer is now impractical, and that is the finding
+
+A single-module `--mutate src/lib/services/quest-timer.ts` run reached only
+306/747 mutants in 84 minutes, with **75 timeouts** and slowing. Covering a
+`while` loop whose exit condition is a mock means every mutant that removes the
+`break`, or keeps the exit condition true, is a **genuine infinite loop** —
+correctly killed, but each one costs the full timeout, and the hung workers
+appear to starve the remaining ones.
+
+So the scores in §6 remain the last trustworthy measured figures. The
+`backgroundTask` work above is verified by the targeted mutations in the table,
+not by a fresh score.
+
+If a full number is wanted later, budget hours rather than minutes, and expect
+a large TimedOut column that Stryker will count as kills. Do not read the
+resulting score as comparable to §6 without subtracting the timeouts.

--- a/docs/superpowers/plans/2026-08-07-mutation-baseline.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-baseline.md
@@ -784,3 +784,115 @@ not by a fresh score.
 If a full number is wanted later, budget hours rather than minutes, and expect
 a large TimedOut column that Stryker will count as kills. Do not read the
 resulting score as comparable to §6 without subtracting the timeouts.
+
+---
+
+## 8. Third pass — 2026-08-10
+
+Three commits on `chore/mutation-testing-pilot`, still no PR. Full suite green
+throughout: 185 suites / 2252 passed / 3 skipped, `tsc --noEmit` clean.
+
+Targets were taken from §7's shortlist, largest first. All three were reached.
+
+### 8.1 `presentPaywall`'s catch block and its unhandled results
+
+`presentPaywall` had tests for two of its six switch arms and none for the
+catch block. That block is where a paywall failure is sorted into "this build
+is misconfigured, simulate the purchase" or "this is a real store failure,
+report it and rethrow". 11 new tests.
+
+**The recursion trap, and how to avoid paying for it.** The misconfiguration
+branch sets `testModeEnabled` and then calls `presentPaywall` again. If a test
+makes the SDK reject *every* time, then any mutation that stops
+`testModeEnabled` being set turns that retry into unbounded recursion — a
+Stryker timeout, which costs the full timeout and is one of the causes of the
+four-hour runs in §6. Rejecting **once** and resolving `'CANCELLED'` on the
+retry turns the identical mutant into an ordinary wrong-return-value failure
+that a normal assertion catches in milliseconds.
+
+This generalises: **when a production path retries, make the mock succeed on
+the retry.** It costs nothing in coverage and converts timeout-kills into
+assertion-kills.
+
+| Mutation | Tests failed (was 0 for all) |
+| --- | --- |
+| test-mode `return true` → `false` | 4 |
+| `throw error` → `return false` | 4 |
+| `if (__DEV__)` → `false` | 3 |
+| `testModeEnabled = true` → `false` | 3 |
+| `readable_error_code ===` → `!==` | 3 |
+| `if (__DEV__)` → `true` | 2 |
+| `'No offerings found'` → `''` | 2 |
+| drop the `?? error?.message` fallback | 2 |
+| RESTORED `return true` → `false` | 1 |
+| NOT_PRESENTED `return false` → `true` | 1 |
+| `default: return false` → `true` | 1 |
+
+Noted, not fixed (out of scope, dev-only): in a development build a rejection
+with no error object crashes the catch handler, because L319 reads
+`error.message?.includes(...)` — the optional chain is on `.includes`, not on
+`.message`. The original failure is replaced by a `TypeError`. Production is
+unaffected: the whole block is `__DEV__`-gated.
+
+### 8.2 The cooperative lock-report retry ladder
+
+`quest-timer.ts` L399–445. Three attempts, one second apart, to tell the
+server the phone is locked. The entire catch block was no-coverage. 2 new
+tests: one proving a failed attempt is retried after the delay, one proving
+the ladder stops at three and that **the quest still starts anyway** — the
+report is best-effort, and activation is decided by the status check that
+follows it. A phone locking in a dead spot must not lose the quest.
+
+| Mutation | Tests failed (was 0 for all) |
+| --- | --- |
+| catch block emptied | 2 |
+| `retryCount < maxRetries` → `false` | 2 |
+| `retryCount < maxRetries` → `>=` | 2 |
+| drop the `error?.response?.data` chain | 2 |
+| `retryCount < maxRetries` → `<=` | 1 |
+| `retryCount++` → `retryCount--` | 1 (by timeout — it retries forever) |
+
+**Two equivalent mutants here, confirmed and left alive.** `return true` at
+the end of a successful attempt and `return false` after the last one. The
+caller is `await sendPhoneLockStatus();` and discards the result. Flipping
+either leaves all 73 tests green, and no test could ever tell them apart.
+Do not chase these.
+
+### 8.3 The participant-rewards merge — and a third fixture finding
+
+On completion the app fetches the run from the server and merges the server's
+adjusted XP into the finished quest. This exists **twice**: once for a quest
+the store had made active, once for a quest stuck in pending because the
+500 ms starter was missed. Only the first had a test, and neither asserted
+anything about the completed-quests history. 2 new tests.
+
+Both merges rewrite that history by matching on quest id **and** stop time,
+because a repeatable quest appears in it once per run. Matching on id alone
+would overwrite an earlier run with this run's rewards. Each test seeds a
+decoy entry sharing the id but not the stop time, which is what makes both
+halves of the condition load-bearing.
+
+**The fixture finding (third of its kind — see §6).** The pending path calls
+`useQuestStore.setState(state => ({…}))`, the updater-function form. The test
+mock was a bare `jest.fn()`: it stores the function and never calls it. So
+everything inside that arrow was unreachable in **every** test, and the report
+listed it as no-coverage rather than as an untested branch. The mock now runs
+updaters against the mock store the way zustand does. All 73 pre-existing
+tests pass unchanged.
+
+Three instances of this class now: a mock's `activeQuest` default, `Env.*`
+being `undefined` repo-wide, and a `setState` mock that drops updater
+functions. **When a region reads as no-coverage despite tests that plainly
+call into it, read the mock before reading the code.**
+
+| Mutation | Tests failed (was 0 for all) |
+| --- | --- |
+| active path `q.id ===` → `!==` | 1 |
+| active path `&&` → `\|\|` | 1 |
+| active path `q.stopTime ===` → `!==` | 1 |
+| pending path `q.id ===` → `!==` | 1 |
+| pending path `&&` → `\|\|` | 1 |
+| pending path `q.stopTime ===` → `!==` | 1 |
+| `if (questRunIdFromQuest)` → `false` | 1 |
+| `participants: questRunData.participants` → `[]` | 1 |
+| keep the pre-merge quest as `recentCompletedQuest` | 1 |

--- a/docs/superpowers/plans/2026-08-07-mutation-baseline.md
+++ b/docs/superpowers/plans/2026-08-07-mutation-baseline.md
@@ -9,6 +9,14 @@ produced it.
 - Raw report: `reports/mutation/index.html` (2.1 MB — do not open it in an agent
   context; it has killed two sessions. Use `/tmp/mutation-report.json` with a targeted
   `node -e` / `jq` query instead.)
+- **`/tmp/mutation-report.json` is not reproducible.** It was hand-extracted from
+  `reports/mutation/index.html`'s embedded `app.report = {...}` JavaScript object
+  literal — open it with `node -e`, not a JSON parser, since it is a JS object literal,
+  not strict JSON. `stryker.config.mjs:19` sets `reporters: ['html', 'clear-text',
+  'progress']` with no `json` reporter, so simply re-running Stryker will **not**
+  regenerate this file. To get it back, either repeat that HTML-literal extraction
+  against a fresh `index.html`, or add `'json'` to the reporters array in
+  `stryker.config.mjs` before running.
 - Runtime: **30m38s**, 86.08 tests run per mutant on average.
 - **Do not re-run Stryker to re-read these numbers.** Everything is transcribed below.
 
@@ -157,14 +165,14 @@ checked:
 
 | Module | Survivors | Real gap | Equivalent | Don't care |
 | --- | ---: | ---: | ---: | ---: |
-| `quest-timer.ts` | 136 | 100 | 7 | 29 |
+| `quest-timer.ts` | 136 | 100 | 5 | 31 |
 | `revenuecat-service.ts` | 48 | 32 | 0 | 16 |
 | `scheduled-quests-store.ts` | 13 | 13 | 0 | 0 |
 | `settings-store.ts` | 17 | 13 | 0 | 4 |
 | `user-store.ts` | 16 | 8 | 0 | 8 |
-| **Total** | **230** | **166** | **7** | **57** |
+| **Total** | **230** | **166** | **5** | **59** |
 
-**166 + 7 + 57 = 230.** ✓ (Per-module: 136 + 48 + 13 + 17 + 16 = 230. ✓)
+**166 + 5 + 59 = 230.** ✓ (Per-module: 136 + 48 + 13 + 17 + 16 = 230. ✓)
 
 ### Classification rules used
 
@@ -174,7 +182,7 @@ So the next reader can check the judgement rather than trust it:
    behavior a user or an operator would notice. Default bucket.
 2. **Equivalent** — the mutant is semantically identical to the original *for every
    input the declared types permit*, so no test can ever kill it. Each one below carries
-   a one-line proof. "Hard to test" is never a reason to land here; only 7 of 230
+   a one-line proof. "Hard to test" is never a reason to land here; only 5 of 230
    qualified.
 3. **Don't care** — the mutated expression's entire observable effect is a
    `console.log` / `console.error` message, or a `__DEV__`-only affordance that is not
@@ -388,7 +396,7 @@ drive the PURCHASED and CANCELLED paths and simply throw the return value away.
 
 ---
 
-### 4.5 `src/lib/services/quest-timer.ts` — 136 survivors (100 real gap, 7 equivalent, 29 don't care)
+### 4.5 `src/lib/services/quest-timer.ts` — 136 survivors (100 real gap, 5 equivalent, 31 don't care)
 
 Existing test: `src/lib/services/quest-timer.test.ts` (517 lines, 13 tests). The two
 patterns that produce nearly all 136 survivors:
@@ -502,28 +510,35 @@ then assert (a) the template/start-time/run-id are restored, and (b)
 | --- | --- | --- | --- |
 | 1201 | `if (BackgroundService.isRunning())` → `true` | `BackgroundService.stop()` is called when no service is running | With `isRunning()` mocked false, assert `stop` is **not** called (the existing Android test only covers the `true` case) |
 
-#### Equivalent (7)
+#### Equivalent (5)
 
 Each of these is unkillable, with the proof:
 
 | Line | Mutation | Why no test can kill it |
 | --- | --- | --- |
-| 27 | `if (jsonString && typeof jsonString === 'string')` → `true` | For the declared type `string \| null \| undefined`: `JSON.parse(null)` coerces to `"null"` and returns `null` — the same value the original returns; `JSON.parse(undefined)` throws and the catch returns `null`. Identical return for every permitted input. |
 | 27 | sub-condition `typeof jsonString === 'string'` → `true` | Given the declared type, `jsonString && typeof jsonString === 'string'` is exactly `Boolean(jsonString)`. The `typeof` operand can only ever be redundant. |
-| 27 | `&&` → `\|\|` | Differs only for `''`, where the mutant enters the `try`, `JSON.parse('')` throws, and the catch returns `null` — the same value. |
 | 40 | `if (value && typeof value === 'string')` → `true` | `parseInt(null)` / `parseInt(undefined)` / `parseInt('')` all yield `NaN`, and the `!isNaN` check then returns `null` — identical to the original for every permitted input. |
 | 40 | `&&` → `\|\|` | Only `''` differs, and it reaches the same `NaN → null` result. |
 | 120 | `if (typeof store.setLiveActivityId === 'function')` → `true` | `useQuestStore` always defines `setLiveActivityId`, so the guard is always true. The `else` branch (a `console.warn`) is dead code. |
 | 278 | same guard in `prepareQuest` → `true` | Same reason. |
 
-The three `L27` / two `L40` entries also carry a design note: **the `typeof x === 'string'`
-operand in both helpers is unreachable defensive code** given the TypeScript signature.
-Deleting it is a better outcome than testing it.
+> **Reclassified from Equivalent to Don't care (see §4.5 Don't care table below):** the
+> full-condition mutant `if (jsonString && typeof jsonString === 'string')` → `true` at
+> L27, and the `&&` → `\|\|` mutant at L27. Neither is strictly equivalent — for input
+> `''` both mutants enter the `try` block, `JSON.parse('')` throws, and
+> `console.error('Failed to parse JSON from storage:')` fires, which the original never
+> does. The return value (`null`) is unchanged, so the only difference is a log line —
+> exactly the "don't care" rule, not equivalence.
 
-#### Don't care (29)
+The one `L27` / two `L40` entries above also carry a design note: **the
+`typeof x === 'string'` operand in both helpers is unreachable defensive code** given the
+TypeScript signature. Deleting it is a better outcome than testing it.
+
+#### Don't care (31)
 
 | Lines | Mutation | Why |
 | --- | --- | --- |
+| 27 (×2) | `if (jsonString && typeof jsonString === 'string')` → `true`; `&&` → `\|\|` | For `''`, both mutants enter the `try` block where `JSON.parse('')` throws and `console.error('Failed to parse JSON from storage:')` fires; the return value (`null`) is unchanged — log-only difference, reclassified from Equivalent (see note above the Equivalent table) |
 | 109 (×2), 110 (×2), 111 | `'[QuestTimer] Loaded quest data:'` → `""`, its payload object → `{}`, `!!this.questTemplate` flips, `this.questTemplate?.id` → non-optional | All inside one `console.log` |
 | 149 (×2), 175, 188, 197, 199, 200, 210 | Log messages and log payload objects in `prepareQuest` | Log-only |
 | 249, 250 | `catch` block of `createQuestRun` → `{}`; its message string → `""` | The catch body is a `console.error` plus a comment; the "continue anyway" behavior is the *absence* of a rethrow and is already covered |
@@ -542,9 +557,9 @@ session, ordered by risk — the damage a real bug in that code would do, weight
 convincingly the current tests pretend to cover it. Start at #1.
 
 Every item below is a **Real gap**. Nothing from the Equivalent or Don't-care buckets is
-worth work; if anything, four of the don't-care clusters argue for *deleting* code
-(the `user-store` rehydration `console.log`s, and the redundant `typeof x === 'string'`
-operands in `quest-timer`'s two parse helpers).
+worth work; if anything, two clusters argue for *deleting* code instead of testing it:
+the `user-store` rehydration `console.log`s (Don't care, §4.2) and the redundant
+`typeof x === 'string'` operands in `quest-timer`'s two parse helpers (Equivalent, §4.5).
 
 | # | Item | Why it ranks here |
 | --- | --- | --- |
@@ -575,10 +590,17 @@ operands in `quest-timer`'s two parse helpers).
 ### Re-running
 
 ```bash
-pnpm test:mutate:audit          # full sweep over the configured modules (~30 min)
-pnpm test:mutate -- <glob>      # single module
+pnpm test:mutate:audit               # full sweep over the configured modules (~30 min)
+pnpm test:mutate src/store/user-store.ts   # single module — pass the path directly,
+                                            # no `--` separator (pnpm does not strip it,
+                                            # so `-- <glob>` leaves `--mutate` without its
+                                            # value and misreads <glob> as a config file)
 ```
 
 Config: `stryker.config.mjs`. Do not add `inPlace: true`. When re-running after fixes,
 compare **covered score** module-by-module against §2 — the total score will move for
 reasons (new tests reaching new code) that have nothing to do with assertion quality.
+**`/tmp/mutation-report.json` will not reappear on its own** — see the note in the
+header above. If you want a fresh JSON dump, add `'json'` to the `reporters` array in
+`stryker.config.mjs` before running, or re-extract it from the new `index.html`'s
+embedded `app.report` object.

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,8 +10,15 @@ module.exports = {
   testMatch: ['**/?(*.)+(spec|test).ts?(x)'],
   // Ignore nested git worktrees (created under .worktrees/) so jest doesn't
   // scan their duplicate test files or collide on their haste module names.
-  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/.worktrees/'],
-  modulePathIgnorePatterns: ['<rootDir>/.worktrees/'],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '<rootDir>/.worktrees/',
+    '<rootDir>/.stryker-tmp/',
+  ],
+  modulePathIgnorePatterns: [
+    '<rootDir>/.worktrees/',
+    '<rootDir>/.stryker-tmp/',
+  ],
   silent: true, // Suppress console output by default
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',

--- a/jest.mutation.config.js
+++ b/jest.mutation.config.js
@@ -1,0 +1,14 @@
+// Jest config used only by Stryker mutation runs.
+//
+// The base config registers `tdd-guard-jest`, `github-actions`, and
+// `jest-junit` reporters. Under Stryker those fire once per mutant, which
+// both slows the run and sprays junit XML into coverage/. `tdd-guard-jest`
+// in particular enforces TDD discipline against code Stryker has
+// deliberately broken, which is not a meaningful signal.
+const base = require('./jest.config');
+
+module.exports = {
+  ...base,
+  reporters: ['default'],
+  collectCoverage: false,
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "check-all": "pnpm run lint && pnpm run type-check && pnpm run lint:translations && pnpm run test",
     "test:ci": "pnpm run test --coverage",
     "test:watch": "pnpm run test --watch",
+    "test:mutate": "stryker run --mutate",
+    "test:mutate:audit": "stryker run",
     "install-maestro": "curl -Ls 'https://get.maestro.mobile.dev' | bash",
     "e2e": ".maestro/run-tests.sh",
     "e2e:onboarding": ".maestro/run-tests.sh onboarding",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,8 @@
     "@commitlint/config-conventional": "^19.2.2",
     "@dev-plugins/react-query": "^0.4.0",
     "@expo/config": "~12.0.14",
+    "@stryker-mutator/core": "^9.6.1",
+    "@stryker-mutator/jest-runner": "^9.6.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/react-native": "^13.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,12 @@ importers:
       '@expo/config':
         specifier: ~12.0.14
         version: 12.0.14
+      '@stryker-mutator/core':
+        specifier: ^9.6.1
+        version: 9.6.1(@types/node@24.10.1)
+      '@stryker-mutator/jest-runner':
+        specifier: ^9.6.1
+        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.10.1))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.9.1
@@ -441,8 +447,16 @@ packages:
     resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/core@7.28.5':
     resolution: {integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.28.5':
@@ -463,6 +477,10 @@ packages:
 
   '@babel/helper-compilation-targets@7.27.2':
     resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-create-class-features-plugin@7.28.5':
@@ -508,8 +526,18 @@ packages:
     resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-transforms@7.28.3':
     resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -576,12 +604,20 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-wrap-function@7.28.3':
     resolution: {integrity: sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.28.4':
     resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.25.9':
@@ -600,6 +636,12 @@ packages:
 
   '@babel/plugin-proposal-decorators@7.28.0':
     resolution: {integrity: sha512-zOiZqvANjWDUaUS9xMxbMcK/Zccztbe/6ikvUXaG9nsPH3w6qh5UaPGAnirI/WhIbZ8m3OHU0ReyPrknG+ZKeg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-decorators@7.29.7':
+    resolution: {integrity: sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -640,6 +682,12 @@ packages:
 
   '@babel/plugin-syntax-decorators@7.27.1':
     resolution: {integrity: sha512-YMq8Z87Lhl8EGkmb0MwYkt36QnxC+fzCgrl66ereamPlYToRpIk5nUjKUY3QKLWq8mwUB1BgbeXcTJhZOCDg5A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-decorators@7.29.7':
+    resolution: {integrity: sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -781,6 +829,18 @@ packages:
 
   '@babel/plugin-transform-destructuring@7.28.5':
     resolution: {integrity: sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-destructuring@7.29.7':
+    resolution: {integrity: sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-explicit-resource-management@7.29.7':
+    resolution: {integrity: sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1401,9 +1461,22 @@ packages:
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
 
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/checkbox@4.3.2':
     resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/checkbox@5.2.1':
+    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1419,9 +1492,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/core@10.3.2':
     resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1437,9 +1528,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/editor@5.2.2':
+    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/expand@4.0.23':
     resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.1.1':
+    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1455,13 +1564,35 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/external-editor@3.0.3':
+    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/figures@1.0.15':
     resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
     engines: {node: '>=18'}
 
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/input@4.3.1':
     resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/input@5.1.2':
+    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1477,9 +1608,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/number@4.1.1':
+    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/password@4.0.23':
     resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.1.1':
+    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1495,9 +1644,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/rawlist@4.1.11':
     resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.3.1':
+    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1513,6 +1680,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/search@4.2.1':
+    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/select@4.4.2':
     resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
     engines: {node: '>=18'}
@@ -1522,9 +1698,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/type@3.0.10':
     resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -2143,6 +2337,9 @@ packages:
       zen-observable:
         optional: true
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@sentry-internal/browser-utils@10.38.0':
     resolution: {integrity: sha512-UOJtYmdcxHCcV0NPfXFff/a95iXl/E0EhuQ1y0uE0BuZDMupWSF5t2BgC4HaE5Aw3RTjDF3XkSHWoIF6ohy7eA==}
     engines: {node: '>=18'}
@@ -2261,6 +2458,10 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
@@ -2269,6 +2470,28 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@stryker-mutator/api@9.6.1':
+    resolution: {integrity: sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==}
+    engines: {node: '>=20.0.0'}
+
+  '@stryker-mutator/core@9.6.1':
+    resolution: {integrity: sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@stryker-mutator/instrumenter@9.6.1':
+    resolution: {integrity: sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==}
+    engines: {node: '>=20.0.0'}
+
+  '@stryker-mutator/jest-runner@9.6.1':
+    resolution: {integrity: sha512-nIrIndfWwdweYkIcxJmyBTpl84nrXs9AE6A8vzEwwzUGvDb9kVvwBPfpEajtdAkjwPceH0pPuVrPkotvqcgYqQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@stryker-mutator/core': 9.6.1
+
+  '@stryker-mutator/util@9.6.1':
+    resolution: {integrity: sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==}
 
   '@tanstack/query-core@5.90.10':
     resolution: {integrity: sha512-EhZVFu9rl7GfRNuJLJ3Y7wtbTnENsvzp+YpcAV7kCYiXni1v8qZh++lpw4ch4rrwC0u/EZRnBHIehzCGzwXDSQ==}
@@ -2691,6 +2914,13 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  angular-html-parser@10.4.0:
+    resolution: {integrity: sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==}
+    engines: {node: '>= 14'}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -3228,6 +3458,10 @@ packages:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -3499,6 +3733,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  des.js@1.1.0:
+    resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -3521,6 +3758,9 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -3936,6 +4176,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   exit-hook@4.0.0:
     resolution: {integrity: sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ==}
     engines: {node: '>=18'}
@@ -4223,8 +4467,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -4252,6 +4505,10 @@ packages:
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -4391,6 +4648,10 @@ packages:
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -4601,6 +4862,10 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -4619,6 +4884,10 @@ packages:
 
   iconv-lite@0.7.0:
     resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -4879,6 +5148,10 @@ packages:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
@@ -4912,6 +5185,10 @@ packages:
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -5185,6 +5462,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  js-md4@0.3.2:
+    resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5231,6 +5511,9 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-rpc-2.0@1.7.1:
+    resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
 
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
@@ -5489,6 +5772,9 @@ packages:
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -5783,6 +6069,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
@@ -5832,6 +6121,19 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mutation-server-protocol@0.4.1:
+    resolution: {integrity: sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==}
+    engines: {node: '>=18'}
+
+  mutation-testing-elements@3.7.3:
+    resolution: {integrity: sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ==}
+
+  mutation-testing-metrics@3.7.3:
+    resolution: {integrity: sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==}
+
+  mutation-testing-report-schema@3.7.3:
+    resolution: {integrity: sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==}
+
   mute-stream@0.0.7:
     resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
 
@@ -5841,6 +6143,10 @@ packages:
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -5939,6 +6245,10 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -6135,6 +6445,10 @@ packages:
 
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
   parse-png@2.1.0:
@@ -6367,6 +6681,10 @@ packages:
     resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
   proc-log@4.2.0:
     resolution: {integrity: sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -6408,6 +6726,10 @@ packages:
   qrcode-terminal@0.11.0:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
     hasBin: true
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
 
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
@@ -7064,6 +7386,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -7216,6 +7542,10 @@ packages:
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -7401,6 +7731,10 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -7454,6 +7788,10 @@ packages:
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -7515,6 +7853,14 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typed-inject@5.0.0:
+    resolution: {integrity: sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==}
+    engines: {node: '>=18'}
+
+  typed-rest-client@2.3.1:
+    resolution: {integrity: sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==}
+    engines: {node: '>= 16.0.0'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -7532,6 +7878,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -7696,6 +8045,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  weapon-regex@1.3.6:
+    resolution: {integrity: sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -8016,6 +8368,8 @@ snapshots:
 
   '@babel/compat-data@7.28.5': {}
 
+  '@babel/compat-data@7.29.7': {}
+
   '@babel/core@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -8027,6 +8381,26 @@ snapshots:
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -8068,6 +8442,14 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.0
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
   '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -8088,6 +8470,19 @@ snapshots:
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/helper-replace-supers': 7.29.7(@babel/core@7.28.5)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
       '@babel/traverse': 7.29.7
       semver: 6.3.1
@@ -8137,12 +8532,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -8185,6 +8605,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.29.7
@@ -8209,6 +8638,8 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
+  '@babel/helper-validator-option@7.29.7': {}
+
   '@babel/helper-wrap-function@7.28.3':
     dependencies:
       '@babel/template': 7.29.7
@@ -8221,6 +8652,11 @@ snapshots:
     dependencies:
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/highlight@7.25.9':
     dependencies:
@@ -8243,6 +8679,15 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -8284,6 +8729,11 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -8317,6 +8767,11 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5)':
@@ -8362,6 +8817,11 @@ snapshots:
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.5)':
@@ -8434,6 +8894,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -8476,6 +8952,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -8632,6 +9116,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -8658,6 +9153,17 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -9322,6 +9828,8 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
+  '@inquirer/ansi@2.0.7': {}
+
   '@inquirer/checkbox@4.3.2(@types/node@24.10.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -9332,10 +9840,26 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
 
+  '@inquirer/checkbox@5.2.1(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.10.1)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.10.1)
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@inquirer/confirm@5.1.21(@types/node@24.10.1)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.10.1)
       '@inquirer/type': 3.0.10(@types/node@24.10.1)
+    optionalDependencies:
+      '@types/node': 24.10.1
+
+  '@inquirer/confirm@6.1.1(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.10.1)
+      '@inquirer/type': 4.0.7(@types/node@24.10.1)
     optionalDependencies:
       '@types/node': 24.10.1
 
@@ -9352,11 +9876,31 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
 
+  '@inquirer/core@11.2.1(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.10.1)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@inquirer/editor@4.2.23(@types/node@24.10.1)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.10.1)
       '@inquirer/external-editor': 1.0.3(@types/node@24.10.1)
       '@inquirer/type': 3.0.10(@types/node@24.10.1)
+    optionalDependencies:
+      '@types/node': 24.10.1
+
+  '@inquirer/editor@5.2.2(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.10.1)
+      '@inquirer/external-editor': 3.0.3(@types/node@24.10.1)
+      '@inquirer/type': 4.0.7(@types/node@24.10.1)
     optionalDependencies:
       '@types/node': 24.10.1
 
@@ -9368,6 +9912,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
 
+  '@inquirer/expand@5.1.1(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.10.1)
+      '@inquirer/type': 4.0.7(@types/node@24.10.1)
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@inquirer/external-editor@1.0.3(@types/node@24.10.1)':
     dependencies:
       chardet: 2.1.1
@@ -9375,12 +9926,28 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
 
+  '@inquirer/external-editor@3.0.3(@types/node@24.10.1)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/figures@2.0.7': {}
 
   '@inquirer/input@4.3.1(@types/node@24.10.1)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.10.1)
       '@inquirer/type': 3.0.10(@types/node@24.10.1)
+    optionalDependencies:
+      '@types/node': 24.10.1
+
+  '@inquirer/input@5.1.2(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.10.1)
+      '@inquirer/type': 4.0.7(@types/node@24.10.1)
     optionalDependencies:
       '@types/node': 24.10.1
 
@@ -9391,11 +9958,26 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
 
+  '@inquirer/number@4.1.1(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.10.1)
+      '@inquirer/type': 4.0.7(@types/node@24.10.1)
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@inquirer/password@4.0.23(@types/node@24.10.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/core': 10.3.2(@types/node@24.10.1)
       '@inquirer/type': 3.0.10(@types/node@24.10.1)
+    optionalDependencies:
+      '@types/node': 24.10.1
+
+  '@inquirer/password@5.1.1(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.10.1)
+      '@inquirer/type': 4.0.7(@types/node@24.10.1)
     optionalDependencies:
       '@types/node': 24.10.1
 
@@ -9414,11 +9996,33 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
 
+  '@inquirer/prompts@8.5.2(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/checkbox': 5.2.1(@types/node@24.10.1)
+      '@inquirer/confirm': 6.1.1(@types/node@24.10.1)
+      '@inquirer/editor': 5.2.2(@types/node@24.10.1)
+      '@inquirer/expand': 5.1.1(@types/node@24.10.1)
+      '@inquirer/input': 5.1.2(@types/node@24.10.1)
+      '@inquirer/number': 4.1.1(@types/node@24.10.1)
+      '@inquirer/password': 5.1.1(@types/node@24.10.1)
+      '@inquirer/rawlist': 5.3.1(@types/node@24.10.1)
+      '@inquirer/search': 4.2.1(@types/node@24.10.1)
+      '@inquirer/select': 5.2.1(@types/node@24.10.1)
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@inquirer/rawlist@4.1.11(@types/node@24.10.1)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.10.1)
       '@inquirer/type': 3.0.10(@types/node@24.10.1)
       yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.1
+
+  '@inquirer/rawlist@5.3.1(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.10.1)
+      '@inquirer/type': 4.0.7(@types/node@24.10.1)
     optionalDependencies:
       '@types/node': 24.10.1
 
@@ -9428,6 +10032,14 @@ snapshots:
       '@inquirer/figures': 1.0.15
       '@inquirer/type': 3.0.10(@types/node@24.10.1)
       yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.1
+
+  '@inquirer/search@4.2.1(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.10.1)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.10.1)
     optionalDependencies:
       '@types/node': 24.10.1
 
@@ -9441,7 +10053,20 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
 
+  '@inquirer/select@5.2.1(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.10.1)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.10.1)
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@inquirer/type@3.0.10(@types/node@24.10.1)':
+    optionalDependencies:
+      '@types/node': 24.10.1
+
+  '@inquirer/type@4.0.7(@types/node@24.10.1)':
     optionalDependencies:
       '@types/node': 24.10.1
 
@@ -10230,6 +10855,8 @@ snapshots:
     transitivePeerDependencies:
       - zenObservable
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@sentry-internal/browser-utils@10.38.0':
     dependencies:
       '@sentry/core': 10.38.0
@@ -10343,6 +10970,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
+  '@sindresorhus/merge-streams@4.0.0': {}
+
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -10352,6 +10981,72 @@ snapshots:
       '@sinonjs/commons': 3.0.1
 
   '@socket.io/component-emitter@3.1.2': {}
+
+  '@stryker-mutator/api@9.6.1':
+    dependencies:
+      mutation-testing-metrics: 3.7.3
+      mutation-testing-report-schema: 3.7.3
+      tslib: 2.8.1
+      typed-inject: 5.0.0
+
+  '@stryker-mutator/core@9.6.1(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/prompts': 8.5.2(@types/node@24.10.1)
+      '@stryker-mutator/api': 9.6.1
+      '@stryker-mutator/instrumenter': 9.6.1
+      '@stryker-mutator/util': 9.6.1
+      ajv: 8.18.0
+      chalk: 5.6.2
+      commander: 14.0.3
+      diff-match-patch: 1.0.5
+      emoji-regex: 10.6.0
+      execa: 9.6.1
+      json-rpc-2.0: 1.7.1
+      lodash.groupby: 4.6.0
+      minimatch: 10.2.5
+      mutation-server-protocol: 0.4.1
+      mutation-testing-elements: 3.7.3
+      mutation-testing-metrics: 3.7.3
+      mutation-testing-report-schema: 3.7.3
+      npm-run-path: 6.0.0
+      progress: 2.0.3
+      rxjs: 7.8.2
+      semver: 7.7.3
+      source-map: 0.7.6
+      tree-kill: 1.2.2
+      tslib: 2.8.1
+      typed-inject: 5.0.0
+      typed-rest-client: 2.3.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+
+  '@stryker-mutator/instrumenter@9.6.1':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7)
+      '@stryker-mutator/api': 9.6.1
+      '@stryker-mutator/util': 9.6.1
+      angular-html-parser: 10.4.0
+      semver: 7.7.3
+      tslib: 2.8.1
+      weapon-regex: 1.3.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@stryker-mutator/jest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.10.1))':
+    dependencies:
+      '@stryker-mutator/api': 9.6.1
+      '@stryker-mutator/core': 9.6.1(@types/node@24.10.1)
+      '@stryker-mutator/util': 9.6.1
+      semver: 7.7.3
+      tslib: 2.8.1
+
+  '@stryker-mutator/util@9.6.1': {}
 
   '@tanstack/query-core@5.90.10': {}
 
@@ -10810,6 +11505,15 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  angular-html-parser@10.4.0: {}
 
   anser@1.4.10: {}
 
@@ -11415,6 +12119,8 @@ snapshots:
 
   commander@13.1.0: {}
 
+  commander@14.0.3: {}
+
   commander@2.20.3: {}
 
   commander@4.1.1: {}
@@ -11684,6 +12390,11 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  des.js@1.1.0:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   destroy@1.2.0: {}
 
   detect-libc@1.0.3: {}
@@ -11695,6 +12406,8 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   didyoumean@1.2.2: {}
+
+  diff-match-patch@1.0.5: {}
 
   diff-sequences@29.6.3: {}
 
@@ -12288,6 +13001,21 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
   exit-hook@4.0.0: {}
 
   exit@0.1.2: {}
@@ -12634,7 +13362,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.19.1:
     dependencies:
@@ -12660,6 +13398,10 @@ snapshots:
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -12795,6 +13537,11 @@ snapshots:
   get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -13036,6 +13783,8 @@ snapshots:
 
   human-signals@5.0.0: {}
 
+  human-signals@8.0.1: {}
+
   husky@9.1.7: {}
 
   i18next@23.16.8:
@@ -13051,6 +13800,10 @@ snapshots:
       safer-buffer: 2.1.2
 
   iconv-lite@0.7.0:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -13303,6 +14056,8 @@ snapshots:
 
   is-path-inside@4.0.0: {}
 
+  is-plain-obj@4.1.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
 
   is-promise@2.2.2: {}
@@ -13329,6 +14084,8 @@ snapshots:
   is-stream@2.0.1: {}
 
   is-stream@3.0.0: {}
+
+  is-stream@4.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -13837,6 +14594,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  js-md4@0.3.2: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -13917,6 +14676,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-rpc-2.0@1.7.1: {}
 
   json-schema-to-ts@3.1.1:
     dependencies:
@@ -14159,6 +14920,8 @@ snapshots:
   lodash.camelcase@4.3.0: {}
 
   lodash.debounce@4.0.8: {}
+
+  lodash.groupby@4.6.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -14640,6 +15403,8 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@10.1.1:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
@@ -14678,11 +15443,25 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mutation-server-protocol@0.4.1:
+    dependencies:
+      zod: 4.1.12
+
+  mutation-testing-elements@3.7.3: {}
+
+  mutation-testing-metrics@3.7.3:
+    dependencies:
+      mutation-testing-report-schema: 3.7.3
+
+  mutation-testing-report-schema@3.7.3: {}
+
   mute-stream@0.0.7: {}
 
   mute-stream@0.0.8: {}
 
   mute-stream@2.0.0: {}
+
+  mute-stream@3.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -14821,6 +15600,11 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
 
   nth-check@2.1.1:
     dependencies:
@@ -15041,6 +15825,8 @@ snapshots:
       index-to-position: 1.2.0
       type-fest: 4.41.0
 
+  parse-ms@4.0.0: {}
+
   parse-png@2.1.0:
     dependencies:
       pngjs: 3.4.0
@@ -15210,6 +15996,10 @@ snapshots:
       react-is-18: react-is@18.3.1
       react-is-19: react-is@19.2.7
 
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
   proc-log@4.2.0: {}
 
   progress@2.0.3: {}
@@ -15246,6 +16036,10 @@ snapshots:
   pure-rand@6.1.0: {}
 
   qrcode-terminal@0.11.0: {}
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
 
   query-string@7.1.3:
     dependencies:
@@ -15971,6 +16765,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -16143,6 +16939,8 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-final-newline@3.0.0: {}
+
+  strip-final-newline@4.0.0: {}
 
   strip-indent@3.0.0:
     dependencies:
@@ -16353,6 +17151,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   ts-algebra@2.0.0: {}
 
   ts-api-utils@1.4.3(typescript@5.9.3):
@@ -16396,6 +17196,8 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 5.9.3
+
+  tunnel@0.0.6: {}
 
   type-check@0.4.0:
     dependencies:
@@ -16454,6 +17256,16 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typed-inject@5.0.0: {}
+
+  typed-rest-client@2.3.1:
+    dependencies:
+      des.js: 1.1.0
+      js-md4: 0.3.2
+      qs: 6.15.1
+      tunnel: 0.0.6
+      underscore: 1.13.8
+
   typescript@5.9.3: {}
 
   ua-parser-js@0.7.41: {}
@@ -16467,6 +17279,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  underscore@1.13.8: {}
 
   undici-types@6.21.0: {}
 
@@ -16633,6 +17447,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  weapon-regex@1.3.6: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -278,15 +278,13 @@ describe('QuestTimer', () => {
     // Fake timers make the 500 ms solo-start window advanceable, and stop a
     // stray timer from a locking test firing during a later one.
     //
-    // `advanceTimers: true` matters for mutation runs, not for this suite:
-    // the cooperative lock-status retry ladder does
-    // `await new Promise(r => setTimeout(r, retryDelay))`, which only runs
-    // when the server call rejects. Under a plain fake clock nothing ever
-    // advances it, so any mutant that reaches that await hangs until Stryker's
-    // timeout — 70+ hangs took one audit from 50 minutes to over four hours.
-    // Letting the clock also track real time keeps those awaits resolving
-    // while advanceTimersByTime() still drives every assertion deterministically.
-    jest.useFakeTimers({ advanceTimers: true });
+    // Deliberately a plain fake clock, NOT `{ advanceTimers: true }`: that was
+    // tried to stop mutation runs hanging on the cooperative retry ladder's
+    // `await new Promise(r => setTimeout(r, retryDelay))`, and it did not help
+    // — the hangs are unbounded loops in the production code that these tests
+    // now reach, not artifacts of the clock. Auto-advancing only bought
+    // nondeterminism under parallel load.
+    jest.useFakeTimers();
     resetQuestTimerStatics();
     mockQuestStore.activeQuest = null;
     mockQuestStore.cooperativeQuestRun = null;

--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -129,13 +129,19 @@ jest.mock('@/store/user-store', () => ({
   },
 }));
 
-jest.mock('@/store/character-store', () => ({
-  useCharacterStore: {
-    getState: jest.fn(() => ({
-      character: { id: 'test-character-id' },
-    })),
-  },
-}));
+jest.mock('@/store/character-store', () => {
+  const mockStore = {
+    character: { id: 'test-character-id' },
+    addXP: jest.fn(),
+    updateStreak: jest.fn(),
+  };
+  return {
+    useCharacterStore: {
+      getState: jest.fn(() => mockStore),
+      __mockStore: mockStore,
+    },
+  };
+});
 
 // Mock uuid
 jest.mock('uuid', () => ({
@@ -158,6 +164,27 @@ jest.mock('react-native-background-actions', () => ({
 }));
 
 // Handle on the shared quest-store mock object so tests can stage store state.
+const questStoreMockModule = jest.requireMock('@/store/quest-store') as {
+  useQuestStore: {
+    setState: jest.Mock;
+    __mockStore: {
+      pendingQuest: {
+        id: string;
+        durationMinutes: number;
+        reward: { xp: number };
+      } | null;
+    };
+  };
+};
+const mockSetState = questStoreMockModule.useQuestStore.setState;
+const mockCharacterStore = (
+  jest.requireMock('@/store/character-store') as {
+    useCharacterStore: {
+      __mockStore: { addXP: jest.Mock; updateStreak: jest.Mock };
+    };
+  }
+).useCharacterStore.__mockStore;
+
 const mockQuestStore = (
   jest.requireMock('@/store/quest-store') as {
     useQuestStore: {
@@ -256,6 +283,7 @@ describe('QuestTimer', () => {
     mockQuestStore.cooperativeQuestRun = null;
     mockQuestStore.recentCompletedQuest = null;
     mockQuestStore.completedQuests = [];
+    questStoreMockModule.useQuestStore.__mockStore.pendingQuest = null;
     BackgroundService.isRunning.mockReturnValue(false);
     // clearAllMocks only clears call records, not implementations. Re-establish
     // createQuestRun's default resolved value so a prior test's mockRejectedValue
@@ -821,6 +849,60 @@ describe('QuestTimer', () => {
       // Skipping this leaves the results screen showing base XP rather than
       // the server's adjusted, perk-applied numbers.
       expect(getQuestRunStatus).toHaveBeenCalledWith('completed-run-id');
+      // …and the fetched rewards have to reach the store, or the round-trip
+      // is pure cost.
+      expect(mockSetState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recentCompletedQuest: expect.objectContaining({
+            id: 'test-quest-id',
+            participants: [{ userId: 'u1', rewards: { adjustedXP: 120 } }],
+          }),
+        })
+      );
+    });
+
+    it('skips the rewards fetch when the completed quest has no run id', async () => {
+      mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 0 };
+      mockQuestStore.recentCompletedQuest = { id: 'test-quest-id' };
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      jest.advanceTimersByTime(15 * 60 * 1000);
+      (getQuestRunStatus as jest.Mock).mockClear();
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(getQuestRunStatus).not.toHaveBeenCalled();
+      expect(mockSetState).not.toHaveBeenCalled();
+    });
+
+    it('completes a quest that was stuck in the pending state', async () => {
+      // The store never transitioned to active (the 500 ms starter was
+      // missed), so the active-quest branch cannot fire. Without this arm the
+      // user finishes the quest and gets nothing.
+      questStoreMockModule.useQuestStore.__mockStore.pendingQuest = {
+        id: 'test-quest-id',
+        durationMinutes: 15,
+        reward: { xp: 100 },
+      };
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      jest.advanceTimersByTime(15 * 60 * 1000);
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(mockSetState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeQuest: null,
+          pendingQuest: null,
+          recentCompletedQuest: expect.objectContaining({
+            id: 'test-quest-id',
+            status: 'completed',
+            questRunId: 'mock-quest-run-id',
+          }),
+        })
+      );
+      expect(mockCharacterStore.addXP).toHaveBeenCalledWith(100);
+      expect(mockCharacterStore.updateStreak).toHaveBeenCalled();
     });
 
     it('does not push a completed Live Activity on Android', async () => {

--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -277,7 +277,16 @@ describe('QuestTimer', () => {
     jest.clearAllMocks();
     // Fake timers make the 500 ms solo-start window advanceable, and stop a
     // stray timer from a locking test firing during a later one.
-    jest.useFakeTimers();
+    //
+    // `advanceTimers: true` matters for mutation runs, not for this suite:
+    // the cooperative lock-status retry ladder does
+    // `await new Promise(r => setTimeout(r, retryDelay))`, which only runs
+    // when the server call rejects. Under a plain fake clock nothing ever
+    // advances it, so any mutant that reaches that await hangs until Stryker's
+    // timeout — 70+ hangs took one audit from 50 minutes to over four hours.
+    // Letting the clock also track real time keeps those awaits resolving
+    // while advanceTimersByTime() still drives every assertion deterministically.
+    jest.useFakeTimers({ advanceTimers: true });
     resetQuestTimerStatics();
     mockQuestStore.activeQuest = null;
     mockQuestStore.cooperativeQuestRun = null;

--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -7,7 +7,12 @@ import { OneSignal } from 'react-native-onesignal';
 
 // Import mocked modules
 import {
+  areNotificationsEnabled,
+  clearAllNotifications,
+} from '@/lib/services/notifications';
+import {
   createQuestRun,
+  getQuestRunStatus,
   updatePhoneLockStatus,
 } from '@/lib/services/quest-run-service';
 import { removeItem, setItem } from '@/lib/storage';
@@ -15,6 +20,7 @@ import { removeItem, setItem } from '@/lib/storage';
 // Import types
 import type {
   CooperativeQuestTemplate,
+  CustomQuestTemplate,
   StoryQuestTemplate,
 } from '@/store/types';
 
@@ -79,6 +85,14 @@ jest.mock('@/lib/storage', () => ({
   }),
 }));
 
+// A single mutable object backs every getState() call, so a test can stage
+// store state by assigning to it (reset in beforeEach).
+//
+// `activeQuest` defaults to null, not to a quest. The solo-start path is
+// guarded by `if (!questStore.activeQuest && this.questTemplate)`, so a
+// non-null activeQuest fixture makes `startQuest` structurally unreachable —
+// the assertion would pass against an implementation that never starts a
+// quest at all. Tests that need an in-progress quest set it explicitly.
 jest.mock('@/store/quest-store', () => {
   const mockStore = {
     setLiveActivityId: jest.fn(),
@@ -87,16 +101,21 @@ jest.mock('@/store/quest-store', () => {
     failQuest: jest.fn(),
     resetActiveQuest: jest.fn(),
     setCooperativeQuestRun: jest.fn(),
-    activeQuest: {
-      id: 'test-quest-id',
-      startTime: 0,
-    },
-    cooperativeQuestRun: null,
+    reset: jest.fn(),
+    activeQuest: null as { id: string; startTime: number } | null,
+    pendingQuest: null,
+    recentCompletedQuest: null,
+    completedQuests: [] as unknown[],
+    failedQuests: [] as unknown[],
+    lastCompletedQuestTimestamp: 0,
+    cooperativeQuestRun: null as { id: string; status: string } | null,
   };
 
   return {
     useQuestStore: {
-      getState: jest.fn().mockReturnValue(mockStore),
+      getState: jest.fn(() => mockStore),
+      setState: jest.fn(),
+      __mockStore: mockStore,
     },
   };
 });
@@ -137,9 +156,98 @@ jest.mock('react-native-background-actions', () => ({
   },
 }));
 
+// Handle on the shared quest-store mock object so tests can stage store state.
+const mockQuestStore = (
+  jest.requireMock('@/store/quest-store') as {
+    useQuestStore: {
+      __mockStore: {
+        setLiveActivityId: jest.Mock;
+        startQuest: jest.Mock;
+        completeQuest: jest.Mock;
+        failQuest: jest.Mock;
+        setCooperativeQuestRun: jest.Mock;
+        activeQuest: { id: string; startTime: number } | null;
+        cooperativeQuestRun: { id: string; status: string } | null;
+      };
+    };
+  }
+).useQuestStore.__mockStore;
+
+const BackgroundService = jest.requireMock(
+  'react-native-background-actions'
+) as {
+  start: jest.Mock;
+  stop: jest.Mock;
+  isRunning: jest.Mock;
+  updateNotification: jest.Mock;
+};
+
+/**
+ * QuestTimer is a static class, so its fields survive between tests. Without
+ * this the suite is order-dependent: a leftover `isPhoneLocked = true` makes
+ * onPhoneLocked return early, and a leftover questTemplate keeps an "unlock
+ * with no quest" case from ever taking the early-return branch.
+ */
+function resetQuestTimerStatics() {
+  const timer = QuestTimer as unknown as {
+    isPhoneLocked: boolean;
+    questStartTime: number | null;
+    questTemplate: unknown;
+    oneSignalActivityId: string | null;
+    questRunId: string | null;
+  };
+  timer.isPhoneLocked = false;
+  timer.questStartTime = null;
+  timer.questTemplate = null;
+  timer.oneSignalActivityId = null;
+  timer.questRunId = null;
+}
+
+function readQuestTimerStatics() {
+  return QuestTimer as unknown as {
+    isPhoneLocked: boolean;
+    questStartTime: number | null;
+    oneSignalActivityId: string | null;
+  };
+}
+
+const storyQuest = (
+  overrides: Partial<StoryQuestTemplate> = {}
+): StoryQuestTemplate => ({
+  id: 'test-quest-id',
+  title: 'Test Quest',
+  durationMinutes: 15,
+  mode: 'story',
+  recap: 'Test quest recap',
+  poiSlug: 'test-poi',
+  story: 'Test story content',
+  options: [{ id: 'option1', text: 'Option 1', nextQuestId: null }],
+  reward: { xp: 100 },
+  ...overrides,
+});
+
+const customQuest = (
+  overrides: Partial<CustomQuestTemplate> = {}
+): CustomQuestTemplate => ({
+  id: 'custom-quest-id',
+  title: 'Go for a walk',
+  durationMinutes: 20,
+  mode: 'custom',
+  category: 'fitness',
+  reward: { xp: 50 },
+  ...overrides,
+});
+
 describe('QuestTimer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Fake timers make the 500 ms solo-start window advanceable, and stop a
+    // stray timer from a locking test firing during a later one.
+    jest.useFakeTimers();
+    resetQuestTimerStatics();
+    mockQuestStore.activeQuest = null;
+    mockQuestStore.cooperativeQuestRun = null;
+    BackgroundService.isRunning.mockReturnValue(false);
     // clearAllMocks only clears call records, not implementations. Re-establish
     // createQuestRun's default resolved value so a prior test's mockRejectedValue
     // can't leak forward. (Previously masked by the static questRunId never being
@@ -151,6 +259,10 @@ describe('QuestTimer', () => {
     Object.keys(mockStorage).forEach((key) => delete mockStorage[key]);
     // Reset Platform.OS to ios for most tests
     Platform.OS = 'ios';
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   describe('prepareQuest', () => {
@@ -320,15 +432,60 @@ describe('QuestTimer', () => {
       );
     });
 
-    it('should handle duplicate phone lock calls', async () => {
-      // Arrange
-      // @ts-ignore
-      QuestTimer.isPhoneLocked = true;
+    it('ignores a duplicate lock event', async () => {
+      // The old version of this test set isPhoneLocked by hand with no quest
+      // prepared, so it asserted nothing the guard at the top of the method
+      // was responsible for. Drive a real quest through instead, and check
+      // the second lock produces no side effects at all — including the
+      // storage reload, which is the only observable difference once the
+      // start-time check downstream also blocks a re-start.
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+      jest.clearAllMocks();
 
-      // Act
       await QuestTimer.onPhoneLocked();
 
-      // Assert
+      expect(mockQuestStore.setLiveActivityId).not.toHaveBeenCalled();
+      expect(updatePhoneLockStatus).not.toHaveBeenCalled();
+      expect(OneSignal.LiveActivities.startDefault).not.toHaveBeenCalled();
+    });
+
+    it('sends lock status through the cooperative path for a cooperative run', async () => {
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'coop-run-id',
+        status: 'pending',
+      };
+      await QuestTimer.prepareQuest(storyQuest(), 'coop-run-id');
+
+      await QuestTimer.onPhoneLocked();
+
+      // Only the cooperative branch polls the server for activation.
+      expect(getQuestRunStatus).toHaveBeenCalledWith('coop-run-id');
+      expect(mockQuestStore.setCooperativeQuestRun).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'coop-run-id', status: 'active' })
+      );
+    });
+
+    it('sends lock status through the solo path for a solo run', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
+
+      await QuestTimer.onPhoneLocked();
+
+      expect(updatePhoneLockStatus).toHaveBeenCalledWith(
+        'mock-quest-run-id',
+        true,
+        expect.any(String)
+      );
+      expect(getQuestRunStatus).not.toHaveBeenCalled();
+    });
+
+    it('does not send lock status when the server issued no run id', async () => {
+      (createQuestRun as jest.Mock).mockRejectedValue(new Error('server down'));
+      await QuestTimer.prepareQuest(storyQuest());
+      (updatePhoneLockStatus as jest.Mock).mockClear();
+
+      await QuestTimer.onPhoneLocked();
+
       expect(updatePhoneLockStatus).not.toHaveBeenCalled();
     });
   });
@@ -364,7 +521,6 @@ describe('QuestTimer', () => {
     it('should handle Android platform', async () => {
       // Arrange
       Platform.OS = 'android';
-      const BackgroundService = require('react-native-background-actions');
       BackgroundService.isRunning.mockReturnValue(true);
 
       // Act
@@ -373,63 +529,221 @@ describe('QuestTimer', () => {
       // Assert
       expect(BackgroundService.stop).toHaveBeenCalled();
     });
+
+    it('does not stop a background service that is not running', async () => {
+      // The guard's other direction. Without this, `if (isRunning())` can be
+      // forced true and only the case above is exercised.
+      BackgroundService.isRunning.mockReturnValue(false);
+
+      await QuestTimer.stopQuest();
+
+      expect(BackgroundService.stop).not.toHaveBeenCalled();
+    });
   });
 
   describe('onPhoneUnlocked', () => {
-    it('marks quest as failed locally when phone is unlocked during quest', async () => {
-      // This test is checking that QuestTimer can handle phone unlock events
-      // The actual logic of failing quests is complex and depends on timing
-      // For now, let's just verify the basic flow works without errors
+    // These previously asserted only `resolves.not.toThrow()`. An empty method
+    // body also does not throw, which is why the whole of onPhoneUnlocked could
+    // be deleted with the suite still green. Assert the outcome instead.
 
-      const mockQuestTemplate: StoryQuestTemplate = {
-        id: 'test-quest-id',
-        title: 'Test Quest',
-        durationMinutes: 15,
-        mode: 'story',
-        recap: 'Test quest recap',
-        poiSlug: 'test-poi',
-        story: 'Test story content',
-        options: [{ id: 'option1', text: 'Option 1', nextQuestId: null }],
-        reward: { xp: 100 },
-      };
+    it('fails the quest when the phone is unlocked before the duration elapses', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
 
-      // Prepare quest first
-      await QuestTimer.prepareQuest(mockQuestTemplate);
+      await QuestTimer.onPhoneUnlocked();
 
-      // Act - call onPhoneUnlocked
-      await expect(QuestTimer.onPhoneUnlocked()).resolves.not.toThrow();
-
-      // The test passes if no errors are thrown
-      // More detailed testing would require mocking the internal timer state
+      expect(mockQuestStore.failQuest).toHaveBeenCalledTimes(1);
+      expect(mockQuestStore.completeQuest).not.toHaveBeenCalled();
     });
 
-    it('handles cooperative quest unlock differently than single-player', async () => {
-      // This test verifies that cooperative quests can be handled without errors
-      // The actual cooperative quest logic is complex and would need more setup
+    it('tells the server the phone is unlocked and tears the run down', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+      (updatePhoneLockStatus as jest.Mock).mockClear();
 
-      const mockQuestTemplate: StoryQuestTemplate = {
-        id: 'test-quest-id',
-        title: 'Cooperative Quest',
-        durationMinutes: 5,
-        mode: 'story',
-        category: 'cooperative',
-        recap: 'Test cooperative quest',
-        poiSlug: 'test-poi',
-        story: 'Test story content',
-        options: [],
-        reward: { xp: 100 },
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(updatePhoneLockStatus).toHaveBeenCalledWith(
+        'mock-quest-run-id',
+        false
+      );
+      // stopQuest() runs as part of the failure path.
+      expect(removeItem).toHaveBeenCalledWith('QUEST_RUN_ID');
+      expect(removeItem).toHaveBeenCalledWith('QUEST_TIMER_START_TIME');
+    });
+
+    it('does nothing when a quest is prepared but never locked', async () => {
+      // The start-time arm of the early-return condition. Note there is
+      // deliberately no "nothing prepared at all" companion test: with every
+      // static null the method is inert under every mutation of it, so such a
+      // test asserts nothing. This one has a run id and a template, and only
+      // the missing start time stops it — so inverting the guard is visible.
+      await QuestTimer.prepareQuest(storyQuest());
+      (updatePhoneLockStatus as jest.Mock).mockClear();
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(mockQuestStore.failQuest).not.toHaveBeenCalled();
+      expect(updatePhoneLockStatus).not.toHaveBeenCalled();
+    });
+
+    it('clears the locked flag so the next lock is processed', async () => {
+      // stopQuest() does not reset isPhoneLocked — only onPhoneUnlocked does.
+      // If that assignment is dropped, the duplicate-lock guard swallows every
+      // subsequent lock and no further quest can ever start.
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+      await QuestTimer.onPhoneUnlocked();
+
+      await QuestTimer.prepareQuest(storyQuest());
+      (updatePhoneLockStatus as jest.Mock).mockClear();
+      await QuestTimer.onPhoneLocked();
+
+      expect(updatePhoneLockStatus).toHaveBeenCalledWith(
+        'mock-quest-run-id',
+        true,
+        expect.any(String)
+      );
+    });
+
+    it('does not push a failed Live Activity for a cooperative quest', async () => {
+      // The single-player branch flips the card to "Quest Failed"; the
+      // cooperative branch leaves it to the server. This is the actual
+      // difference the test name has always claimed.
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'cooperative-quest-run-id',
+        status: 'active',
       };
-
-      // For cooperative quests, we need to provide a quest run ID
       await QuestTimer.prepareQuest(
-        mockQuestTemplate,
+        storyQuest({ durationMinutes: 5 }),
         'cooperative-quest-run-id'
       );
+      await QuestTimer.onPhoneLocked();
+      (OneSignal.LiveActivities.startDefault as jest.Mock).mockClear();
 
-      // Act - call onPhoneUnlocked
-      await expect(QuestTimer.onPhoneUnlocked()).resolves.not.toThrow();
+      await QuestTimer.onPhoneUnlocked();
 
-      // The test passes if no errors are thrown
+      expect(mockQuestStore.failQuest).toHaveBeenCalledTimes(1);
+      expect(OneSignal.LiveActivities.startDefault).not.toHaveBeenCalled();
+    });
+
+    it('completes the quest when the phone is unlocked after the duration', async () => {
+      // The other side of the elapsed-time comparison. Without it the
+      // `>=` boundary and the whole completion arm are unasserted, and a
+      // flipped comparison would fail every quest the user actually finished.
+      mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 0 };
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      jest.advanceTimersByTime(15 * 60 * 1000);
+      (OneSignal.LiveActivities.startDefault as jest.Mock).mockClear();
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(mockQuestStore.completeQuest).toHaveBeenCalledWith(true);
+      expect(mockQuestStore.failQuest).not.toHaveBeenCalled();
+      expect(OneSignal.LiveActivities.startDefault).toHaveBeenCalledWith(
+        expect.any(String),
+        {
+          title: 'Quest Complete',
+          description: 'Congratulations on finishing your quest!',
+        },
+        { durationMinutes: 15, status: 'completed' }
+      );
+    });
+
+    it('shows the failure notification on Android instead of a Live Activity', async () => {
+      Platform.OS = 'android';
+      BackgroundService.isRunning.mockReturnValue(true);
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+      BackgroundService.updateNotification.mockClear();
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(BackgroundService.updateNotification).toHaveBeenCalledWith({
+        taskTitle: 'Quest Failed',
+        taskDesc: 'You unlocked your phone. Try again next time!',
+        progressBar: { max: 100, value: 0, indeterminate: false },
+      });
+      expect(OneSignal.LiveActivities.startDefault).not.toHaveBeenCalled();
+    });
+
+    it('flips the Live Activity to failed for a single-player quest', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+      const activityId = readQuestTimerStatics().oneSignalActivityId;
+      (OneSignal.LiveActivities.startDefault as jest.Mock).mockClear();
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(OneSignal.LiveActivities.startDefault).toHaveBeenCalledWith(
+        activityId,
+        { title: 'Quest Failed', description: 'Try again next time' },
+        { durationMinutes: 15, status: 'failed' }
+      );
+    });
+  });
+
+  describe('solo quest start', () => {
+    it('starts the quest in the store 500 ms after the phone is locked', async () => {
+      const template = storyQuest();
+      await QuestTimer.prepareQuest(template);
+
+      await QuestTimer.onPhoneLocked();
+      // The delay is deliberate — assert it has not started yet, so a mutant
+      // that starts the quest synchronously is also caught.
+      expect(mockQuestStore.startQuest).not.toHaveBeenCalled();
+      const startTime = readQuestTimerStatics().questStartTime;
+
+      jest.advanceTimersByTime(500);
+
+      expect(mockQuestStore.startQuest).toHaveBeenCalledWith({
+        ...template,
+        startTime,
+        status: 'active',
+      });
+    });
+
+    it('does not start the quest if the phone was unlocked inside the window', async () => {
+      // Server unreachable at prepare, so there is no run id. onPhoneUnlocked
+      // then clears isPhoneLocked and early-returns without tearing down the
+      // template — which is what isolates the in-callback lock check.
+      (createQuestRun as jest.Mock).mockRejectedValue(new Error('server down'));
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+      await QuestTimer.onPhoneUnlocked();
+
+      jest.advanceTimersByTime(500);
+
+      expect(mockQuestStore.startQuest).not.toHaveBeenCalled();
+    });
+
+    it('does not start a second quest when one is already active', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+      // The store gained an active quest during the 500 ms window (e.g. a
+      // restored session). The timer must stand down.
+      mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 1 };
+
+      jest.advanceTimersByTime(500);
+
+      expect(mockQuestStore.startQuest).not.toHaveBeenCalled();
+    });
+
+    it('does not double-start a cooperative quest via the solo timer', async () => {
+      // The cooperative branch starts the quest itself once the server reports
+      // it active. If the solo/cooperative discriminator flips, the 500 ms
+      // timer starts it a second time.
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'cooperative-quest-run-id',
+        status: 'active',
+      };
+      await QuestTimer.prepareQuest(storyQuest(), 'cooperative-quest-run-id');
+
+      await QuestTimer.onPhoneLocked();
+      jest.advanceTimersByTime(500);
+
+      expect(mockQuestStore.startQuest).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -472,46 +786,326 @@ describe('QuestTimer', () => {
         'existing-coop-run-id'
       );
     });
+
+    // The discriminator is `mode === 'cooperative' || (mode === 'custom' &&
+    // category === 'cooperative')`. Flipping that `&&` to `||` makes EVERY
+    // custom quest throw. Both arms need a test or the operator is free.
+    it('creates a solo run for a custom quest in a non-cooperative category', async () => {
+      await QuestTimer.prepareQuest(customQuest({ category: 'fitness' }));
+
+      expect(createQuestRun).toHaveBeenCalledTimes(1);
+      expect(setItem).toHaveBeenCalledWith('QUEST_RUN_ID', 'mock-quest-run-id');
+    });
+
+    it('throws for a cooperative custom quest with no run id', async () => {
+      await expect(
+        QuestTimer.prepareQuest(customQuest({ category: 'cooperative' }))
+      ).rejects.toThrow(
+        'Cooperative quest must have an existing quest run ID from server'
+      );
+      expect(createQuestRun).not.toHaveBeenCalled();
+    });
+
+    it('stores cooperative run data when the server returns an invitation', async () => {
+      (createQuestRun as jest.Mock).mockResolvedValue({
+        id: 'coop-run-id',
+        invitationId: 'invitation-1',
+        // The server sends participants as bare ids or as objects; both must
+        // normalise to the object shape.
+        participants: [
+          'user-a',
+          { userId: 'user-b', ready: true, status: 'accepted' },
+        ],
+      });
+
+      await QuestTimer.prepareQuest(storyQuest());
+
+      expect(mockQuestStore.setCooperativeQuestRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'coop-run-id',
+          questId: 'test-quest-id',
+          hostId: 'test-user-id',
+          status: 'pending',
+          invitationId: 'invitation-1',
+          participants: [
+            { userId: 'user-a', ready: false, status: 'pending' },
+            { userId: 'user-b', ready: true, status: 'accepted' },
+          ],
+        })
+      );
+    });
+
+    it('does not store cooperative run data when participants are missing', async () => {
+      // Both fields are required. With `||` in place of `&&`, a solo run that
+      // happens to carry an invitationId would be promoted to cooperative.
+      (createQuestRun as jest.Mock).mockResolvedValue({
+        id: 'run-id',
+        invitationId: 'invitation-1',
+      });
+
+      await QuestTimer.prepareQuest(storyQuest());
+
+      expect(mockQuestStore.setCooperativeQuestRun).not.toHaveBeenCalled();
+    });
+
+    it('does not store cooperative run data for a solo run', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
+
+      expect(mockQuestStore.setCooperativeQuestRun).not.toHaveBeenCalled();
+    });
   });
 
-  describe('Android platform specific tests', () => {
+  describe('notification hygiene at prepare', () => {
+    it('clears stale notifications when notifications are enabled', async () => {
+      (areNotificationsEnabled as jest.Mock).mockResolvedValue(true);
+
+      await QuestTimer.prepareQuest(storyQuest());
+
+      expect(clearAllNotifications).toHaveBeenCalled();
+    });
+
+    it('does not clear notifications when the user has them disabled', async () => {
+      (areNotificationsEnabled as jest.Mock).mockResolvedValue(false);
+
+      await QuestTimer.prepareQuest(storyQuest());
+
+      expect(clearAllNotifications).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Live Activity payloads', () => {
+    it('starts the pending card with the ready copy and duration', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
+
+      expect(OneSignal.LiveActivities.startDefault).toHaveBeenCalledWith(
+        expect.any(String),
+        {
+          title: 'Quest Ready',
+          description: 'Lock your phone to begin your quest',
+        },
+        { durationMinutes: 15, status: 'pending' }
+      );
+    });
+
+    it('publishes the minted activity id to the quest store', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
+
+      const mintedId = (OneSignal.LiveActivities.startDefault as jest.Mock).mock
+        .calls[0][0];
+      expect(mockQuestStore.setLiveActivityId).toHaveBeenCalledWith(mintedId);
+    });
+
+    it('reuses the prepare-time id and flips the card to active on lock', async () => {
+      // Minting a second id here is the H1 defect: the server's stale-activity
+      // sweep would dismiss the card belonging to the running quest.
+      await QuestTimer.prepareQuest(storyQuest());
+      const preparedId = (OneSignal.LiveActivities.startDefault as jest.Mock)
+        .mock.calls[0][0];
+
+      await QuestTimer.onPhoneLocked();
+
+      expect(OneSignal.LiveActivities.startDefault).toHaveBeenLastCalledWith(
+        preparedId,
+        { title: 'Test Quest', description: 'Focus on your quest' },
+        { durationMinutes: 15, status: 'active' }
+      );
+    });
+
+    it('does not touch Live Activities on Android', async () => {
+      Platform.OS = 'android';
+
+      await QuestTimer.prepareQuest(storyQuest());
+
+      expect(OneSignal.LiveActivities.startDefault).not.toHaveBeenCalled();
+      // H2 registration is iOS-only — there is no card to register. Asserted
+      // as "not called at all" rather than by argument shape, because
+      // expect.anything() does not match null: a `not.toHaveBeenCalledWith(
+      // expect.anything(), false, expect.anything())` assertion still passes
+      // against an actual call of (runId, false, null).
+      expect(updatePhoneLockStatus).not.toHaveBeenCalled();
+
+      // The lock-time card update is iOS-only too.
+      await QuestTimer.onPhoneLocked();
+      expect(OneSignal.LiveActivities.startDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Android background service', () => {
     beforeEach(() => {
       Platform.OS = 'android';
     });
 
-    it('should use BackgroundService for Android', async () => {
-      // Arrange
-      const BackgroundService = require('react-native-background-actions');
-      const mockQuestTemplate: StoryQuestTemplate = {
-        id: 'test-quest-id',
-        title: 'Test Quest',
-        durationMinutes: 15,
-        mode: 'story',
-        recap: 'Test quest recap',
-        poiSlug: 'test-poi',
-        story: 'Test story content',
-        options: [],
-        reward: { xp: 100 },
-      };
+    it('starts the foreground service with a declared type and icon', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
 
-      // Act
-      await QuestTimer.prepareQuest(mockQuestTemplate);
-
-      // Assert
+      // Asserted as a whole object, not objectContaining: dropping
+      // foregroundServiceType kills the service on Android 14+, and an
+      // objectContaining assertion would not notice.
       expect(BackgroundService.start).toHaveBeenCalledWith(
         expect.any(Function),
-        expect.objectContaining({
+        {
           taskName: 'QuestTimer',
           taskTitle: 'Quest Ready',
           taskDesc: 'Lock your phone to begin your quest',
-          parameters: expect.objectContaining({
+          taskIcon: { name: 'ic_launcher', type: 'mipmap' },
+          color: '#77c5bf',
+          foregroundServiceType: ['specialUse'],
+          progressBar: { max: 100, value: 0, indeterminate: true },
+          parameters: {
             questDuration: 900000, // 15 * 60 * 1000
             questTitle: 'Test Quest',
+            questDescription: 'Test quest recap',
             questId: 'test-quest-id',
+          },
+        }
+      );
+    });
+
+    it('falls back to the title when the template has no recap', async () => {
+      await QuestTimer.prepareQuest(customQuest({ title: 'Go for a walk' }));
+
+      expect(BackgroundService.start).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          parameters: expect.objectContaining({
+            questDescription: 'Go for a walk',
           }),
         })
       );
-      expect(OneSignal.LiveActivities.startDefault).not.toHaveBeenCalled();
+    });
+
+    it('falls back to generic copy when the recap is empty', async () => {
+      await QuestTimer.prepareQuest(storyQuest({ recap: '' }));
+
+      expect(BackgroundService.start).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          parameters: expect.objectContaining({
+            questDescription: 'Focus on your quest',
+          }),
+        })
+      );
+    });
+
+    it('updates the notification on lock when the service is running', async () => {
+      BackgroundService.isRunning.mockReturnValue(true);
+
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+
+      expect(BackgroundService.updateNotification).toHaveBeenCalledWith({
+        taskTitle: 'Quest in progress: Test Quest',
+        taskDesc: 'Keep your phone locked for 15 minutes to complete the quest',
+        progressBar: { max: 100, value: 0, indeterminate: false },
+      });
+    });
+
+    it('does not update the notification when no service is running', async () => {
+      BackgroundService.isRunning.mockReturnValue(false);
+
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+
+      expect(BackgroundService.updateNotification).not.toHaveBeenCalled();
+    });
+
+    it('does not update the notification on iOS', async () => {
+      Platform.OS = 'ios';
+      BackgroundService.isRunning.mockReturnValue(true);
+
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+
+      expect(BackgroundService.updateNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('persistence round-trip', () => {
+    it('writes every quest key when the phone locks', async () => {
+      const template = storyQuest();
+      await QuestTimer.prepareQuest(template);
+
+      await QuestTimer.onPhoneLocked();
+
+      const { questStartTime, oneSignalActivityId } = readQuestTimerStatics();
+      expect(setItem).toHaveBeenCalledWith(
+        'QUEST_TIMER_TEMPLATE',
+        JSON.stringify(template)
+      );
+      expect(setItem).toHaveBeenCalledWith(
+        'QUEST_TIMER_START_TIME',
+        String(questStartTime)
+      );
+      expect(setItem).toHaveBeenCalledWith(
+        'ONESIGNAL_ACTIVITY_ID',
+        oneSignalActivityId
+      );
+      expect(setItem).toHaveBeenCalledWith('QUEST_RUN_ID', 'mock-quest-run-id');
+    });
+
+    it('clears the stored ids when there is no card and no run', async () => {
+      // Android mints no Live Activity; a failed createQuestRun leaves no run
+      // id. Both stale keys must be removed or a new quest attaches to a dead
+      // run / an undismissable card.
+      Platform.OS = 'android';
+      (createQuestRun as jest.Mock).mockRejectedValue(new Error('server down'));
+
+      await QuestTimer.prepareQuest(storyQuest());
+
+      expect(removeItem).toHaveBeenCalledWith('ONESIGNAL_ACTIVITY_ID');
+      expect(removeItem).toHaveBeenCalledWith('QUEST_RUN_ID');
+      expect(setItem).not.toHaveBeenCalledWith(
+        'QUEST_RUN_ID',
+        expect.anything()
+      );
+    });
+
+    it('restores a running quest from storage after an app restart', async () => {
+      // Every static is null here (fresh process). Everything the unlock path
+      // needs — run id, start time, template — has to come back out of
+      // storage, so this one assertion covers the whole read path.
+      const template = storyQuest();
+      mockStorage['QUEST_TIMER_TEMPLATE'] = JSON.stringify(template);
+      mockStorage['QUEST_TIMER_START_TIME'] = String(Date.now() - 60_000);
+      mockStorage['ONESIGNAL_ACTIVITY_ID'] = 'restored-activity-id';
+      mockStorage['QUEST_RUN_ID'] = 'restored-run-id';
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(mockQuestStore.setLiveActivityId).toHaveBeenCalledWith(
+        'restored-activity-id'
+      );
+      expect(updatePhoneLockStatus).toHaveBeenCalledWith(
+        'restored-run-id',
+        false
+      );
+      expect(mockQuestStore.failQuest).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not push a null activity id into the store on restore', async () => {
+      // Android has no Live Activity, so nothing is stored under that key.
+      // Publishing null would clear the store's handle rather than leave it.
+      mockStorage['QUEST_TIMER_TEMPLATE'] = JSON.stringify(storyQuest());
+      mockStorage['QUEST_TIMER_START_TIME'] = String(Date.now() - 60_000);
+      mockStorage['QUEST_RUN_ID'] = 'restored-run-id';
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(mockQuestStore.setLiveActivityId).not.toHaveBeenCalled();
+    });
+
+    it('does not restamp the start time when a lock event repeats', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+      const firstStart = readQuestTimerStatics().questStartTime;
+
+      // Screen off → on → off without the quest ever being unlocked. Clearing
+      // the duplicate-lock flag is what a real second lock event does.
+      readQuestTimerStatics().isPhoneLocked = false;
+      jest.advanceTimersByTime(60_000);
+      await QuestTimer.onPhoneLocked();
+
+      expect(readQuestTimerStatics().questStartTime).toBe(firstStart);
     });
   });
 });

--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -117,7 +117,17 @@ jest.mock('@/store/quest-store', () => {
   return {
     useQuestStore: {
       getState: jest.fn(() => mockStore),
-      setState: jest.fn(),
+      // Real zustand runs an updater function against the current state and
+      // merges what it returns. A bare jest.fn() stores the function and
+      // never calls it, so everything inside a `setState(state => …)` is
+      // unreachable in every test — it reads as code with no coverage rather
+      // than as an untested branch.
+      setState: jest.fn((next) => {
+        Object.assign(
+          mockStore,
+          typeof next === 'function' ? next(mockStore) : next
+        );
+      }),
       __mockStore: mockStore,
     },
   };
@@ -939,6 +949,45 @@ describe('QuestTimer', () => {
       );
     });
 
+    it('rewrites only the matching entry in the completed-quests history', async () => {
+      // The history is matched on id *and* stop time, because a repeatable
+      // quest appears in it once per run. Matching on id alone would rewrite
+      // an earlier run of the same quest with this run's rewards.
+      const earlierRun = { id: 'test-quest-id', stopTime: 6 };
+      mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 0 };
+      mockQuestStore.recentCompletedQuest = {
+        id: 'test-quest-id',
+        questRunId: 'completed-run-id',
+        stopTime: 5,
+      };
+      mockQuestStore.completedQuests = [
+        { id: 'test-quest-id', stopTime: 5 },
+        earlierRun,
+      ];
+      (getQuestRunStatus as jest.Mock).mockResolvedValue({
+        id: 'completed-run-id',
+        status: 'completed',
+        participants: [{ userId: 'u1', rewards: { adjustedXP: 120 } }],
+      });
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      jest.advanceTimersByTime(15 * 60 * 1000);
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(mockSetState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          completedQuests: [
+            expect.objectContaining({
+              stopTime: 5,
+              participants: [{ userId: 'u1', rewards: { adjustedXP: 120 } }],
+            }),
+            earlierRun,
+          ],
+        })
+      );
+    });
+
     it('skips the rewards fetch when the completed quest has no run id', async () => {
       mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 0 };
       mockQuestStore.recentCompletedQuest = { id: 'test-quest-id' };
@@ -981,6 +1030,45 @@ describe('QuestTimer', () => {
       );
       expect(mockCharacterStore.addXP).toHaveBeenCalledWith(100);
       expect(mockCharacterStore.updateStreak).toHaveBeenCalled();
+    });
+
+    it('fetches participant rewards for a quest that was stuck in pending', async () => {
+      // The rewards merge exists twice: once for a quest the store had made
+      // active, once here. Only the first arm had a test, so a stuck quest
+      // could complete showing base XP instead of the server's adjusted
+      // numbers and nothing would notice.
+      const earlierRun = { id: 'test-quest-id', stopTime: -1 };
+      questStoreMockModule.useQuestStore.__mockStore.pendingQuest = {
+        id: 'test-quest-id',
+        durationMinutes: 15,
+        reward: { xp: 100 },
+      };
+      mockQuestStore.completedQuests = [earlierRun];
+      (getQuestRunStatus as jest.Mock).mockResolvedValue({
+        id: 'mock-quest-run-id',
+        status: 'completed',
+        participants: [{ userId: 'u1', rewards: { adjustedXP: 140 } }],
+      });
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      jest.advanceTimersByTime(15 * 60 * 1000);
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(getQuestRunStatus).toHaveBeenCalledWith('mock-quest-run-id');
+      expect(mockQuestStore.recentCompletedQuest).toEqual(
+        expect.objectContaining({
+          id: 'test-quest-id',
+          participants: [{ userId: 'u1', rewards: { adjustedXP: 140 } }],
+        })
+      );
+      // The new run is rewritten in the history; the earlier one is not.
+      expect(mockQuestStore.completedQuests).toEqual([
+        earlierRun,
+        expect.objectContaining({
+          participants: [{ userId: 'u1', rewards: { adjustedXP: 140 } }],
+        }),
+      ]);
     });
 
     it('does not push a completed Live Activity on Android', async () => {

--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -6,9 +6,11 @@ import { Platform } from 'react-native';
 import { OneSignal } from 'react-native-onesignal';
 
 // Import mocked modules
+import { queryClient } from '@/api/common';
 import {
   areNotificationsEnabled,
   clearAllNotifications,
+  scheduleQuestCompletionNotification,
 } from '@/lib/services/notifications';
 import {
   createQuestRun,
@@ -143,6 +145,11 @@ jest.mock('@/store/character-store', () => {
   };
 });
 
+// backgroundTask's stuck-in-pending completion arm require()s this lazily.
+jest.mock('@/api/common', () => ({
+  queryClient: { invalidateQueries: jest.fn() },
+}));
+
 // Mock uuid
 jest.mock('uuid', () => ({
   v4: jest.fn(() => 'test-uuid-' + Math.random()),
@@ -244,6 +251,26 @@ function readQuestTimerStatics() {
     oneSignalActivityId: string | null;
   };
 }
+
+/**
+ * The background task is handed to BackgroundService.start(), which is mocked,
+ * so it never runs on its own. Pull it back off the mock to drive it directly.
+ */
+function capturedBackgroundTask(): (taskData?: {
+  questDuration: number;
+  questTitle: string;
+  questId: string;
+  questDescription: string;
+}) => Promise<void> {
+  return BackgroundService.start.mock.calls[0][0];
+}
+
+const taskDataFor = (durationMinutes = 15) => ({
+  questDuration: durationMinutes * 60 * 1000,
+  questTitle: 'Test Quest',
+  questId: 'test-quest-id',
+  questDescription: 'Test quest recap',
+});
 
 const storyQuest = (
   overrides: Partial<StoryQuestTemplate> = {}
@@ -1427,6 +1454,222 @@ describe('QuestTimer', () => {
       await QuestTimer.onPhoneLocked();
 
       expect(readQuestTimerStatics().questStartTime).toBe(firstStart);
+    });
+  });
+
+  // This is the loop that actually runs a quest while the phone is locked:
+  // elapsed-time maths, the progress notification, completion detection and
+  // teardown. None of it was executed by any test — ~180 of the module's
+  // no-coverage mutants live here.
+  //
+  // The loop is `while (BackgroundService.isRunning())`, so isRunning is the
+  // exit control. Every test below must either drive the loop to an explicit
+  // `break` or flip isRunning false, otherwise the loop's
+  // `await new Promise(r => setTimeout(r, updateInterval))` never resolves
+  // under fake timers and the test hangs instead of failing.
+  describe('backgroundTask', () => {
+    it('does nothing without task data', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
+      const backgroundTask = capturedBackgroundTask();
+      jest.clearAllMocks();
+
+      await backgroundTask();
+
+      expect(BackgroundService.updateNotification).not.toHaveBeenCalled();
+      expect(mockQuestStore.completeQuest).not.toHaveBeenCalled();
+    });
+
+    it('reports elapsed progress on the Android notification', async () => {
+      Platform.OS = 'android';
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      const backgroundTask = capturedBackgroundTask();
+      BackgroundService.updateNotification.mockClear();
+      // Exactly half way through, so the percentage maths is pinned to a value
+      // that is not 0 or 100 — either of which several mutants also produce.
+      jest.advanceTimersByTime(7.5 * 60 * 1000);
+      let iterations = 0;
+      BackgroundService.isRunning.mockImplementation(() => iterations++ < 1);
+
+      const running = backgroundTask(taskDataFor(15));
+      await jest.advanceTimersByTimeAsync(9000); // the loop's update interval
+      await running;
+
+      expect(BackgroundService.updateNotification).toHaveBeenCalledWith({
+        progressBar: { max: 100, value: 50, indeterminate: false },
+      });
+      expect(mockQuestStore.completeQuest).not.toHaveBeenCalled();
+    });
+
+    it('completes the quest once the duration elapses', async () => {
+      mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 0 };
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      const backgroundTask = capturedBackgroundTask();
+      const activityId = readQuestTimerStatics().oneSignalActivityId;
+      jest.advanceTimersByTime(15 * 60 * 1000);
+      BackgroundService.isRunning.mockReturnValue(true);
+      (OneSignal.LiveActivities.startDefault as jest.Mock).mockClear();
+
+      await backgroundTask(taskDataFor(15));
+
+      expect(mockQuestStore.completeQuest).toHaveBeenCalledWith(true);
+      expect(BackgroundService.updateNotification).toHaveBeenCalledWith({
+        progressBar: { max: 100, value: 100, indeterminate: false },
+      });
+      expect(OneSignal.LiveActivities.startDefault).toHaveBeenCalledWith(
+        activityId,
+        {
+          title: 'Quest Complete',
+          description: 'Congratulations on finishing your quest!',
+        },
+        { durationMinutes: 15, status: 'completed' }
+      );
+      // Teardown, or the service keeps running after the quest is over.
+      expect(BackgroundService.stop).toHaveBeenCalled();
+      expect(removeItem).toHaveBeenCalledWith('QUEST_RUN_ID');
+    });
+
+    it('schedules the completion notification on Android only', async () => {
+      Platform.OS = 'android';
+      mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 0 };
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      const backgroundTask = capturedBackgroundTask();
+      jest.advanceTimersByTime(15 * 60 * 1000);
+      BackgroundService.isRunning.mockReturnValue(true);
+      (OneSignal.LiveActivities.startDefault as jest.Mock).mockClear();
+
+      await backgroundTask(taskDataFor(15));
+
+      expect(scheduleQuestCompletionNotification).toHaveBeenCalledWith(
+        'test-quest-id'
+      );
+      // Android has no Live Activity to complete.
+      expect(OneSignal.LiveActivities.startDefault).not.toHaveBeenCalled();
+    });
+
+    it('does not schedule a completion notification on iOS', async () => {
+      mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 0 };
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      const backgroundTask = capturedBackgroundTask();
+      jest.advanceTimersByTime(15 * 60 * 1000);
+      BackgroundService.isRunning.mockReturnValue(true);
+
+      await backgroundTask(taskDataFor(15));
+
+      expect(scheduleQuestCompletionNotification).not.toHaveBeenCalled();
+    });
+
+    it('tears down when it notices the phone was unlocked', async () => {
+      await QuestTimer.prepareQuest(storyQuest());
+      await QuestTimer.onPhoneLocked();
+      const backgroundTask = capturedBackgroundTask();
+      // The unlock listener has already flipped the flag. The loop has to
+      // notice and stop, rather than ticking against an abandoned quest.
+      readQuestTimerStatics().isPhoneLocked = false;
+      BackgroundService.isRunning.mockReturnValue(true);
+      BackgroundService.updateNotification.mockClear();
+
+      await backgroundTask(taskDataFor(15));
+
+      expect(BackgroundService.stop).toHaveBeenCalled();
+      expect(BackgroundService.updateNotification).not.toHaveBeenCalled();
+      expect(mockQuestStore.completeQuest).not.toHaveBeenCalled();
+    });
+
+    it('completes a cooperative quest still stuck in the pending state', async () => {
+      questStoreMockModule.useQuestStore.__mockStore.pendingQuest = {
+        id: 'test-quest-id',
+        durationMinutes: 15,
+        reward: { xp: 100 },
+      };
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      const backgroundTask = capturedBackgroundTask();
+      jest.advanceTimersByTime(15 * 60 * 1000);
+      BackgroundService.isRunning.mockReturnValue(true);
+
+      await backgroundTask(taskDataFor(15));
+
+      expect(mockSetState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pendingQuest: null,
+          activeQuest: null,
+          recentCompletedQuest: expect.objectContaining({
+            id: 'test-quest-id',
+            status: 'completed',
+          }),
+        })
+      );
+      expect(mockCharacterStore.addXP).toHaveBeenCalledWith(100);
+      expect(mockCharacterStore.updateStreak).toHaveBeenCalled();
+      // Stale user details would otherwise show the pre-quest XP.
+      expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['user', 'details'],
+      });
+    });
+
+    it('starts a cooperative quest once the server reports it active', async () => {
+      // Locked, but the server had not activated the run when the service
+      // started, so no start time was ever stamped.
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'coop-run-id',
+        status: 'pending',
+      };
+      const template = storyQuest();
+      await QuestTimer.prepareQuest(template, 'coop-run-id');
+      const backgroundTask = capturedBackgroundTask();
+      const actualStartTime = Date.now() - 60_000;
+      (getQuestRunStatus as jest.Mock).mockResolvedValue({
+        id: 'coop-run-id',
+        status: 'active',
+        actualStartTime,
+        scheduledEndTime: actualStartTime + 900_000,
+      });
+      readQuestTimerStatics().isPhoneLocked = true;
+      let iterations = 0;
+      BackgroundService.isRunning.mockImplementation(() => iterations++ < 1);
+      mockQuestStore.startQuest.mockClear();
+
+      const running = backgroundTask(taskDataFor(15));
+      await jest.advanceTimersByTimeAsync(9000);
+      await running;
+
+      // Anchored to the server's time, not Date.now(), or this participant
+      // finishes at a different moment from everyone else in the run.
+      expect(mockQuestStore.startQuest).toHaveBeenCalledWith({
+        ...template,
+        startTime: actualStartTime,
+        status: 'active',
+      });
+      expect(mockQuestStore.setCooperativeQuestRun).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'coop-run-id', status: 'active' })
+      );
+    });
+
+    it('fails the quest when the server reports the cooperative run failed', async () => {
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'coop-run-id',
+        status: 'pending',
+      };
+      await QuestTimer.prepareQuest(storyQuest(), 'coop-run-id');
+      const backgroundTask = capturedBackgroundTask();
+      (getQuestRunStatus as jest.Mock).mockResolvedValue({
+        id: 'coop-run-id',
+        status: 'failed',
+      });
+      readQuestTimerStatics().isPhoneLocked = true;
+      BackgroundService.isRunning.mockReturnValue(true);
+
+      await backgroundTask(taskDataFor(15));
+
+      expect(mockQuestStore.setCooperativeQuestRun).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'coop-run-id', status: 'failed' })
+      );
+      expect(mockQuestStore.failQuest).toHaveBeenCalled();
+      expect(BackgroundService.stop).toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -562,6 +562,50 @@ describe('QuestTimer', () => {
       );
     });
 
+    it('retries the lock report after a failed attempt', async () => {
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'coop-run-id',
+        status: 'pending',
+      };
+      await QuestTimer.prepareQuest(storyQuest(), 'coop-run-id');
+      (updatePhoneLockStatus as jest.Mock)
+        .mockClear()
+        .mockRejectedValueOnce(new Error('offline'));
+
+      const locking = QuestTimer.onPhoneLocked();
+      // The ladder waits a second between attempts. Without this the second
+      // attempt never happens and the assertion below reads 1.
+      await jest.advanceTimersByTimeAsync(1000);
+      await locking;
+
+      expect(updatePhoneLockStatus).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up after three attempts and still starts the quest', async () => {
+      // A phone that locks in a dead spot must not lose the quest. The
+      // ladder's return value is discarded on purpose: the lock report is
+      // best-effort, and activation is decided by the status check that
+      // follows it.
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'coop-run-id',
+        status: 'pending',
+      };
+      await QuestTimer.prepareQuest(storyQuest(), 'coop-run-id');
+      (updatePhoneLockStatus as jest.Mock)
+        .mockClear()
+        .mockRejectedValue(new Error('offline'));
+
+      const locking = QuestTimer.onPhoneLocked();
+      await jest.advanceTimersByTimeAsync(2000);
+      await locking;
+
+      expect(updatePhoneLockStatus).toHaveBeenCalledTimes(3);
+      expect(getQuestRunStatus).toHaveBeenCalledWith('coop-run-id');
+      expect(mockQuestStore.setCooperativeQuestRun).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'coop-run-id', status: 'active' })
+      );
+    });
+
     it('starts a cooperative quest at the server-supplied start time', async () => {
       const actualStartTime = 1_700_000_000_000;
       mockQuestStore.cooperativeQuestRun = {

--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -16,6 +16,7 @@ import {
   updatePhoneLockStatus,
 } from '@/lib/services/quest-run-service';
 import { removeItem, setItem } from '@/lib/storage';
+import { useUserStore } from '@/store/user-store';
 // Import the store for assertions
 // Import types
 import type {
@@ -168,6 +169,12 @@ const mockQuestStore = (
         setCooperativeQuestRun: jest.Mock;
         activeQuest: { id: string; startTime: number } | null;
         cooperativeQuestRun: { id: string; status: string } | null;
+        recentCompletedQuest: {
+          id: string;
+          questRunId?: string;
+          stopTime?: number;
+        } | null;
+        completedQuests: unknown[];
       };
     };
   }
@@ -247,6 +254,8 @@ describe('QuestTimer', () => {
     resetQuestTimerStatics();
     mockQuestStore.activeQuest = null;
     mockQuestStore.cooperativeQuestRun = null;
+    mockQuestStore.recentCompletedQuest = null;
+    mockQuestStore.completedQuests = [];
     BackgroundService.isRunning.mockReturnValue(false);
     // clearAllMocks only clears call records, not implementations. Re-establish
     // createQuestRun's default resolved value so a prior test's mockRejectedValue
@@ -254,6 +263,22 @@ describe('QuestTimer', () => {
     // reset between tests; M1's prepare-time reset removes that masking.)
     (createQuestRun as jest.Mock).mockResolvedValue({
       id: 'mock-quest-run-id',
+    });
+    // Same reason: tests that stage a 'pending' or 'failed' run would
+    // otherwise leak that status into every later cooperative test.
+    (getQuestRunStatus as jest.Mock).mockResolvedValue({
+      id: 'mock-quest-run-id',
+      status: 'active',
+      actualStartTime: Date.now(),
+      scheduledEndTime: Date.now() + 900000,
+    });
+    (updatePhoneLockStatus as jest.Mock).mockResolvedValue({
+      id: 'mock-quest-run-id',
+      status: 'active',
+      participants: [],
+    });
+    (useUserStore.getState as jest.Mock).mockReturnValue({
+      user: { id: 'test-user-id' },
     });
     // Clear the mock storage
     Object.keys(mockStorage).forEach((key) => delete mockStorage[key]);
@@ -456,14 +481,118 @@ describe('QuestTimer', () => {
         status: 'pending',
       };
       await QuestTimer.prepareQuest(storyQuest(), 'coop-run-id');
+      const activityId = readQuestTimerStatics().oneSignalActivityId;
+      (updatePhoneLockStatus as jest.Mock).mockClear();
 
       await QuestTimer.onPhoneLocked();
 
+      // The cooperative branch still reports the lock, and carries the live
+      // activity id so the server can dismiss the card.
+      expect(updatePhoneLockStatus).toHaveBeenCalledWith(
+        'coop-run-id',
+        true,
+        activityId
+      );
       // Only the cooperative branch polls the server for activation.
       expect(getQuestRunStatus).toHaveBeenCalledWith('coop-run-id');
       expect(mockQuestStore.setCooperativeQuestRun).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'coop-run-id', status: 'active' })
       );
+    });
+
+    it('starts a cooperative quest at the server-supplied start time', async () => {
+      const actualStartTime = 1_700_000_000_000;
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'coop-run-id',
+        status: 'pending',
+      };
+      (getQuestRunStatus as jest.Mock).mockResolvedValue({
+        id: 'coop-run-id',
+        status: 'active',
+        actualStartTime,
+        scheduledEndTime: actualStartTime + 900_000,
+      });
+      const template = storyQuest();
+      await QuestTimer.prepareQuest(template, 'coop-run-id');
+
+      await QuestTimer.onPhoneLocked();
+
+      // Falling back to Date.now() here would desynchronise this participant
+      // from everyone else in the run.
+      expect(mockQuestStore.startQuest).toHaveBeenCalledWith({
+        ...template,
+        startTime: actualStartTime,
+        status: 'active',
+      });
+    });
+
+    it('does not start a cooperative quest the server has not activated', async () => {
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'coop-run-id',
+        status: 'pending',
+      };
+      (getQuestRunStatus as jest.Mock).mockResolvedValue({
+        id: 'coop-run-id',
+        status: 'pending',
+        actualStartTime: undefined,
+      });
+      await QuestTimer.prepareQuest(storyQuest(), 'coop-run-id');
+
+      await QuestTimer.onPhoneLocked();
+      jest.advanceTimersByTime(500);
+
+      expect(mockQuestStore.startQuest).not.toHaveBeenCalled();
+      expect(mockQuestStore.setCooperativeQuestRun).not.toHaveBeenCalled();
+    });
+
+    it('fails the local quest when the server says the run already failed', async () => {
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'coop-run-id',
+        status: 'pending',
+      };
+      (getQuestRunStatus as jest.Mock).mockResolvedValue({
+        id: 'coop-run-id',
+        status: 'failed',
+      });
+      await QuestTimer.prepareQuest(storyQuest(), 'coop-run-id');
+
+      await QuestTimer.onPhoneLocked();
+
+      expect(mockQuestStore.setCooperativeQuestRun).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'coop-run-id', status: 'failed' })
+      );
+      expect(mockQuestStore.failQuest).toHaveBeenCalled();
+    });
+
+    it('does not restart a cooperative quest that is already active locally', async () => {
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'coop-run-id',
+        status: 'pending',
+      };
+      mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 1 };
+      await QuestTimer.prepareQuest(storyQuest(), 'coop-run-id');
+
+      await QuestTimer.onPhoneLocked();
+
+      expect(mockQuestStore.startQuest).not.toHaveBeenCalled();
+    });
+
+    it('updates the Android notification when a cooperative quest activates', async () => {
+      Platform.OS = 'android';
+      BackgroundService.isRunning.mockReturnValue(true);
+      mockQuestStore.cooperativeQuestRun = {
+        id: 'coop-run-id',
+        status: 'pending',
+      };
+      await QuestTimer.prepareQuest(storyQuest(), 'coop-run-id');
+
+      await QuestTimer.onPhoneLocked();
+
+      expect(BackgroundService.updateNotification).toHaveBeenCalledWith({
+        taskTitle: 'Quest in progress: Test Quest',
+        taskDesc: 'Keep your phone locked for 15 minutes to complete the quest',
+        progressBar: { max: 100, value: 0, indeterminate: false },
+      });
     });
 
     it('sends lock status through the solo path for a solo run', async () => {
@@ -578,12 +707,18 @@ describe('QuestTimer', () => {
       // static null the method is inert under every mutation of it, so such a
       // test asserts nothing. This one has a run id and a template, and only
       // the missing start time stops it — so inverting the guard is visible.
+      //
+      // activeQuest is staged so that the downstream `questStartTime &&
+      // questTemplate` guard is observable too: relaxing it to `||` would
+      // reach the fallback completion call below.
+      mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 0 };
       await QuestTimer.prepareQuest(storyQuest());
       (updatePhoneLockStatus as jest.Mock).mockClear();
 
       await QuestTimer.onPhoneUnlocked();
 
       expect(mockQuestStore.failQuest).not.toHaveBeenCalled();
+      expect(mockQuestStore.completeQuest).not.toHaveBeenCalled();
       expect(updatePhoneLockStatus).not.toHaveBeenCalled();
     });
 
@@ -649,6 +784,56 @@ describe('QuestTimer', () => {
         },
         { durationMinutes: 15, status: 'completed' }
       );
+    });
+
+    it('does not complete a quest the store is not actually running', async () => {
+      // The store moved on to a different quest. Completing on id mismatch
+      // would credit the wrong quest.
+      mockQuestStore.activeQuest = { id: 'some-other-quest', startTime: 0 };
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      jest.advanceTimersByTime(15 * 60 * 1000);
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(mockQuestStore.completeQuest).not.toHaveBeenCalled();
+    });
+
+    it('fetches participant rewards for a completed run', async () => {
+      mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 0 };
+      mockQuestStore.recentCompletedQuest = {
+        id: 'test-quest-id',
+        questRunId: 'completed-run-id',
+        stopTime: 5,
+      };
+      (getQuestRunStatus as jest.Mock).mockResolvedValue({
+        id: 'completed-run-id',
+        status: 'completed',
+        participants: [{ userId: 'u1', rewards: { adjustedXP: 120 } }],
+      });
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      jest.advanceTimersByTime(15 * 60 * 1000);
+      (getQuestRunStatus as jest.Mock).mockClear();
+
+      await QuestTimer.onPhoneUnlocked();
+
+      // Skipping this leaves the results screen showing base XP rather than
+      // the server's adjusted, perk-applied numbers.
+      expect(getQuestRunStatus).toHaveBeenCalledWith('completed-run-id');
+    });
+
+    it('does not push a completed Live Activity on Android', async () => {
+      Platform.OS = 'android';
+      mockQuestStore.activeQuest = { id: 'test-quest-id', startTime: 0 };
+      await QuestTimer.prepareQuest(storyQuest({ durationMinutes: 15 }));
+      await QuestTimer.onPhoneLocked();
+      jest.advanceTimersByTime(15 * 60 * 1000);
+
+      await QuestTimer.onPhoneUnlocked();
+
+      expect(mockQuestStore.completeQuest).toHaveBeenCalledWith(true);
+      expect(OneSignal.LiveActivities.startDefault).not.toHaveBeenCalled();
     });
 
     it('shows the failure notification on Android instead of a Live Activity', async () => {
@@ -832,6 +1017,53 @@ describe('QuestTimer', () => {
             { userId: 'user-b', ready: true, status: 'accepted' },
           ],
         })
+      );
+    });
+
+    it('prefers the server questId over the local template id', async () => {
+      // The fallback chain ends at `quest-${run.id}`. Getting the order wrong
+      // attaches the run to the wrong quest in the store.
+      (createQuestRun as jest.Mock).mockResolvedValue({
+        id: 'coop-run-id',
+        questId: 'server-quest-id',
+        invitationId: 'invitation-1',
+        participants: [],
+      });
+
+      await QuestTimer.prepareQuest(storyQuest());
+
+      expect(mockQuestStore.setCooperativeQuestRun).toHaveBeenCalledWith(
+        expect.objectContaining({ questId: 'server-quest-id' })
+      );
+    });
+
+    it('falls back to the nested quest id when the server sends no questId', async () => {
+      (createQuestRun as jest.Mock).mockResolvedValue({
+        id: 'coop-run-id',
+        quest: { id: 'nested-quest-id' },
+        invitationId: 'invitation-1',
+        participants: [],
+      });
+
+      await QuestTimer.prepareQuest(storyQuest());
+
+      expect(mockQuestStore.setCooperativeQuestRun).toHaveBeenCalledWith(
+        expect.objectContaining({ questId: 'nested-quest-id' })
+      );
+    });
+
+    it('records an empty host id when there is no signed-in user', async () => {
+      (useUserStore.getState as jest.Mock).mockReturnValue({ user: null });
+      (createQuestRun as jest.Mock).mockResolvedValue({
+        id: 'coop-run-id',
+        invitationId: 'invitation-1',
+        participants: [],
+      });
+
+      await QuestTimer.prepareQuest(storyQuest());
+
+      expect(mockQuestStore.setCooperativeQuestRun).toHaveBeenCalledWith(
+        expect.objectContaining({ hostId: '' })
       );
     });
 

--- a/src/lib/services/quest-timer.test.ts
+++ b/src/lib/services/quest-timer.test.ts
@@ -709,6 +709,10 @@ describe('QuestTimer', () => {
         taskDesc: 'Keep your phone locked for 15 minutes to complete the quest',
         progressBar: { max: 100, value: 0, indeterminate: false },
       });
+      // Exactly once. The cooperative activation branch used to post this
+      // notification itself and then fall through to the shared call at the
+      // end of onPhoneLocked, which posts the identical payload.
+      expect(BackgroundService.updateNotification).toHaveBeenCalledTimes(1);
     });
 
     it('sends lock status through the solo path for a solo run', async () => {

--- a/src/lib/services/quest-timer.ts
+++ b/src/lib/services/quest-timer.ts
@@ -24,7 +24,10 @@ import { useUserStore } from '@/store/user-store';
 // --- Linter Fix for Type Errors ---
 // Helper function to safely parse JSON from storage
 function parseJson<T>(jsonString: string | null | undefined): T | null {
-  if (jsonString && typeof jsonString === 'string') {
+  // No `typeof jsonString === 'string'` operand: the signature already
+  // guarantees it, so the check could only ever be redundant — an unkillable
+  // branch that no test can distinguish from its absence.
+  if (jsonString) {
     try {
       return JSON.parse(jsonString) as T;
     } catch (e) {
@@ -37,7 +40,7 @@ function parseJson<T>(jsonString: string | null | undefined): T | null {
 
 // Helper function to safely parse Int from storage
 function parseIntSafe(value: string | null | undefined): number | null {
-  if (value && typeof value === 'string') {
+  if (value) {
     const parsed = parseInt(value, 10);
     return !isNaN(parsed) ? parsed : null;
   }
@@ -116,14 +119,9 @@ export default class QuestTimer {
 
       // Update the store with the live activity ID if it exists
       if (this.oneSignalActivityId) {
-        const store = useQuestStore.getState();
-        if (typeof store.setLiveActivityId === 'function') {
-          store.setLiveActivityId(this.oneSignalActivityId);
-        } else {
-          console.warn(
-            'setLiveActivityId function not found in quest store state.'
-          );
-        }
+        // The store always defines setLiveActivityId, so the old
+        // `typeof … === 'function'` guard had a permanently dead else branch.
+        useQuestStore.getState().setLiveActivityId(this.oneSignalActivityId);
       }
     } catch (error) {
       console.error('Error loading quest data:', error);
@@ -274,10 +272,7 @@ export default class QuestTimer {
           attributes,
           pendingContent
         );
-        const store = useQuestStore.getState();
-        if (typeof store.setLiveActivityId === 'function') {
-          store.setLiveActivityId(this.oneSignalActivityId);
-        }
+        useQuestStore.getState().setLiveActivityId(this.oneSignalActivityId);
       } catch (error) {
         console.error(
           'Error starting pending OneSignal Live Activity (Default):',

--- a/src/lib/services/quest-timer.ts
+++ b/src/lib/services/quest-timer.ts
@@ -486,25 +486,9 @@ export default class QuestTimer {
                 questStore.startQuest(quest);
               }
 
-              // Update Android notification to show quest is active
-              if (Platform.OS === 'android' && BackgroundService.isRunning()) {
-                try {
-                  await BackgroundService.updateNotification({
-                    taskTitle: `Quest in progress: ${this.questTemplate.title}`,
-                    taskDesc: `Keep your phone locked for ${this.questTemplate.durationMinutes} minutes to complete the quest`,
-                    progressBar: {
-                      max: 100,
-                      value: 0,
-                      indeterminate: false,
-                    },
-                  });
-                } catch (error) {
-                  console.error(
-                    '[QuestTimer] Failed to update Android notification:',
-                    error
-                  );
-                }
-              }
+              // No Android notification update here. Every path through this
+              // method falls through to the shared one at the end, which posts
+              // the identical payload.
             } else if (questRun.status === 'failed') {
               console.log(
                 '[QuestTimer] Quest already failed by another participant'

--- a/src/lib/services/revenuecat-service.test.ts
+++ b/src/lib/services/revenuecat-service.test.ts
@@ -473,6 +473,197 @@ describe('RevenueCatService remaining public surface', () => {
   });
 });
 
+describe('RevenueCatService.presentPaywall result handling', () => {
+  let service: RevenueCatService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silenceConsole();
+    // A fresh instance per test. The configuration-error branch below latches
+    // `testModeEnabled` on the instance, and every later paywall call on that
+    // instance would then take the simulated-purchase shortcut.
+    service = freshService();
+    service.initialize();
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('reports success and refreshes entitlements when the purchase was restored', async () => {
+    mockPresentPaywall.mockResolvedValue('RESTORED');
+    (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({});
+
+    await expect(service.presentPaywall('settings')).resolves.toBe(true);
+
+    expect(Purchases.getCustomerInfo).toHaveBeenCalled();
+    expect(posthogClient.capture).toHaveBeenCalledWith(
+      'restore_purchases_succeeded',
+      { source: 'settings', method: 'paywall' }
+    );
+  });
+
+  it('reports failure when the paywall was never shown', async () => {
+    mockPresentPaywall.mockResolvedValue('NOT_PRESENTED');
+
+    await expect(service.presentPaywall('settings')).resolves.toBe(false);
+    expect(Purchases.getCustomerInfo).not.toHaveBeenCalled();
+  });
+
+  it('reports failure for a result the switch does not recognise', async () => {
+    // A newer SDK adding a result value must not read as a purchase.
+    mockPresentPaywall.mockResolvedValue('SOME_FUTURE_RESULT');
+
+    await expect(service.presentPaywall('settings')).resolves.toBe(false);
+    expect(Purchases.getCustomerInfo).not.toHaveBeenCalled();
+  });
+
+  it('simulates a purchase once test mode is on, without showing a paywall', async () => {
+    jest.useFakeTimers();
+    try {
+      service.enableTestMode();
+
+      const pending = service.presentPaywall('settings');
+      await jest.advanceTimersByTimeAsync(1500);
+
+      await expect(pending).resolves.toBe(true);
+      expect(mockPresentPaywall).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('RevenueCatService.presentPaywall failure handling', () => {
+  const originalDev = __DEV__;
+  let service: RevenueCatService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silenceConsole();
+    service = freshService();
+    service.initialize();
+  });
+
+  afterEach(() => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = originalDev;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * Rejects the first paywall call and resolves 'CANCELLED' on any later one.
+   *
+   * The retry is recursive: the catch block sets test mode and calls
+   * presentPaywall again. Rejecting every time would make the recursion
+   * unbounded whenever test mode fails to be set, so the test would hang
+   * rather than fail. Resolving the second call turns the same defect into a
+   * plain wrong return value.
+   */
+  function failOnceThenCancel(error: unknown) {
+    mockPresentPaywall
+      .mockReset()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue('CANCELLED');
+  }
+
+  it('falls back to a simulated purchase when development is misconfigured', async () => {
+    jest.useFakeTimers();
+    failOnceThenCancel(new Error('No offerings found for this app'));
+
+    const pending = service.presentPaywall('settings');
+    await jest.advanceTimersByTimeAsync(1500);
+
+    await expect(pending).resolves.toBe(true);
+    // The retry takes the test-mode shortcut, so the SDK is not asked twice.
+    expect(mockPresentPaywall).toHaveBeenCalledTimes(1);
+    expect(posthogClient.capture).not.toHaveBeenCalledWith(
+      'purchase_failed',
+      expect.anything()
+    );
+  });
+
+  it('recognises a missing bundle ID as the same misconfiguration', async () => {
+    jest.useFakeTimers();
+    failOnceThenCancel(new Error('Bundle ID does not match'));
+
+    const pending = service.presentPaywall('settings');
+    await jest.advanceTimersByTimeAsync(1500);
+
+    await expect(pending).resolves.toBe(true);
+  });
+
+  it('recognises the native configuration-error code', async () => {
+    // iOS reports it here rather than on error.message.
+    jest.useFakeTimers();
+    failOnceThenCancel(
+      Object.assign(new Error('unhelpful'), {
+        userInfo: { readable_error_code: 'CONFIGURATION_ERROR' },
+      })
+    );
+
+    const pending = service.presentPaywall('settings');
+    await jest.advanceTimersByTimeAsync(1500);
+
+    await expect(pending).resolves.toBe(true);
+  });
+
+  it('reports a store failure rather than pretending the purchase worked', async () => {
+    failOnceThenCancel(
+      Object.assign(new Error('store blew up'), { code: 'STORE_PROBLEM' })
+    );
+
+    await expect(service.presentPaywall('settings')).rejects.toThrow(
+      'store blew up'
+    );
+    expect(mockPresentPaywall).toHaveBeenCalledTimes(1);
+    expect(posthogClient.capture).toHaveBeenCalledWith('purchase_failed', {
+      source: 'settings',
+      method: 'paywall',
+      error_code: 'STORE_PROBLEM',
+    });
+  });
+
+  it('reports the message when the failure carries no code', async () => {
+    failOnceThenCancel(new Error('offerings unavailable'));
+
+    await expect(service.presentPaywall('settings')).rejects.toThrow(
+      'offerings unavailable'
+    );
+    expect(posthogClient.capture).toHaveBeenCalledWith('purchase_failed', {
+      source: 'settings',
+      method: 'paywall',
+      error_code: 'offerings unavailable',
+    });
+  });
+
+  it('never enables test mode in a production build', async () => {
+    // The same misconfiguration that unlocks premium for free in development
+    // must reach the user as a failure once __DEV__ is off.
+    (globalThis as { __DEV__?: boolean }).__DEV__ = false;
+    failOnceThenCancel(new Error('No offerings found for this app'));
+
+    await expect(service.presentPaywall('settings')).rejects.toThrow(
+      'No offerings found'
+    );
+    expect(posthogClient.capture).toHaveBeenCalledWith('purchase_failed', {
+      source: 'settings',
+      method: 'paywall',
+      error_code: 'No offerings found for this app',
+    });
+  });
+
+  it('survives a rejection with no error object', async () => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = false;
+    failOnceThenCancel(undefined);
+
+    await expect(service.presentPaywall('settings')).rejects.toBeUndefined();
+    expect(posthogClient.capture).toHaveBeenCalledWith('purchase_failed', {
+      source: 'settings',
+      method: 'paywall',
+      error_code: 'unknown',
+    });
+  });
+});
+
 describe('RevenueCatService error propagation', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/lib/services/revenuecat-service.test.ts
+++ b/src/lib/services/revenuecat-service.test.ts
@@ -299,6 +299,42 @@ describe('RevenueCatService.refreshCustomerInfo recovery', () => {
     ).resolves.toMatchObject({ activeSubscriptions: [] });
   });
 
+  it('rethrows a rejection that carries no message at all', async () => {
+    // `error.message?.includes(...)` without the optional chain turns this
+    // into a TypeError thrown from the handler, hiding the real failure.
+    (Purchases.getCustomerInfo as jest.Mock).mockRejectedValue({
+      code: 'STORE_PROBLEM',
+    });
+
+    await expect(revenueCatService.refreshCustomerInfo()).rejects.toEqual({
+      code: 'STORE_PROBLEM',
+    });
+  });
+
+  it('rethrows when userInfo exists but carries no description', async () => {
+    (Purchases.getCustomerInfo as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('boom'), { userInfo: {} })
+    );
+
+    await expect(revenueCatService.refreshCustomerInfo()).rejects.toThrow(
+      'boom'
+    );
+  });
+
+  it('rethrows when the native description is some other error', async () => {
+    // Blanking the matched phrase makes `includes('')` always true, which
+    // would swallow every native error as "no active account".
+    (Purchases.getCustomerInfo as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('boom'), {
+        userInfo: { description: 'Receipt validation failed' },
+      })
+    );
+
+    await expect(revenueCatService.refreshCustomerInfo()).rejects.toThrow(
+      'boom'
+    );
+  });
+
   it('rethrows any other failure instead of inventing an empty account', async () => {
     // Swallowing this would report every paying user as unsubscribed the
     // moment the network blips.
@@ -671,6 +707,16 @@ describe('RevenueCatService analytics', () => {
       expect(posthogClient.capture).toHaveBeenCalledWith('purchase_cancelled', {
         source: 'settings',
         method: 'paywall',
+      });
+    });
+
+    it('attributes the view to "unknown" when no source is given', async () => {
+      mockPresentPaywall.mockResolvedValue('CANCELLED');
+
+      await revenueCatService.presentPaywall();
+
+      expect(posthogClient.capture).toHaveBeenCalledWith('paywall_viewed', {
+        source: 'unknown',
       });
     });
 

--- a/src/lib/services/revenuecat-service.test.ts
+++ b/src/lib/services/revenuecat-service.test.ts
@@ -1,9 +1,35 @@
+import { Env } from '@env';
+import { Platform } from 'react-native';
 import Purchases from 'react-native-purchases';
 import RevenueCatUI from 'react-native-purchases-ui';
 
 import { posthogClient } from '@/lib/posthog';
 
-import { revenueCatService } from './revenuecat-service';
+import { RevenueCatService, revenueCatService } from './revenuecat-service';
+
+// `Env` is `Constants.expoConfig?.extra ?? {}`, and under Jest expoConfig has
+// no `extra` — so every Env.* value is undefined by default. Without this stub
+// the iOS and Android branches of initialize() both configure RevenueCat with
+// `{ apiKey: undefined }` and no assertion can tell them apart.
+jest.mock('expo-constants', () => {
+  const actual = jest.requireActual('expo-constants');
+  const actualDefault = actual.default ?? actual;
+  return {
+    ...actual,
+    __esModule: true,
+    default: {
+      ...actualDefault,
+      expoConfig: {
+        ...(actualDefault.expoConfig ?? {}),
+        extra: {
+          ...(actualDefault.expoConfig?.extra ?? {}),
+          REVENUECAT_APPLE_API_KEY: 'test-apple-api-key',
+          REVENUECAT_GOOGLE_API_KEY: 'test-google-api-key',
+        },
+      },
+    },
+  };
+});
 
 // Override the global jest-setup mock: the service's paywall flow needs the
 // PAYWALL_RESULT enum, which the global mock does not provide.
@@ -30,6 +56,223 @@ const testPackage = {
     currencyCode: 'USD',
   },
 } as any;
+
+/**
+ * A never-initialized instance. The exported singleton is initialized once for
+ * the whole file, so every "not initialized" guard and the platform key
+ * selection in initialize() are otherwise unreachable.
+ */
+function freshService(): RevenueCatService {
+  (RevenueCatService as unknown as { instance?: RevenueCatService }).instance =
+    undefined;
+  return RevenueCatService.getInstance();
+}
+
+function silenceConsole() {
+  jest.spyOn(console, 'log').mockImplementation();
+  jest.spyOn(console, 'error').mockImplementation();
+}
+
+describe('RevenueCatService.initialize', () => {
+  const originalPlatform = Platform.OS;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silenceConsole();
+  });
+
+  afterEach(() => {
+    Platform.OS = originalPlatform;
+    jest.restoreAllMocks();
+  });
+
+  // Guard the guard: if the two keys were ever the same value, the two tests
+  // below would pass against an implementation that always picks one of them.
+  it('has distinct API keys per platform to assert against', () => {
+    expect(Env.REVENUECAT_APPLE_API_KEY).toBeTruthy();
+    expect(Env.REVENUECAT_GOOGLE_API_KEY).toBeTruthy();
+    expect(Env.REVENUECAT_APPLE_API_KEY).not.toBe(
+      Env.REVENUECAT_GOOGLE_API_KEY
+    );
+  });
+
+  it('configures with the Apple key on iOS', () => {
+    Platform.OS = 'ios';
+
+    freshService().initialize();
+
+    expect(Purchases.configure).toHaveBeenCalledTimes(1);
+    expect(Purchases.configure).toHaveBeenCalledWith({
+      apiKey: Env.REVENUECAT_APPLE_API_KEY,
+    });
+  });
+
+  it('configures with the Google key on Android', () => {
+    Platform.OS = 'android';
+
+    freshService().initialize();
+
+    expect(Purchases.configure).toHaveBeenCalledTimes(1);
+    expect(Purchases.configure).toHaveBeenCalledWith({
+      apiKey: Env.REVENUECAT_GOOGLE_API_KEY,
+    });
+  });
+
+  it('configures the SDK exactly once across repeated calls', () => {
+    const service = freshService();
+
+    service.initialize();
+    service.initialize();
+
+    expect(Purchases.configure).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports itself unconfigured until initialize() runs', () => {
+    const service = freshService();
+
+    expect(service.isConfigured()).toBe(false);
+    service.initialize();
+    expect(service.isConfigured()).toBe(true);
+  });
+
+  it('hands back the same singleton to every caller', () => {
+    // A broken singleton silently resets isInitialized per caller, so every
+    // "not initialized" guard starts firing in production.
+    expect(RevenueCatService.getInstance()).toBe(
+      RevenueCatService.getInstance()
+    );
+  });
+});
+
+describe('RevenueCatService guards before initialization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silenceConsole();
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('refuses to refresh customer info', async () => {
+    await expect(freshService().refreshCustomerInfo()).rejects.toThrow(
+      'RevenueCat not initialized'
+    );
+    expect(Purchases.getCustomerInfo).not.toHaveBeenCalled();
+  });
+
+  it('refuses to present the paywall and reports failure to the caller', async () => {
+    await expect(freshService().presentPaywall('settings')).resolves.toBe(
+      false
+    );
+    expect(mockPresentPaywall).not.toHaveBeenCalled();
+  });
+});
+
+describe('RevenueCatService.hasPremiumAccess', () => {
+  const originalDev = __DEV__;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silenceConsole();
+  });
+
+  afterEach(() => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = originalDev;
+    jest.restoreAllMocks();
+  });
+
+  it('grants access in development without consulting RevenueCat', async () => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = true;
+
+    await expect(revenueCatService.hasPremiumAccess()).resolves.toBe(true);
+    expect(Purchases.getCustomerInfo).not.toHaveBeenCalled();
+  });
+
+  // Everything below sets __DEV__ = false. Under Jest it is true by default,
+  // so the entire real entitlement path is unreachable without this — the
+  // `if (__DEV__) return true` short-circuit is the first statement.
+  it('denies access in production when the SDK was never configured', async () => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = false;
+
+    await expect(freshService().hasPremiumAccess()).resolves.toBe(false);
+    expect(Purchases.getCustomerInfo).not.toHaveBeenCalled();
+  });
+
+  it('grants access in production when an entitlement is active', async () => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = false;
+    (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({
+      entitlements: { active: { premium: {} } },
+    });
+    const service = freshService();
+    service.initialize();
+
+    await expect(service.hasPremiumAccess()).resolves.toBe(true);
+  });
+
+  it('denies access in production when no entitlement is active', async () => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = false;
+    (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({
+      entitlements: { active: {} },
+    });
+    const service = freshService();
+    service.initialize();
+
+    await expect(service.hasPremiumAccess()).resolves.toBe(false);
+  });
+
+  it('denies access in production when the lookup fails', async () => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = false;
+    (Purchases.getCustomerInfo as jest.Mock).mockRejectedValue(
+      new Error('network')
+    );
+    const service = freshService();
+    service.initialize();
+
+    await expect(service.hasPremiumAccess()).resolves.toBe(false);
+  });
+});
+
+describe('RevenueCatService session lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silenceConsole();
+    revenueCatService.initialize();
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('logs the user in and caches the returned customer info', async () => {
+    const customerInfo = { originalAppUserId: 'user-1' };
+    (Purchases.logIn as jest.Mock).mockResolvedValue({ customerInfo });
+
+    await revenueCatService.loginUser('user-1');
+
+    expect(Purchases.logIn).toHaveBeenCalledWith('user-1');
+    expect(revenueCatService.getCustomerInfo()).toEqual(customerInfo);
+  });
+
+  it('logs the user out so entitlements do not follow into the next session', async () => {
+    (Purchases.logOut as jest.Mock).mockResolvedValue({
+      originalAppUserId: 'anonymous',
+    });
+
+    await revenueCatService.logoutUser();
+
+    expect(Purchases.logOut).toHaveBeenCalled();
+    expect(revenueCatService.getCustomerInfo()).toEqual({
+      originalAppUserId: 'anonymous',
+    });
+  });
+
+  it('returns and caches refreshed customer info', async () => {
+    const customerInfo = { originalAppUserId: 'user-1' };
+    (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue(customerInfo);
+
+    await expect(revenueCatService.refreshCustomerInfo()).resolves.toEqual(
+      customerInfo
+    );
+    expect(revenueCatService.getCustomerInfo()).toEqual(customerInfo);
+  });
+});
 
 describe('RevenueCatService analytics', () => {
   beforeAll(() => {
@@ -100,6 +343,22 @@ describe('RevenueCatService analytics', () => {
         error_code: 'STORE_PROBLEM',
       });
     });
+
+    it('survives a rejection with no error object', async () => {
+      // The catch block reads error?.userCancelled and error?.code. Drop
+      // either optional chain and this rejection becomes a TypeError thrown
+      // from inside the handler, masking the real store failure.
+      (mockPurchases.purchasePackage as jest.Mock).mockRejectedValue(undefined);
+
+      await expect(
+        revenueCatService.purchasePackage(testPackage)
+      ).rejects.toBeUndefined();
+
+      expect(posthogClient.capture).toHaveBeenCalledWith('purchase_failed', {
+        package_id: 'monthly',
+        error_code: undefined,
+      });
+    });
   });
 
   describe('restorePurchases', () => {
@@ -137,7 +396,12 @@ describe('RevenueCatService analytics', () => {
       mockPresentPaywall.mockResolvedValue('PURCHASED');
       (mockPurchases.getCustomerInfo as jest.Mock).mockResolvedValue({});
 
-      await revenueCatService.presentPaywall('settings');
+      // The return value is what unlocks premium in the UI. Dropping this
+      // assertion lets a flipped `return true` ship a paid purchase that the
+      // app treats as a failure.
+      await expect(revenueCatService.presentPaywall('settings')).resolves.toBe(
+        true
+      );
 
       expect(posthogClient.capture).toHaveBeenCalledWith('paywall_viewed', {
         source: 'settings',
@@ -151,12 +415,27 @@ describe('RevenueCatService analytics', () => {
     it('captures paywall_viewed and purchase_cancelled when cancelled', async () => {
       mockPresentPaywall.mockResolvedValue('CANCELLED');
 
-      await revenueCatService.presentPaywall('settings');
+      // A flipped `return false` here unlocks premium for free.
+      await expect(revenueCatService.presentPaywall('settings')).resolves.toBe(
+        false
+      );
 
       expect(posthogClient.capture).toHaveBeenCalledWith('paywall_viewed', {
         source: 'settings',
       });
       expect(posthogClient.capture).toHaveBeenCalledWith('purchase_cancelled', {
+        source: 'settings',
+        method: 'paywall',
+      });
+    });
+
+    it('reports failure to the caller when the paywall errors', async () => {
+      mockPresentPaywall.mockResolvedValue('ERROR');
+
+      await expect(revenueCatService.presentPaywall('settings')).resolves.toBe(
+        false
+      );
+      expect(posthogClient.capture).toHaveBeenCalledWith('purchase_failed', {
         source: 'settings',
         method: 'paywall',
       });

--- a/src/lib/services/revenuecat-service.test.ts
+++ b/src/lib/services/revenuecat-service.test.ts
@@ -118,6 +118,31 @@ describe('RevenueCatService.initialize', () => {
     });
   });
 
+  it('does not configure on a platform with no key', () => {
+    // Expo web has neither key. Configuring there with the wrong platform's
+    // key is worse than not configuring at all.
+    Platform.OS = 'web';
+
+    freshService().initialize();
+
+    expect(Purchases.configure).not.toHaveBeenCalled();
+  });
+
+  it('turns on verbose SDK logging only in development', () => {
+    const originalDev = __DEV__;
+    (globalThis as { __DEV__?: boolean }).__DEV__ = false;
+    try {
+      freshService().initialize();
+      expect(Purchases.setLogLevel).not.toHaveBeenCalled();
+
+      (globalThis as { __DEV__?: boolean }).__DEV__ = true;
+      freshService().initialize();
+      expect(Purchases.setLogLevel).toHaveBeenCalledWith('VERBOSE');
+    } finally {
+      (globalThis as { __DEV__?: boolean }).__DEV__ = originalDev;
+    }
+  });
+
   it('configures the SDK exactly once across repeated calls', () => {
     const service = freshService();
 
@@ -228,6 +253,226 @@ describe('RevenueCatService.hasPremiumAccess', () => {
     service.initialize();
 
     await expect(service.hasPremiumAccess()).resolves.toBe(false);
+  });
+});
+
+describe('RevenueCatService.refreshCustomerInfo recovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silenceConsole();
+    // The synthesised fallback below reads this enum, which the global
+    // react-native-purchases mock does not define.
+    (
+      Purchases as unknown as { VERIFICATION_RESULT: Record<string, string> }
+    ).VERIFICATION_RESULT = { NOT_REQUESTED: 'NOT_REQUESTED' };
+    revenueCatService.initialize();
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('synthesises empty entitlements when there is no active account', async () => {
+    (Purchases.getCustomerInfo as jest.Mock).mockRejectedValue(
+      new Error('No active account found')
+    );
+
+    const info = await revenueCatService.refreshCustomerInfo();
+
+    expect(info.entitlements.active).toEqual({});
+    expect(info.entitlements.all).toEqual({});
+    expect(info.activeSubscriptions).toEqual([]);
+    expect(info.allPurchasedProductIdentifiers).toEqual([]);
+    expect(info.latestExpirationDate).toBeNull();
+    expect(info.managementURL).toBeNull();
+    expect(info.originalAppUserId).toBe('');
+  });
+
+  it('recognises the no-active-account signal on the native userInfo shape', async () => {
+    // iOS reports it here rather than on error.message.
+    (Purchases.getCustomerInfo as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('unhelpful'), {
+        userInfo: { description: 'No active account' },
+      })
+    );
+
+    await expect(
+      revenueCatService.refreshCustomerInfo()
+    ).resolves.toMatchObject({ activeSubscriptions: [] });
+  });
+
+  it('rethrows any other failure instead of inventing an empty account', async () => {
+    // Swallowing this would report every paying user as unsubscribed the
+    // moment the network blips.
+    (Purchases.getCustomerInfo as jest.Mock).mockRejectedValue(
+      new Error('network unreachable')
+    );
+
+    await expect(revenueCatService.refreshCustomerInfo()).rejects.toThrow(
+      'network unreachable'
+    );
+  });
+
+  it('denies premium when the customer info carries no entitlements', async () => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = false;
+    (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({});
+    const service = freshService();
+    service.initialize();
+
+    await expect(service.hasPremiumAccess()).resolves.toBe(false);
+
+    (globalThis as { __DEV__?: boolean }).__DEV__ = true;
+  });
+});
+
+describe('RevenueCatService remaining public surface', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silenceConsole();
+    revenueCatService.initialize();
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('getOfferings returns the current offering', async () => {
+    const current = { identifier: 'default' };
+    (Purchases.getOfferings as jest.Mock).mockResolvedValue({ current });
+
+    await expect(revenueCatService.getOfferings()).resolves.toBe(current);
+  });
+
+  it('getOfferings degrades to null rather than throwing at the call site', async () => {
+    (Purchases.getOfferings as jest.Mock).mockRejectedValue(
+      new Error('offline')
+    );
+
+    await expect(revenueCatService.getOfferings()).resolves.toBeNull();
+  });
+
+  it('getManagementURL returns the subscription management link', async () => {
+    (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({
+      managementURL: 'https://apps.apple.com/account/subscriptions',
+    });
+
+    await expect(revenueCatService.getManagementURL()).resolves.toBe(
+      'https://apps.apple.com/account/subscriptions'
+    );
+  });
+
+  it('getManagementURL returns null when the account has no link', async () => {
+    (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({
+      managementURL: null,
+    });
+
+    await expect(revenueCatService.getManagementURL()).resolves.toBeNull();
+  });
+
+  it('restorePurchases returns the restored customer info', async () => {
+    const customerInfo = { originalAppUserId: 'user-1' };
+    (Purchases.restorePurchases as jest.Mock).mockResolvedValue(customerInfo);
+
+    await expect(revenueCatService.restorePurchases()).resolves.toBe(
+      customerInfo
+    );
+    expect(revenueCatService.getCustomerInfo()).toBe(customerInfo);
+  });
+
+  it('purchasePackage returns the customer info from the completed purchase', async () => {
+    const customerInfo = { originalAppUserId: 'user-1' };
+    (Purchases.purchasePackage as jest.Mock).mockResolvedValue({
+      customerInfo,
+    });
+
+    await expect(revenueCatService.purchasePackage(testPackage)).resolves.toBe(
+      customerInfo
+    );
+  });
+
+  describe('presentPaywallIfNeeded', () => {
+    it('delegates to presentPaywall when no entitlement is named', async () => {
+      mockPresentPaywall.mockResolvedValue('PURCHASED');
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({});
+
+      await expect(revenueCatService.presentPaywallIfNeeded()).resolves.toBe(
+        true
+      );
+      expect(mockPresentPaywall).toHaveBeenCalled();
+      expect(RevenueCatUI.presentPaywallIfNeeded).not.toHaveBeenCalled();
+    });
+
+    it('reports success and refreshes entitlements when purchased', async () => {
+      (RevenueCatUI.presentPaywallIfNeeded as jest.Mock).mockResolvedValue(
+        'PURCHASED'
+      );
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({});
+
+      await expect(
+        revenueCatService.presentPaywallIfNeeded('premium')
+      ).resolves.toBe(true);
+      expect(RevenueCatUI.presentPaywallIfNeeded).toHaveBeenCalledWith({
+        requiredEntitlementIdentifier: 'premium',
+      });
+      expect(Purchases.getCustomerInfo).toHaveBeenCalled();
+    });
+
+    it('reports success when the purchase was restored rather than new', async () => {
+      (RevenueCatUI.presentPaywallIfNeeded as jest.Mock).mockResolvedValue(
+        'RESTORED'
+      );
+      (Purchases.getCustomerInfo as jest.Mock).mockResolvedValue({});
+
+      await expect(
+        revenueCatService.presentPaywallIfNeeded('premium')
+      ).resolves.toBe(true);
+    });
+
+    it('reports failure without refreshing when cancelled', async () => {
+      (RevenueCatUI.presentPaywallIfNeeded as jest.Mock).mockResolvedValue(
+        'CANCELLED'
+      );
+
+      await expect(
+        revenueCatService.presentPaywallIfNeeded('premium')
+      ).resolves.toBe(false);
+      expect(Purchases.getCustomerInfo).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('RevenueCatService error propagation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    silenceConsole();
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('leaves the service unconfigured when the SDK throws on configure', () => {
+    (Purchases.configure as jest.Mock).mockImplementation(() => {
+      throw new Error('bad api key');
+    });
+    const service = freshService();
+
+    expect(() => service.initialize()).toThrow('bad api key');
+    // Must not latch as initialized, or every later guard waves through an
+    // unconfigured SDK.
+    expect(service.isConfigured()).toBe(false);
+  });
+
+  it('propagates a login failure to the caller', async () => {
+    (Purchases.logIn as jest.Mock).mockRejectedValue(new Error('login failed'));
+
+    await expect(revenueCatService.loginUser('user-1')).rejects.toThrow(
+      'login failed'
+    );
+  });
+
+  it('propagates a logout failure to the caller', async () => {
+    (Purchases.logOut as jest.Mock).mockRejectedValue(
+      new Error('logout failed')
+    );
+
+    await expect(revenueCatService.logoutUser()).rejects.toThrow(
+      'logout failed'
+    );
   });
 });
 

--- a/src/store/scheduled-quests-store.test.ts
+++ b/src/store/scheduled-quests-store.test.ts
@@ -1,6 +1,16 @@
 import { act, renderHook } from '@testing-library/react-native';
 
+import { getItem, setItem } from '@/lib/storage';
+
 import { useScheduledQuestsStore } from './scheduled-quests-store';
+
+jest.mock('@/lib/storage', () => ({
+  getItem: jest.fn(() => null),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+const STORAGE_KEY = 'scheduled-quests-storage';
 
 const run = (id: string, startISO = '2030-01-01T05:00:00.000Z') =>
   ({
@@ -20,8 +30,19 @@ const run = (id: string, startISO = '2030-01-01T05:00:00.000Z') =>
     maxParticipants: 10,
   }) as any;
 
+const settlementFor = (questRunId: string) =>
+  ({
+    questRunId,
+    completedAt: '2030-01-01T06:00:00.000Z',
+    participants: [],
+  }) as any;
+
 describe('scheduled-quests-store', () => {
-  beforeEach(() => act(() => useScheduledQuestsStore.getState().reset()));
+  beforeEach(() => {
+    act(() => useScheduledQuestsStore.getState().reset());
+    jest.clearAllMocks();
+    (getItem as jest.Mock).mockReturnValue(null);
+  });
 
   it('replaces registrations wholesale on fetch', () => {
     const { result } = renderHook(() => useScheduledQuestsStore());
@@ -29,17 +50,39 @@ describe('scheduled-quests-store', () => {
     expect(result.current.myRegistrations.map((r) => r.id)).toEqual(['a', 'b']);
   });
 
-  it('upserts a registration without duplicating', () => {
+  // Every fixture below seeds TWO registrations on purpose. On a one-element
+  // array `.some` and `.every` agree, and the map ternary has only one element
+  // to choose between — so an implementation that appends duplicates, and one
+  // that overwrites every entry with the incoming run, both look correct.
+  it('upserts an existing registration without touching its neighbours', () => {
     const { result } = renderHook(() => useScheduledQuestsStore());
-    act(() => result.current.setMyRegistrations([run('a')]));
+    act(() => result.current.setMyRegistrations([run('a'), run('b')]));
+
     act(() =>
-      result.current.upsertRegistration({ ...run('a'), status: 'active' })
+      result.current.upsertRegistration({ ...run('b'), status: 'active' })
     );
-    act(() => result.current.upsertRegistration(run('b')));
-    expect(result.current.myRegistrations).toHaveLength(2);
+
+    expect(result.current.myRegistrations.map((r) => r.id)).toEqual(['a', 'b']);
+    expect(
+      result.current.myRegistrations.find((r) => r.id === 'b')?.status
+    ).toBe('active');
+    // The neighbour must be left exactly as it was.
     expect(
       result.current.myRegistrations.find((r) => r.id === 'a')?.status
-    ).toBe('active');
+    ).toBe('pending');
+  });
+
+  it('appends a registration it has not seen before', () => {
+    const { result } = renderHook(() => useScheduledQuestsStore());
+    act(() => result.current.setMyRegistrations([run('a'), run('b')]));
+
+    act(() => result.current.upsertRegistration(run('c')));
+
+    expect(result.current.myRegistrations.map((r) => r.id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
   });
 
   it('removes a registration', () => {
@@ -49,16 +92,70 @@ describe('scheduled-quests-store', () => {
     expect(result.current.myRegistrations.map((r) => r.id)).toEqual(['b']);
   });
 
-  it('records settlements by questRunId and drops the registration', () => {
+  it('records a settlement and drops only the settled registration', () => {
     const { result } = renderHook(() => useScheduledQuestsStore());
-    act(() => result.current.setMyRegistrations([run('a')]));
-    const settlement = {
-      questRunId: 'a',
-      completedAt: '2030-01-01T06:00:00.000Z',
-      participants: [],
-    };
-    act(() => result.current.recordSettlement(settlement as any));
+    act(() => result.current.setMyRegistrations([run('a'), run('b')]));
+    const settlement = settlementFor('a');
+
+    act(() => result.current.recordSettlement(settlement));
+
     expect(result.current.settlements.a).toEqual(settlement);
-    expect(result.current.myRegistrations).toHaveLength(0);
+    // Seeded with two so that "drops everything" is distinguishable from
+    // "drops the settled one".
+    expect(result.current.myRegistrations.map((r) => r.id)).toEqual(['b']);
+  });
+
+  it('reset empties both registrations and settlements', () => {
+    const { result } = renderHook(() => useScheduledQuestsStore());
+    act(() => result.current.setMyRegistrations([run('a'), run('b')]));
+    act(() => result.current.recordSettlement(settlementFor('a')));
+
+    act(() => result.current.reset());
+
+    expect(result.current.myRegistrations).toEqual([]);
+    expect(result.current.settlements).toEqual({});
+  });
+
+  describe('persistence', () => {
+    it('writes both slices under the pinned storage key', () => {
+      const { result } = renderHook(() => useScheduledQuestsStore());
+
+      act(() => result.current.setMyRegistrations([run('a')]));
+      act(() => result.current.recordSettlement(settlementFor('a')));
+
+      expect(setItem).toHaveBeenCalledWith(STORAGE_KEY, expect.any(String));
+      const written = JSON.parse(
+        (setItem as jest.Mock).mock.calls.at(-1)![1] as string
+      );
+      // Pin the shape, not just the fact that something was written: a
+      // partialize that returns {} still calls setItem.
+      expect(written.state.settlements.a).toEqual(settlementFor('a'));
+      expect(written.state).toHaveProperty('myRegistrations');
+    });
+
+    it('rehydrates registrations written by a previous launch', () => {
+      (getItem as jest.Mock).mockImplementation((name: string) =>
+        name === STORAGE_KEY
+          ? JSON.stringify({
+              state: { myRegistrations: [run('a'), run('b')], settlements: {} },
+              version: 0,
+            })
+          : null
+      );
+
+      // A fresh module instance is the only way to observe hydration, which
+      // happens once when the store is created.
+      let store: typeof useScheduledQuestsStore;
+      jest.isolateModules(() => {
+        store = require('./scheduled-quests-store')
+          .useScheduledQuestsStore as typeof useScheduledQuestsStore;
+      });
+
+      expect(getItem).toHaveBeenCalledWith(STORAGE_KEY);
+      expect(store!.getState().myRegistrations.map((r) => r.id)).toEqual([
+        'a',
+        'b',
+      ]);
+    });
   });
 });

--- a/src/store/settings-store.test.ts
+++ b/src/store/settings-store.test.ts
@@ -1,9 +1,23 @@
+import { getItem, setItem } from '@/lib/storage';
+
 import { useSettingsStore } from './settings-store';
 
+jest.mock('@/lib/storage', () => ({
+  getItem: jest.fn(() => null),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+const STORAGE_KEY = 'unquest-settings';
+
+const resetStore = () => {
+  useSettingsStore.setState(useSettingsStore.getInitialState());
+  jest.clearAllMocks();
+  (getItem as jest.Mock).mockReturnValue(null);
+};
+
 describe('settings-store narratorVoice', () => {
-  beforeEach(() => {
-    useSettingsStore.setState(useSettingsStore.getInitialState());
-  });
+  beforeEach(resetStore);
 
   it('defaults narratorVoice to null (never explicitly chosen)', () => {
     expect(useSettingsStore.getState().narratorVoice).toBeNull();
@@ -16,9 +30,7 @@ describe('settings-store narratorVoice', () => {
 });
 
 describe('settings-store onboardingSoundEnabled', () => {
-  beforeEach(() => {
-    useSettingsStore.setState(useSettingsStore.getInitialState());
-  });
+  beforeEach(resetStore);
 
   it('defaults onboardingSoundEnabled to true', () => {
     expect(useSettingsStore.getState().onboardingSoundEnabled).toBe(true);
@@ -27,5 +39,105 @@ describe('settings-store onboardingSoundEnabled', () => {
   it('setOnboardingSoundEnabled stores an explicit choice', () => {
     useSettingsStore.getState().setOnboardingSoundEnabled(false);
     expect(useSettingsStore.getState().onboardingSoundEnabled).toBe(false);
+  });
+});
+
+// Every default below encodes a product decision. Pinning them exactly means
+// changing one is a deliberate, visible act rather than a silent regression.
+describe('settings-store notification defaults', () => {
+  beforeEach(resetStore);
+
+  it('leaves the daily reminder off until the user opts in', () => {
+    // Defaulting this to true would schedule notifications for users who
+    // never asked for them.
+    expect(useSettingsStore.getState().dailyReminder).toEqual({
+      enabled: false,
+      time: null,
+    });
+  });
+
+  it('ships the streak warning on, at 18:00', () => {
+    // The fixed 18:00 send time is a known live problem — it fires while
+    // evening questers are mid-quest (server issue #73). Whatever it becomes,
+    // it must not change by accident.
+    expect(useSettingsStore.getState().streakWarning).toEqual({
+      enabled: true,
+      time: { hour: 18, minute: 0 },
+    });
+  });
+
+  it('has not yet prompted a fresh install for a reminder', () => {
+    // Defaulting to true suppresses the prompt for every new user.
+    expect(useSettingsStore.getState().hasBeenPromptedForReminder).toBe(false);
+  });
+});
+
+describe('settings-store notification setters', () => {
+  beforeEach(resetStore);
+
+  it('setDailyReminder stores the chosen time', () => {
+    const reminder = { enabled: true, time: { hour: 7, minute: 30 } };
+
+    useSettingsStore.getState().setDailyReminder(reminder);
+
+    expect(useSettingsStore.getState().dailyReminder).toEqual(reminder);
+  });
+
+  it('setStreakWarning stores the chosen time', () => {
+    const warning = { enabled: false, time: { hour: 21, minute: 15 } };
+
+    useSettingsStore.getState().setStreakWarning(warning);
+
+    expect(useSettingsStore.getState().streakWarning).toEqual(warning);
+  });
+
+  it('setHasBeenPromptedForReminder records that the prompt was shown', () => {
+    useSettingsStore.getState().setHasBeenPromptedForReminder(true);
+
+    expect(useSettingsStore.getState().hasBeenPromptedForReminder).toBe(true);
+  });
+});
+
+describe('settings-store persistence', () => {
+  beforeEach(resetStore);
+
+  it('writes settings under the pinned storage key', () => {
+    useSettingsStore.getState().setNarratorVoice('female');
+
+    expect(setItem).toHaveBeenCalledWith(STORAGE_KEY, expect.any(String));
+    const written = JSON.parse(
+      (setItem as jest.Mock).mock.calls.at(-1)![1] as string
+    );
+    expect(written.state.narratorVoice).toBe('female');
+  });
+
+  it('rehydrates settings written by a previous launch', () => {
+    // Blanking the key orphans every existing user's settings on upgrade.
+    (getItem as jest.Mock).mockImplementation((name: string) =>
+      name === STORAGE_KEY
+        ? JSON.stringify({
+            state: {
+              narratorVoice: 'female',
+              streakWarning: { enabled: false, time: { hour: 9, minute: 0 } },
+            },
+            version: 0,
+          })
+        : null
+    );
+
+    let store: typeof useSettingsStore;
+    jest.isolateModules(() => {
+      store = require('./settings-store')
+        .useSettingsStore as typeof useSettingsStore;
+    });
+
+    expect(getItem).toHaveBeenCalledWith(STORAGE_KEY);
+    expect(store!.getState().narratorVoice).toBe('female');
+    // A non-default value, so a mutant that discards the stored blob and
+    // falls back to the initial state is visible here.
+    expect(store!.getState().streakWarning).toEqual({
+      enabled: false,
+      time: { hour: 9, minute: 0 },
+    });
   });
 });

--- a/src/store/user-store.test.ts
+++ b/src/store/user-store.test.ts
@@ -1,10 +1,12 @@
 import * as Sentry from '@sentry/react-native';
 
+import { getItem, setItem } from '@/lib/storage';
+
 import { useUserStore } from './user-store';
 
 // Mock storage (persist middleware reads/writes through this)
 jest.mock('@/lib/storage', () => ({
-  getItem: jest.fn(),
+  getItem: jest.fn(() => null),
   setItem: jest.fn(),
   removeItem: jest.fn(),
 }));
@@ -13,23 +15,101 @@ jest.mock('@sentry/react-native', () => ({
   setUser: jest.fn(),
 }));
 
-describe('user-store Sentry correlation', () => {
+const STORAGE_KEY = 'user-storage';
+
+const aUser = () =>
+  ({
+    id: 'user-abc-123',
+    email: 'secret@example.com',
+    featureFlags: ['beta'],
+  }) as any;
+
+describe('user-store', () => {
   beforeEach(() => {
     useUserStore.setState({ user: null });
     jest.clearAllMocks();
+    (getItem as jest.Mock).mockReturnValue(null);
   });
 
-  it('setUser reports id-only to Sentry (never email)', () => {
-    useUserStore.getState().setUser({
-      id: 'user-abc-123',
-      email: 'secret@example.com',
-    } as any);
-    // toHaveBeenCalledWith is an exact match: it fails if email is included.
-    expect(Sentry.setUser).toHaveBeenCalledWith({ id: 'user-abc-123' });
+  describe('Sentry correlation', () => {
+    it('setUser reports id-only to Sentry (never email)', () => {
+      useUserStore.getState().setUser(aUser());
+      // toHaveBeenCalledWith is an exact match: it fails if email is included.
+      expect(Sentry.setUser).toHaveBeenCalledWith({ id: 'user-abc-123' });
+    });
+
+    it('clearUser clears the Sentry user', () => {
+      useUserStore.getState().clearUser();
+      expect(Sentry.setUser).toHaveBeenCalledWith(null);
+    });
   });
 
-  it('clearUser clears the Sentry user', () => {
-    useUserStore.getState().clearUser();
-    expect(Sentry.setUser).toHaveBeenCalledWith(null);
+  // These assert the state transition itself. Without them `set({ user })` can
+  // be replaced by `set({})` and the Sentry tests above still pass — sign-in
+  // and account-wipe would both be reported to Sentry and then dropped.
+  describe('state', () => {
+    it('setUser puts the user in the store', () => {
+      const user = aUser();
+
+      useUserStore.getState().setUser(user);
+
+      expect(useUserStore.getState().user).toEqual(user);
+    });
+
+    it('clearUser empties the store', () => {
+      useUserStore.getState().setUser(aUser());
+
+      useUserStore.getState().clearUser();
+
+      expect(useUserStore.getState().user).toBeNull();
+    });
+
+    it('updateUser merges into the existing user', () => {
+      useUserStore.getState().setUser(aUser());
+
+      useUserStore.getState().updateUser({ email: 'new@example.com' });
+
+      expect(useUserStore.getState().user).toEqual({
+        ...aUser(),
+        email: 'new@example.com',
+      });
+    });
+
+    it('updateUser leaves a signed-out store signed out', () => {
+      // The other direction of the `state.user ? … : null` branch. Without it
+      // a mutant that always merges would spawn a user out of nothing.
+      useUserStore.getState().updateUser({ email: 'new@example.com' });
+
+      expect(useUserStore.getState().user).toBeNull();
+    });
+  });
+
+  describe('persistence', () => {
+    it('writes the user under the pinned storage key', () => {
+      useUserStore.getState().setUser(aUser());
+
+      expect(setItem).toHaveBeenCalledWith(STORAGE_KEY, expect.any(String));
+      const written = JSON.parse(
+        (setItem as jest.Mock).mock.calls.at(-1)![1] as string
+      );
+      expect(written.state.user.id).toBe('user-abc-123');
+    });
+
+    it('rehydrates the user written by a previous launch', () => {
+      // Blanking the key here is what logs every existing user out on upgrade.
+      (getItem as jest.Mock).mockImplementation((name: string) =>
+        name === STORAGE_KEY
+          ? JSON.stringify({ state: { user: aUser() }, version: 0 })
+          : null
+      );
+
+      let store: typeof useUserStore;
+      jest.isolateModules(() => {
+        store = require('./user-store').useUserStore as typeof useUserStore;
+      });
+
+      expect(getItem).toHaveBeenCalledWith(STORAGE_KEY);
+      expect(store!.getState().user).toEqual(aUser());
+    });
   });
 });

--- a/src/store/user-store.ts
+++ b/src/store/user-store.ts
@@ -51,10 +51,9 @@ export const useUserStore = create<UserState>()(
         setItem: setItemForStorage,
         removeItem: removeItemForStorage,
       })),
-      onRehydrateStorage: () => (state) => {
-        console.log('[UserStore] Rehydrated with user:', state?.user?.id);
-        console.log('[UserStore] Feature flags:', state?.user?.featureFlags);
-      },
+      // No onRehydrateStorage handler: it only logged the rehydrated user id
+      // and feature flags to the console on every launch — a user identifier
+      // in device logs, buying nothing a breakpoint would not.
     }
   )
 );

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -30,9 +30,18 @@ const config = {
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/report.json' },
   concurrency: 12,
-  // jest-expo startup is ~1.7s for a single small file; the 5000ms default
-  // would flag slow-but-correct runs as timeouts.
-  timeoutMS: 60000,
+  // Overhead allowance on top of the measured dry-run time (Stryker adds
+  // timeoutFactor * dryRunTime itself). jest-expo startup is ~1.7s for a
+  // single small file, so 10s is already generous.
+  //
+  // Do NOT raise this back to 60s. quest-timer.test.ts runs on fake timers, so
+  // a mutant that reaches an `await new Promise(r => setTimeout(r, delay))`
+  // — the cooperative lock-status retry ladder — hangs rather than resolving.
+  // Those are real kills (the mutant that forces `retryCount < maxRetries`
+  // true is a genuine infinite loop), but at 60s each they took the audit from
+  // 50 minutes to over four hours. Report the TimedOut column alongside the
+  // score: Stryker counts timeouts as killed.
+  timeoutMS: 10000,
 };
 
 export default config;

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -1,0 +1,34 @@
+// @ts-check
+/** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+const config = {
+  packageManager: 'pnpm',
+  testRunner: 'jest',
+  jest: {
+    projectType: 'custom',
+    configFile: 'jest.mutation.config.js',
+    enableFindRelatedTests: true,
+  },
+  // Run only the tests that cover each mutant. Without this every mutant
+  // runs the whole suite, turning a minutes-long run into an hours-long one.
+  coverageAnalysis: 'perTest',
+  // The audit set (Task 3). Override per-file with `--mutate <path>`.
+  mutate: [
+    'src/store/settings-store.ts',
+    'src/store/user-store.ts',
+    'src/store/scheduled-quests-store.ts',
+    'src/lib/services/revenuecat-service.ts',
+    'src/lib/services/quest-timer.ts',
+  ],
+  // Keep the sandbox small — ios/ and android/ are large native trees that
+  // no mutation run needs.
+  ignorePatterns: ['ios', 'android', '.worktrees', 'coverage', 'reports'],
+  disableTypeChecks: 'src/**/*.{ts,tsx}',
+  reporters: ['html', 'clear-text', 'progress'],
+  htmlReporter: { fileName: 'reports/mutation/index.html' },
+  concurrency: 12,
+  // jest-expo startup is ~1.7s for a single small file; the 5000ms default
+  // would flag slow-but-correct runs as timeouts.
+  timeoutMS: 60000,
+};
+
+export default config;

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -23,8 +23,12 @@ const config = {
   // no mutation run needs.
   ignorePatterns: ['ios', 'android', '.worktrees', 'coverage', 'reports'],
   disableTypeChecks: 'src/**/*.{ts,tsx}',
-  reporters: ['html', 'clear-text', 'progress'],
+  // 'json' is what makes a run's survivors queryable afterwards. Without it
+  // the only artifact is a 2 MB HTML file whose embedded `app.report` object
+  // has to be hand-extracted before it can be read.
+  reporters: ['html', 'json', 'clear-text', 'progress'],
   htmlReporter: { fileName: 'reports/mutation/index.html' },
+  jsonReporter: { fileName: 'reports/mutation/report.json' },
   concurrency: 12,
   // jest-expo startup is ~1.7s for a single small file; the 5000ms default
   // would flag slow-but-correct runs as timeouts.

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -29,7 +29,11 @@ const config = {
   reporters: ['html', 'json', 'clear-text', 'progress'],
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/report.json' },
-  concurrency: 12,
+  // 12 saturated the box: login-form.test.tsx (the slowest suite, ~24s) then
+  // blew Jest's 5s per-test default during the dry run and aborted the whole
+  // audit. Oversubscription also inflates the score, since Stryker counts a
+  // TimedOut mutant as killed.
+  concurrency: 8,
   // Overhead allowance on top of the measured dry-run time (Stryker adds
   // timeoutFactor * dryRunTime itself). jest-expo startup is ~1.7s for a
   // single small file, so 10s is already generous.

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -42,6 +42,11 @@ const config = {
   // 50 minutes to over four hours. Report the TimedOut column alongside the
   // score: Stryker counts timeouts as killed.
   timeoutMS: 10000,
+  // Separate from timeoutMS: this bounds the initial full-suite run that
+  // measures per-test coverage. The default is 5 minutes, which the audit set
+  // now exceeds — a failed dry run aborts the whole audit with
+  // "Something went wrong in the initial test run".
+  dryRunTimeoutMinutes: 20,
 };
 
 export default config;


### PR DESCRIPTION
## What this is

Mutation testing on the five highest-risk modules, and the test work that came out of it.

A passing test proves nothing until you have watched it fail. Mutation testing checks that automatically: it breaks the source in small ways (flip a condition, empty a block, swap `&&` for `||`) and reports which breakages no test noticed. Each surviving breakage is either a gap in the tests or a change that genuinely cannot be observed.

The starting number was the point of the exercise. **Of the code the test suite actually executed, only 43% of breakages were caught.** More than half of the executed code could be arbitrarily broken with CI still green.

## Results

Scores are for the five audited modules. "Covered" ignores code no test reaches, so it measures how good the existing tests are rather than how much code they touch — that is the number to compare.

| Module | total | covered |
| --- | --- | --- |
| `scheduled-quests-store.ts` | 70.21 → 97.87 | 71.74 → **100.00** |
| `user-store.ts` | 25.93 → 94.74 | 30.43 → **100.00** |
| `settings-store.ts` | 29.03 → 80.65 | 34.62 → 86.21 |
| `revenuecat-service.ts` | 18.25 → 74.52 | 50.00 → **76.56** |
| `quest-timer.ts` | 10.04 → 42.17 | 36.15 → 72.25 |
| **All five** | 15.33 → **50.14** | 43.07 → **75.41** |

`revenuecat-service.ts` is a fresh measurement over the same 263 mutants, so it is directly comparable. `quest-timer.ts` is from an earlier point and is now understated — three later test commits are not in it, and re-measuring that file is impractical for reasons written up in the plan doc.

## What it changed in the app

**One behaviour change, and it is a real fix.** When the server had already activated a cooperative quest, `onPhoneLocked` posted the Android "Quest in progress" notification from inside the activation branch, then fell through to the shared call at the end of the method and posted the identical payload again. Two native calls where one was intended. The inner one is gone, and the test now asserts the call count — it fails with "Expected 1, received 2" against the old code.

Everything else that touches `src/` is dead-code removal, all of it flagged by breakages that no test could possibly catch because the branch was unreachable:

- `parseJson` / `parseIntSafe`: the `typeof x === 'string'` checks. The signatures already guarantee it.
- Two `typeof store.setLiveActivityId === 'function'` guards. The store always defines it, so both `else` branches were dead.
- `user-store`'s `onRehydrateStorage`. It only logged a user id and feature flags to the console on every launch.

## The findings worth reading

Three cases where a **test fixture**, not the code, was the problem. No coverage tool finds these, and Stryker cannot either — it does not mutate fixtures. Each one made a region look tested when it was not:

1. `quest-timer.test.ts` mocked the store with `activeQuest` already set. The solo-start path is guarded by `if (!questStore.activeQuest && …)`, so `questStore.startQuest` — the line that makes a quest exist — was unreachable in **every** test.
2. `Env.*` is `undefined` in every Jest test repo-wide. The iOS and Android RevenueCat branches were therefore indistinguishable: both configured `{ apiKey: undefined }`. A build where in-app purchases were dead on both platforms would have passed CI.
3. The `useQuestStore.setState` mock was a bare `jest.fn()`. It stored updater functions and never called them, so everything inside a `setState(state => …)` was unreachable. It now behaves like zustand.

The rule that came out of it: when a region reads as having no coverage despite tests that plainly call into it, read the mock before you read the code.

## Deliberately left alive

Not every surviving breakage is worth chasing.

- `settings-store`'s last four sit in a rehydration handler whose only effect is a `console.error`. An error log on hydration failure has diagnostic value. 86.21% is that module's practical ceiling.
- The cooperative lock-report ladder returns `true` on success and `false` after the last attempt, but the caller discards the result. Nothing can observe either. Flipping them leaves all 75 tests green.
- `hasPremiumAccess` has a dead test-mode branch (an earlier `if (__DEV__) return true` returns first). Noted for deletion, not touched here — this branch is a test pass.

## Also in here

- Stryker config, a `test:mutate` script, and a JSON reporter so a run's survivors can be queried instead of read out of a 2 MB HTML file.
- `CLAUDE.md` gains a Verify phase after Red/Green/Refactor, and the rule that a new assertion is assumed vacuous until a mutation proves otherwise.
- `docs/superpowers/plans/2026-08-07-mutation-baseline.md` — the full baseline, triage, results, and the operational warnings. Read §7 before running a full audit; it explains why one run took over four hours and how to avoid it.

## Verification

- 185 suites / 2252 passed / 3 skipped
- `tsc --noEmit` clean
- Every new assertion in the last three commits was proven capable of failing by a targeted mutation, restored afterwards. The counts are in each commit message.

No device QA needed: the only behaviour change removes a duplicate native notification call, and the assertion covering it fails against the old code.
